### PR TITLE
fix condition checking only sequential for collection like things 

### DIFF
--- a/src/com/walmartlabs/lacinia/internal_utils.clj
+++ b/src/com/walmartlabs/lacinia/internal_utils.clj
@@ -135,6 +135,12 @@
   [v]
   (str \` (name v) \'))
 
+(defn sequential-or-set?
+  "Returns true if x is a Sequential or Set"
+  [x]
+  (or (sequential? x) (set? x)))
+
+
 (defn is-internal-type-name?
   "Identifies type names that are added by introspection."
   [type-name]

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -13,7 +13,7 @@
     [com.walmartlabs.lacinia.constants :as constants]
     [com.walmartlabs.lacinia.internal-utils
      :refer [cond-let ensure-seq map-vals map-kvs filter-vals deep-merge q
-             is-internal-type-name?]]
+             is-internal-type-name? sequential-or-set?]]
     [com.walmartlabs.lacinia.resolve :refer [ResolverResult resolved-value resolve-errors resolve-as]]
     [clojure.string :as str])
   (:import
@@ -306,14 +306,14 @@
 (defn ^:private enforce-single-result
   [tuple]
   (with-resolved-value [value tuple]
-    (if-not (sequential? value)
+    (if-not (sequential-or-set? value)
       tuple
       (error "Field resolver returned a collection of values, expected only a single value."))))
 
 (defn ^:private enforce-multiple-results
   [tuple]
   (with-resolved-value [value tuple]
-    (if (sequential? value)
+    (if (sequential-or-set? value)
       tuple
       (error "Field resolver returned a single value, expected a collection of values."))))
 


### PR DESCRIPTION
This allow Sets to be used as field values in resolver returned data. Before this patch it errors on a sequential? check and thus disallows the use of Set. This is similar to how json encoders operate (encoding Sets as Arrays).
related to #21
