### PR TITLE
Load clojure.set dependency

### DIFF
--- a/src/com/walmartlabs/lacinia/validation/no_unused_fragments.clj
+++ b/src/com/walmartlabs/lacinia/validation/no_unused_fragments.clj
@@ -1,4 +1,5 @@
-(ns com.walmartlabs.lacinia.validation.no-unused-fragments)
+(ns com.walmartlabs.lacinia.validation.no-unused-fragments
+  (:require [clojure.set])
 
 (defn ^:private fragment-names-used
   "Returns a sequence of all fragment names


### PR DESCRIPTION
Without this (and unless you have loaded `clojure.set` by yourself), when you try to require `com.walmartlabs.lacinia` the load fails with `CompilerException java.lang.ClassNotFoundException: clojure.set, compiling:(com/walmartlabs/lacinia/validation/no_unused_fragments.clj:36:31)`