### PR TITLE
Typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ This needs only be done once, in application startup code:
   (-> "schema.edn"
       io/resource
       slurp
+      edn/read-string
       (attach-resolvers {:get-hero get-hero
                          :get-droid (constantly {})})
       schema/compile))


### PR DESCRIPTION
I think edn/read-string was missed in the README snippet