### PR TITLE
Throw exception for inline fragments with invalid type conditions.

### DIFF
--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -803,7 +803,7 @@
           (throw-exception (format "Inline fragment has a type condition on unknown type %s."
                                    (q type-name)))
           (let [concrete-types (expand-fragment-type-to-concrete-types fragment-type)
-                fragment-path-term (keyword "..." (-> m :type name))
+                fragment-path-term (keyword "..." (name type-name))
                 inline-fragment (-> m
                                     (assoc :selection-type :inline-fragment
                                            :concrete-types concrete-types)

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -342,11 +342,9 @@
                }
              }
             }"]
-    (is (= {:errors
-            [{:message
-              "Inline fragment has a type condition on unknown type `foo'.",
-              :query-path [:human]
-              :locations [{:line 2 :column 31}]}]}
+    (is (= {:errors [{:message "Inline fragment has a type condition on unknown type `foo'."
+                      :query-path [:human]
+                      :locations [{:line 2 :column 31}]}]}
            (execute *schema* q nil nil)))))
 
 (deftest invalid-query

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -334,6 +334,19 @@
                           :homePlanet "Tatooine"
                           :appears_in ["NEWHOPE" "EMPIRE" "JEDI"]}
                    :leia {:appears_in ["NEWHOPE" "EMPIRE" "JEDI"]}}}
+           (execute *schema* q nil nil))))
+  (let [q "query InvalidInlineFragment {
+             human(id: \"1001\") {
+               ... on foo {
+                 name
+               }
+             }
+            }"]
+    (is (= {:errors
+            [{:message
+              "Inline fragment has a type condition on unknown type `foo'.",
+              :query-path [:human]
+              :locations [{:line 2 :column 31}]}]}
            (execute *schema* q nil nil)))))
 
 (deftest invalid-query
@@ -777,5 +790,3 @@
                      :query-path [:events :lookup]}]}
                  (execute schema q2 nil nil))
               "should return error message"))))))
-
-


### PR DESCRIPTION
If inline fragment contains type condition, we should check if this type is defined in schema. At the moment we're throwing NPE. This PR fixes https://github.com/walmartlabs/lacinia/issues/2.

Ping @hlship @bcarrell 