### PR TITLE
Change internal representation of enum values from string to keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## 0.15.0 -- UNRELEASED
+
+This release fleshes out the Lacinia type system to be fully compliant with the
+GraphQL type system.
+Previously, there were significant limitations when combining `list` and `not-null` modifiers on types.
+
+The internal representation of enum values has changed from string to keyword.
+You will now see a keyword, not a string, supplied as the value of an enum-typed argument
+or variable.
+
+
 ## 0.14.0 -- 29 Mar 2017
 
 This release adds some very small performance improvements.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ of the available options:
 {:enums
  {:episode
   {:description "The episodes of the original Star Wars trilogy."
-   :values ["NEWHOPE" "EMPIRE" "JEDI"]}}
+   :values [:NEWHOPE :EMPIRE :JEDI]}}
 
  :objects
  {:droid
@@ -110,7 +110,7 @@ Here's what the `get-hero` field resolver might look like:
 ```clojure
 (defn get-hero [context arguments value]
   (let [{:keys [episode]} arguments]
-    (if (= episode "NEWHOPE")
+    (if (= episode :NEWHOPE)
       {:id 1000
        :name "Luke"
        :home-planet "Tatooine"

--- a/dev-resources/star-wars-schema.edn
+++ b/dev-resources/star-wars-schema.edn
@@ -1,7 +1,7 @@
 {:enums
  {:episode
   {:description "The episodes of the original Star Wars trilogy."
-   :values ["NEWHOPE" "EMPIRE" "JEDI"]}}
+   :values [:NEWHOPE :EMPIRE :JEDI]}}
 
  :interfaces
  {:character

--- a/docs/_examples/enum-definition.edn
+++ b/docs/_examples/enum-definition.edn
@@ -1,4 +1,4 @@
 {:enums
  {:episode
   {:description "The episodes of the original Star Wars trilogy."
-   :values ["NEWHOPE" "EMPIRE" "JEDI"]}}}
+   :values [:NEWHOPE :EMPIRE :JEDI]}}}

--- a/docs/_examples/overview-exec-query.edn
+++ b/docs/_examples/overview-exec-query.edn
@@ -3,6 +3,6 @@
   '[org.example.schema :refer [star-wars-schema]])
 
 (ql/execute (star-wars-schema)
-  "query { human(id: \"1001\"){ name }}"
+  "query { human(id: \"1001\") { name }}"
   nil nil)
 => {:data {:human #ordered/map([:name "Darth Vader"])}}

--- a/docs/enums.rst
+++ b/docs/enums.rst
@@ -5,18 +5,20 @@ Enums
 
    Read about `enums <https://facebook.github.io/graphql/#sec-Enums>`_.
 
-GraphQL supports enumerated types: enums are effectively a string type, where the possible
-values are restricted to a predefined set.
+GraphQL supports enumerated types, types whose value is limited to a explicit list.
 
 .. literalinclude:: _examples/enum-definition.edn
    :language: clojure
 
 It is allowed to define enum values as either strings, keywords, or symbols.
-Internally, the enum values are converted to strings.
-Keyword values must be unique, otherwise an exception is thrown when compiling the schema.
+Internally, the enum values are converted to keywords.
+
+Enum values must be unique, otherwise an exception is thrown when compiling the schema.
+
+Enum values must be GraphQL Names: they may contain only letters, numbers, and underscores.
 
 When an enum type is used as an argument, the value provided to the field resolver function
-will be a string, regardless of whether the enum was defined using strings, keywords, or symbols.
+will be a keyword, regardless of whether the enum values were defined using strings, keywords, or symbols.
 
 As with many other elements in GraphQL, a description may be provided (for use with
 :doc:`introspection`).

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "0.14.0"
+(defproject com.walmartlabs/lacinia "0.15.0"
   :description "A GraphQL server implementation in Clojure"
   :license {:name "Apache, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}

--- a/src/com/walmartlabs/lacinia/internal_utils.clj
+++ b/src/com/walmartlabs/lacinia/internal_utils.clj
@@ -136,3 +136,15 @@
   [context & body]
   `(binding [*exception-context* (merge *exception-context* ~context)]
      ~@body))
+
+(defn as-keyword
+  [v]
+  (cond
+    (keyword? v) v
+
+    (symbol? v) (-> v name keyword)
+
+    (string? v) (keyword v)
+
+    :else
+    (throw (ex-info "Can't convert value to keyword." {:value v}))))

--- a/src/com/walmartlabs/lacinia/introspection.clj
+++ b/src/com/walmartlabs/lacinia/introspection.clj
@@ -9,12 +9,12 @@
     [com.walmartlabs.lacinia.constants :as constants]))
 
 (def ^:private category->kind
-  {:scalar "SCALAR"
-   :object "OBJECT"
-   :interface "INTERFACE"
-   :union "UNION"
-   :enum "ENUM"
-   :input-object "INPUT_OBJECT"})
+  {:scalar :SCALAR
+   :object :OBJECT
+   :interface :INTERFACE
+   :union :UNION
+   :enum :ENUM
+   :input-object :INPUT_OBJECT})
 
 (defn ^:private schema-type
   ([schema type-def]
@@ -102,7 +102,7 @@
       ;; Use the ordered list, not the set, in case order
       ;; has meaning (unlike elsewhere we we sort alphabetically).
       (for [value (get type-def :values)]
-        {:name value
+        {:name (name value)
          :isDeprecated false}))))
 
 (defn ^:private resolve-input-fields
@@ -132,11 +132,11 @@
     (case kind
 
       :list
-      {:kind "LIST"
+      {:kind :LIST
        ::type-map type}
 
       :non-null
-      {:kind "NON_NULL"
+      {:kind :NON_NULL
        ::type-map type}
 
       :root

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -9,7 +9,7 @@
             [com.walmartlabs.lacinia.internal-utils
              :refer [cond-let update? q map-vals filter-vals
                      with-exception-context throw-exception to-message
-                     keepv]]
+                     keepv as-keyword]]
             [com.walmartlabs.lacinia.schema :as schema]
             [com.walmartlabs.lacinia.constants :as constants]
             [clojure.spec :as s])
@@ -140,7 +140,7 @@
       :floatvalue [:scalar first-value]
       :booleanvalue [:scalar first-value]
       :nullvalue [:null nil]
-      :enumValue [:enum (-> first-value second)]
+      :enumValue [:enum (-> first-value second as-keyword)]
       :objectValue [:object (xform-argument-map (next argument-value))]
       :arrayValue [:array (mapv (comp xform-argument-value second) (next argument-value))]
       :variable [:variable (-> first-value second keyword)])))
@@ -299,7 +299,8 @@
                          {:argument-type enum-type-name}))
 
       (or (get (:values-set type-def) arg-value)
-          (throw-exception "Provided argument value is not member of enum type."
+          (throw-exception (format "Provided argument value %s is not member of enum type."
+                                   (q arg-value))
                            {:allowed-values (:values-set type-def)
                             :enum-type enum-type-name})))))
 

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -13,7 +13,7 @@
     [com.walmartlabs.lacinia.constants :as constants]
     [com.walmartlabs.lacinia.internal-utils
      :refer [map-vals map-kvs filter-vals deep-merge q
-             is-internal-type-name? sequential-or-set?]]
+             is-internal-type-name? sequential-or-set? as-keyword]]
     [com.walmartlabs.lacinia.resolve :refer [ResolverResult resolved-value resolve-errors resolve-as]]
     [clojure.string :as str])
   (:import
@@ -39,18 +39,6 @@
                  s))
              schema
              schema))
-
-(defn ^:private as-keyword
-  [v]
-  (cond
-    (keyword? v) v
-
-    (symbol? v) (-> v name keyword)
-
-    (string? v) (keyword v)
-
-    :else
-    (throw (ex-info "Unexpected type value." {:type v}))))
 
 (defn tag-with-type
   "Tags a value with a GraphQL type name, a keyword.
@@ -569,7 +557,7 @@
 
 (defmethod compile-type :enum
   [enum schema]
-  (let [values (->> enum :values (mapv name))
+  (let [values (->> enum :values (mapv as-keyword))
         values-set (set values)]
     (when-not (= (count values) (count values-set))
       (throw (ex-info (format "Values defined for enum %s must be unique."

--- a/test/com/walmartlabs/introspection_test.clj
+++ b/test/com/walmartlabs/introspection_test.clj
@@ -13,7 +13,7 @@
 
 (deftest simple-introspection-query
   (let [q "{ __type(name: \"human\") { kind name fields { name }}}"]
-    (is (= {:data {:__type {:kind "OBJECT"
+    (is (= {:data {:__type {:kind :OBJECT
                             :name "human"
                             :fields
                             (->> compiled-schema :human :fields keys
@@ -36,54 +36,54 @@
              }
            }}"]
     (is (= {:data {:__type {:fields [{:name "appears_in"
-                                      :type {:kind "LIST"
+                                      :type {:kind :LIST
                                              :name nil}}
                                      {:name "arch_enemy"
-                                      :type {:kind "NON_NULL"
+                                      :type {:kind :NON_NULL
                                              :name nil}}
                                      {:name "bar"
-                                      :type {:kind "INTERFACE"
+                                      :type {:kind :INTERFACE
                                              :name "character"}}
                                      {:name "best_friend"
-                                      :type {:kind "INTERFACE"
+                                      :type {:kind :INTERFACE
                                              :name "character"}}
                                      {:name "droids"
-                                      :type {:kind "NON_NULL"
+                                      :type {:kind :NON_NULL
                                              :name nil}}
                                      {:name "enemies"
-                                      :type {:kind "LIST"
+                                      :type {:kind :LIST
                                              :name nil}}
                                      {:name "error_field"
-                                      :type {:kind "SCALAR"
+                                      :type {:kind :SCALAR
                                              :name "String"}}
                                      {:name "family"
-                                      :type {:kind "NON_NULL"
+                                      :type {:kind :NON_NULL
                                              :name nil}}
                                      {:name "foo"
-                                      :type {:kind "NON_NULL"
+                                      :type {:kind :NON_NULL
                                              :name nil}}
                                      {:name "forceSide"
-                                      :type {:kind "OBJECT"
+                                      :type {:kind :OBJECT
                                              :name "force"}}
                                      {:name "friends"
-                                      :type {:kind "LIST"
+                                      :type {:kind :LIST
                                              :name nil}}
                                      {:name "homePlanet"
-                                      :type {:kind "SCALAR"
+                                      :type {:kind :SCALAR
                                              :name "String"}}
                                      {:name "id"
-                                      :type {:kind "SCALAR"
+                                      :type {:kind :SCALAR
                                              :name "String"}}
                                      {:name "multiple_errors_field"
-                                      :type {:kind "SCALAR"
+                                      :type {:kind :SCALAR
                                              :name "String"}}
                                      {:name "name"
-                                      :type {:kind "SCALAR"
+                                      :type {:kind :SCALAR
                                              :name "String"}}
                                      {:name "primary_function"
-                                      :type {:kind "LIST"
+                                      :type {:kind :LIST
                                              :name nil}}]
-                            :kind "OBJECT"
+                            :kind :OBJECT
                             :name "human"}}}
            (execute q)))))
 
@@ -111,24 +111,24 @@
           }
         }}"]
     (is (= {:data {:__type {:fields [{:name "actors"
-                                      :type {:kind "LIST"
+                                      :type {:kind :LIST
                                              :name nil
-                                             :ofType {:kind "NON_NULL"
+                                             :ofType {:kind :NON_NULL
                                                       :name nil
-                                                      :ofType {:kind "SCALAR"
+                                                      :ofType {:kind :SCALAR
                                                                :name "String"}}}}
                                      {:name "release_year"
-                                      :type {:kind "SCALAR"
+                                      :type {:kind :SCALAR
                                              :name "Int"
                                              :ofType nil}}
                                      {:name "sequel"
-                                      :type {:kind "OBJECT"
+                                      :type {:kind :OBJECT
                                              :name "movie"
                                              :ofType nil}}
                                      {:name "title"
-                                      :type {:kind "NON_NULL"
+                                      :type {:kind :NON_NULL
                                              :name nil
-                                             :ofType {:kind "SCALAR"
+                                             :ofType {:kind :SCALAR
                                                       :name "String"
                                                       :ofType nil}}}]}}}
            (-> (lacinia/execute schema q nil nil)
@@ -136,7 +136,7 @@
 
 (deftest object-introspection-query
   (let [q "{ __type(name: \"droid\") { kind name interfaces { name }}}"]
-    (is (= {:data {:__type {:kind "OBJECT"
+    (is (= {:data {:__type {:kind :OBJECT
                             :name "droid"
                             :interfaces [{:name "character"}]}}}
            (execute q)))))
@@ -163,162 +163,162 @@
            }}"]
     (is (= {:data {:__type {:fields [{:name "appears_in"
                                       :type {:fields []
-                                             :kind "LIST"
+                                             :kind :LIST
                                              :name nil}}
                                      {:name "arch_enemy"
                                       :type {:fields []
-                                             :kind "NON_NULL"
+                                             :kind :NON_NULL
                                              :name nil}}
                                      {:name "bar"
                                       :type {:fields [{:name "appears_in"
-                                                       :type {:kind "LIST"
+                                                       :type {:kind :LIST
                                                               :name nil
                                                               :ofType {:enumValues [{:name "NEWHOPE"}
                                                                                     {:name "EMPIRE"}
                                                                                     {:name "JEDI"}]}}}
                                                       {:name "arch_enemy"
-                                                       :type {:kind "NON_NULL"
+                                                       :type {:kind :NON_NULL
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "bar"
-                                                       :type {:kind "INTERFACE"
+                                                       :type {:kind :INTERFACE
                                                               :name "character"
                                                               :ofType nil}}
                                                       {:name "best_friend"
-                                                       :type {:kind "INTERFACE"
+                                                       :type {:kind :INTERFACE
                                                               :name "character"
                                                               :ofType nil}}
                                                       {:name "droids"
-                                                       :type {:kind "NON_NULL"
+                                                       :type {:kind :NON_NULL
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "enemies"
-                                                       :type {:kind "LIST"
+                                                       :type {:kind :LIST
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "family"
-                                                       :type {:kind "NON_NULL"
+                                                       :type {:kind :NON_NULL
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "foo"
-                                                       :type {:kind "NON_NULL"
+                                                       :type {:kind :NON_NULL
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "forceSide"
-                                                       :type {:kind "OBJECT"
+                                                       :type {:kind :OBJECT
                                                               :name "force"
                                                               :ofType nil}}
                                                       {:name "friends"
-                                                       :type {:kind "LIST"
+                                                       :type {:kind :LIST
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "id"
-                                                       :type {:kind "SCALAR"
+                                                       :type {:kind :SCALAR
                                                               :name "String"
                                                               :ofType nil}}
                                                       {:name "name"
-                                                       :type {:kind "SCALAR"
+                                                       :type {:kind :SCALAR
                                                               :name "String"
                                                               :ofType nil}}]
-                                             :kind "INTERFACE"
+                                             :kind :INTERFACE
                                              :name "character"}}
                                      {:name "best_friend"
                                       :type {:fields [{:name "appears_in"
-                                                       :type {:kind "LIST"
+                                                       :type {:kind :LIST
                                                               :name nil
                                                               :ofType {:enumValues [{:name "NEWHOPE"}
                                                                                     {:name "EMPIRE"}
                                                                                     {:name "JEDI"}]}}}
                                                       {:name "arch_enemy"
-                                                       :type {:kind "NON_NULL"
+                                                       :type {:kind :NON_NULL
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "bar"
-                                                       :type {:kind "INTERFACE"
+                                                       :type {:kind :INTERFACE
                                                               :name "character"
                                                               :ofType nil}}
                                                       {:name "best_friend"
-                                                       :type {:kind "INTERFACE"
+                                                       :type {:kind :INTERFACE
                                                               :name "character"
                                                               :ofType nil}}
                                                       {:name "droids"
-                                                       :type {:kind "NON_NULL"
+                                                       :type {:kind :NON_NULL
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "enemies"
-                                                       :type {:kind "LIST"
+                                                       :type {:kind :LIST
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "family"
-                                                       :type {:kind "NON_NULL"
+                                                       :type {:kind :NON_NULL
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "foo"
-                                                       :type {:kind "NON_NULL"
+                                                       :type {:kind :NON_NULL
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "forceSide"
-                                                       :type {:kind "OBJECT"
+                                                       :type {:kind :OBJECT
                                                               :name "force"
                                                               :ofType nil}}
                                                       {:name "friends"
-                                                       :type {:kind "LIST"
+                                                       :type {:kind :LIST
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "id"
-                                                       :type {:kind "SCALAR"
+                                                       :type {:kind :SCALAR
                                                               :name "String"
                                                               :ofType nil}}
                                                       {:name "name"
-                                                       :type {:kind "SCALAR"
+                                                       :type {:kind :SCALAR
                                                               :name "String"
                                                               :ofType nil}}]
-                                             :kind "INTERFACE"
+                                             :kind :INTERFACE
                                              :name "character"}}
                                      {:name "droids"
                                       :type {:fields []
-                                             :kind "NON_NULL"
+                                             :kind :NON_NULL
                                              :name nil}}
                                      {:name "enemies"
                                       :type {:fields []
-                                             :kind "LIST"
+                                             :kind :LIST
                                              :name nil}}
                                      {:name "family"
                                       :type {:fields []
-                                             :kind "NON_NULL"
+                                             :kind :NON_NULL
                                              :name nil}}
                                      {:name "foo"
                                       :type {:fields []
-                                             :kind "NON_NULL"
+                                             :kind :NON_NULL
                                              :name nil}}
                                      {:name "forceSide"
                                       :type {:fields [{:name "id"
-                                                       :type {:kind "SCALAR"
+                                                       :type {:kind :SCALAR
                                                               :name "String"
                                                               :ofType nil}}
                                                       {:name "members"
-                                                       :type {:kind "LIST"
+                                                       :type {:kind :LIST
                                                               :name nil
                                                               :ofType {:enumValues []}}}
                                                       {:name "name"
-                                                       :type {:kind "SCALAR"
+                                                       :type {:kind :SCALAR
                                                               :name "String"
                                                               :ofType nil}}]
-                                             :kind "OBJECT"
+                                             :kind :OBJECT
                                              :name "force"}}
                                      {:name "friends"
                                       :type {:fields []
-                                             :kind "LIST"
+                                             :kind :LIST
                                              :name nil}}
                                      {:name "id"
                                       :type {:fields []
-                                             :kind "SCALAR"
+                                             :kind :SCALAR
                                              :name "String"}}
                                      {:name "name"
                                       :type {:fields []
-                                             :kind "SCALAR"
+                                             :kind :SCALAR
                                              :name "String"}}]
-                            :kind "INTERFACE"
+                            :kind :INTERFACE
                             :name "character"}}}
            (execute q)))))
 
@@ -354,58 +354,58 @@
                                                    {:name "hero"}
                                                    {:name "human"}
                                                    {:name "now"}]
-                                          :kind "OBJECT"
+                                          :kind :OBJECT
                                           :name "QueryRoot"}
                               :types [{:description nil
-                                       :kind "SCALAR"
+                                       :kind :SCALAR
                                        :name "Boolean"}
                                       {:description nil
-                                       :kind "SCALAR"
+                                       :kind :SCALAR
                                        :name "Date"}
                                       {:description nil
-                                       :kind "SCALAR"
+                                       :kind :SCALAR
                                        :name "Float"}
                                       {:description nil
-                                       :kind "SCALAR"
+                                       :kind :SCALAR
                                        :name "ID"}
                                       {:description nil
-                                       :kind "SCALAR"
+                                       :kind :SCALAR
                                        :name "Int"}
                                       {:description "Root of all mutations."
-                                       :kind "OBJECT"
+                                       :kind :OBJECT
                                        :name "MutationRoot"}
                                       {:description "Root of all queries."
-                                       :kind "OBJECT"
+                                       :kind :OBJECT
                                        :name "QueryRoot"}
                                       {:description nil
-                                       :kind "SCALAR"
+                                       :kind :SCALAR
                                        :name "String"}
                                       {:description nil
-                                       :kind "INTERFACE"
+                                       :kind :INTERFACE
                                        :name "character"}
                                       {:description nil
-                                       :kind "OBJECT"
+                                       :kind :OBJECT
                                        :name "droid"}
                                       {:description nil
-                                       :kind "OBJECT"
+                                       :kind :OBJECT
                                        :name "echoArgs"}
                                       {:description "The episodes of the original Star Wars trilogy."
-                                       :kind "ENUM"
+                                       :kind :ENUM
                                        :name "episode"}
                                       {:description nil
-                                       :kind "OBJECT"
+                                       :kind :OBJECT
                                        :name "force"}
                                       {:description nil
-                                       :kind "OBJECT"
+                                       :kind :OBJECT
                                        :name "galaxy-date"}
                                       {:description nil
-                                       :kind "OBJECT"
+                                       :kind :OBJECT
                                        :name "human"}
                                       {:description nil
-                                       :kind "INPUT_OBJECT"
+                                       :kind :INPUT_OBJECT
                                        :name "nestedInputObject"}
                                       {:description nil
-                                       :kind "INPUT_OBJECT"
+                                       :kind :INPUT_OBJECT
                                        :name "testInputObject"}]}}}
            (execute q)))))
 
@@ -492,7 +492,7 @@
                      :fields []
                      :inputFields []
                      :interfaces []
-                     :kind "SCALAR"
+                     :kind :SCALAR
                      :name "Boolean"
                      :possibleTypes []}
                     {:description nil
@@ -500,7 +500,7 @@
                      :fields []
                      :inputFields []
                      :interfaces []
-                     :kind "SCALAR"
+                     :kind :SCALAR
                      :name "Date"
                      :possibleTypes []}
                     {:description nil
@@ -508,7 +508,7 @@
                      :fields []
                      :inputFields []
                      :interfaces []
-                     :kind "SCALAR"
+                     :kind :SCALAR
                      :name "Float"
                      :possibleTypes []}
                     {:description nil
@@ -516,7 +516,7 @@
                      :fields []
                      :inputFields []
                      :interfaces []
-                     :kind "SCALAR"
+                     :kind :SCALAR
                      :name "ID"
                      :possibleTypes []}
                     {:description nil
@@ -524,7 +524,7 @@
                      :fields []
                      :inputFields []
                      :interfaces []
-                     :kind "SCALAR"
+                     :kind :SCALAR
                      :name "Int"
                      :possibleTypes []}
                     {:description "Root of all mutations."
@@ -532,77 +532,77 @@
                      :fields [{:args [{:defaultValue nil
                                        :description nil
                                        :name "does_nothing"
-                                       :type {:kind "SCALAR"
+                                       :type {:kind :SCALAR
                                               :name "String"
                                               :ofType nil}}
                                       {:defaultValue nil
                                        :description nil
                                        :name "episodes"
-                                       :type {:kind "NON_NULL"
+                                       :type {:kind :NON_NULL
                                               :name nil
-                                              :ofType {:kind "LIST"
+                                              :ofType {:kind :LIST
                                                        :name nil
-                                                       :ofType {:kind "ENUM"
+                                                       :ofType {:kind :ENUM
                                                                 :name "episode"
                                                                 :ofType nil}}}}
                                       {:defaultValue nil
                                        :description nil
                                        :name "id"
-                                       :type {:kind "NON_NULL"
+                                       :type {:kind :NON_NULL
                                               :name nil
-                                              :ofType {:kind "SCALAR"
+                                              :ofType {:kind :SCALAR
                                                        :name "String"
                                                        :ofType nil}}}]
                                :deprecationReason nil
                                :description nil
                                :isDeprecated false
                                :name "addHeroEpisodes"
-                               :type {:kind "INTERFACE"
+                               :type {:kind :INTERFACE
                                       :name "character"
                                       :ofType nil}}
                               {:args [{:defaultValue nil
                                        :description nil
                                        :name "id"
-                                       :type {:kind "NON_NULL"
+                                       :type {:kind :NON_NULL
                                               :name nil
-                                              :ofType {:kind "SCALAR"
+                                              :ofType {:kind :SCALAR
                                                        :name "String"
                                                        :ofType nil}}}
                                       {:defaultValue nil
                                        :description nil
                                        :name "newHomePlanet"
-                                       :type {:kind "SCALAR"
+                                       :type {:kind :SCALAR
                                               :name "String"
                                               :ofType nil}}]
                                :deprecationReason nil
                                :description nil
                                :isDeprecated false
                                :name "changeHeroHomePlanet"
-                               :type {:kind "OBJECT"
+                               :type {:kind :OBJECT
                                       :name "human"
                                       :ofType nil}}
                               {:args [{:defaultValue nil
                                        :description nil
                                        :name "from"
-                                       :type {:kind "SCALAR"
+                                       :type {:kind :SCALAR
                                               :name "String"
                                               :ofType nil}}
                                       {:defaultValue "Rey"
                                        :description nil
                                        :name "to"
-                                       :type {:kind "SCALAR"
+                                       :type {:kind :SCALAR
                                               :name "String"
                                               :ofType nil}}]
                                :deprecationReason nil
                                :description nil
                                :isDeprecated false
                                :name "changeHeroName"
-                               :type {:kind "INTERFACE"
+                               :type {:kind :INTERFACE
                                       :name "character"
                                       :ofType nil}}]
                      :inputFields []
                      :interfaces []
-                     :kind "OBJECT"
+                     :kind :OBJECT
                      :name "MutationRoot"
                      :possibleTypes []}
                     {:description "Root of all queries."
@@ -610,71 +610,71 @@
                      :fields [{:args [{:defaultValue "2001"
                                        :description nil
                                        :name "id"
-                                       :type {:kind "SCALAR"
+                                       :type {:kind :SCALAR
                                               :name "String"
                                               :ofType nil}}]
                                :deprecationReason nil
                                :description nil
                                :isDeprecated false
                                :name "droid"
-                               :type {:kind "OBJECT"
+                               :type {:kind :OBJECT
                                       :name "droid"
                                       :ofType nil}}
                               {:args [{:defaultValue nil
                                        :description nil
                                        :name "inputObject"
-                                       :type {:kind "INPUT_OBJECT"
+                                       :type {:kind :INPUT_OBJECT
                                               :name "testInputObject"
                                               :ofType nil}}
                                       {:defaultValue nil
                                        :description nil
                                        :name "integer"
-                                       :type {:kind "SCALAR"
+                                       :type {:kind :SCALAR
                                               :name "Int"
                                               :ofType nil}}
                                       {:defaultValue nil
                                        :description nil
                                        :name "integerArray"
-                                       :type {:kind "LIST"
+                                       :type {:kind :LIST
                                               :name nil
-                                              :ofType {:kind "SCALAR"
+                                              :ofType {:kind :SCALAR
                                                        :name "Int"
                                                        :ofType nil}}}]
                                :deprecationReason nil
                                :description nil
                                :isDeprecated false
                                :name "echoArgs"
-                               :type {:kind "OBJECT"
+                               :type {:kind :OBJECT
                                       :name "echoArgs"
                                       :ofType nil}}
                               {:args [{:defaultValue nil
                                        :description nil
                                        :name "episode"
-                                       :type {:kind "ENUM"
+                                       :type {:kind :ENUM
                                               :name "episode"
                                               :ofType nil}}]
                                :deprecationReason nil
                                :description nil
                                :isDeprecated false
                                :name "hero"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "INTERFACE"
+                                      :ofType {:kind :INTERFACE
                                                :name "character"
                                                :ofType nil}}}
                               {:args [{:defaultValue "1001"
                                        :description nil
                                        :name "id"
-                                       :type {:kind "SCALAR"
+                                       :type {:kind :SCALAR
                                               :name "String"
                                               :ofType nil}}]
                                :deprecationReason nil
                                :description nil
                                :isDeprecated false
                                :name "human"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "OBJECT"
+                                      :ofType {:kind :OBJECT
                                                :name "human"
                                                :ofType nil}}}
                               {:args []
@@ -682,12 +682,12 @@
                                :description nil
                                :isDeprecated false
                                :name "now"
-                               :type {:kind "OBJECT"
+                               :type {:kind :OBJECT
                                       :name "galaxy-date"
                                       :ofType nil}}]
                      :inputFields []
                      :interfaces []
-                     :kind "OBJECT"
+                     :kind :OBJECT
                      :name "QueryRoot"
                      :possibleTypes []}
                     {:description nil
@@ -695,7 +695,7 @@
                      :fields []
                      :inputFields []
                      :interfaces []
-                     :kind "SCALAR"
+                     :kind :SCALAR
                      :name "String"
                      :possibleTypes []}
                     {:description nil
@@ -705,9 +705,9 @@
                                :description nil
                                :isDeprecated false
                                :name "appears_in"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "ENUM"
+                                      :ofType {:kind :ENUM
                                                :name "episode"
                                                :ofType nil}}}
                               {:args []
@@ -715,9 +715,9 @@
                                :description nil
                                :isDeprecated false
                                :name "arch_enemy"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "INTERFACE"
+                                      :ofType {:kind :INTERFACE
                                                :name "character"
                                                :ofType nil}}}
                               {:args []
@@ -725,7 +725,7 @@
                                :description nil
                                :isDeprecated false
                                :name "bar"
-                               :type {:kind "INTERFACE"
+                               :type {:kind :INTERFACE
                                       :name "character"
                                       :ofType nil}}
                               {:args []
@@ -733,7 +733,7 @@
                                :description nil
                                :isDeprecated false
                                :name "best_friend"
-                               :type {:kind "INTERFACE"
+                               :type {:kind :INTERFACE
                                       :name "character"
                                       :ofType nil}}
                               {:args []
@@ -741,24 +741,24 @@
                                :description nil
                                :isDeprecated false
                                :name "droids"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "LIST"
+                                      :ofType {:kind :LIST
                                                :name nil
-                                               :ofType {:kind "NON_NULL"
+                                               :ofType {:kind :NON_NULL
                                                         :name nil
-                                                        :ofType {:kind "INTERFACE"
+                                                        :ofType {:kind :INTERFACE
                                                                  :name "character"}}}}}
                               {:args []
                                :deprecationReason nil
                                :description nil
                                :isDeprecated false
                                :name "enemies"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "NON_NULL"
+                                      :ofType {:kind :NON_NULL
                                                :name nil
-                                               :ofType {:kind "INTERFACE"
+                                               :ofType {:kind :INTERFACE
                                                         :name "character"
                                                         :ofType nil}}}}
                               {:args []
@@ -766,11 +766,11 @@
                                :description nil
                                :isDeprecated false
                                :name "family"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "LIST"
+                                      :ofType {:kind :LIST
                                                :name nil
-                                               :ofType {:kind "INTERFACE"
+                                               :ofType {:kind :INTERFACE
                                                         :name "character"
                                                         :ofType nil}}}}
                               {:args []
@@ -778,9 +778,9 @@
                                :description nil
                                :isDeprecated false
                                :name "foo"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "SCALAR"
+                                      :ofType {:kind :SCALAR
                                                :name "String"
                                                :ofType nil}}}
                               {:args []
@@ -788,7 +788,7 @@
                                :description nil
                                :isDeprecated false
                                :name "forceSide"
-                               :type {:kind "OBJECT"
+                               :type {:kind :OBJECT
                                       :name "force"
                                       :ofType nil}}
                               {:args []
@@ -796,9 +796,9 @@
                                :description nil
                                :isDeprecated false
                                :name "friends"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "INTERFACE"
+                                      :ofType {:kind :INTERFACE
                                                :name "character"
                                                :ofType nil}}}
                               {:args []
@@ -806,7 +806,7 @@
                                :description nil
                                :isDeprecated false
                                :name "id"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "String"
                                       :ofType nil}}
                               {:args []
@@ -814,17 +814,17 @@
                                :description nil
                                :isDeprecated false
                                :name "name"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "String"
                                       :ofType nil}}]
                      :inputFields []
                      :interfaces []
-                     :kind "INTERFACE"
+                     :kind :INTERFACE
                      :name "character"
-                     :possibleTypes [{:kind "OBJECT"
+                     :possibleTypes [{:kind :OBJECT
                                       :name "droid"
                                       :ofType nil}
-                                     {:kind "OBJECT"
+                                     {:kind :OBJECT
                                       :name "human"
                                       :ofType nil}]}
                     {:description nil
@@ -834,9 +834,9 @@
                                :description nil
                                :isDeprecated false
                                :name "accessories"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "SCALAR"
+                                      :ofType {:kind :SCALAR
                                                :name "String"
                                                :ofType nil}}}
                               {:args []
@@ -844,9 +844,9 @@
                                :description nil
                                :isDeprecated false
                                :name "appears_in"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "ENUM"
+                                      :ofType {:kind :ENUM
                                                :name "episode"
                                                :ofType nil}}}
                               {:args []
@@ -854,9 +854,9 @@
                                :description nil
                                :isDeprecated false
                                :name "arch_enemy"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "INTERFACE"
+                                      :ofType {:kind :INTERFACE
                                                :name "character"
                                                :ofType nil}}}
                               {:args []
@@ -864,7 +864,7 @@
                                :description nil
                                :isDeprecated false
                                :name "bar"
-                               :type {:kind "INTERFACE"
+                               :type {:kind :INTERFACE
                                       :name "character"
                                       :ofType nil}}
                               {:args []
@@ -872,7 +872,7 @@
                                :description nil
                                :isDeprecated false
                                :name "best_friend"
-                               :type {:kind "INTERFACE"
+                               :type {:kind :INTERFACE
                                       :name "character"
                                       :ofType nil}}
                               {:args []
@@ -880,24 +880,24 @@
                                :description nil
                                :isDeprecated false
                                :name "droids"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "LIST"
+                                      :ofType {:kind :LIST
                                                :name nil
-                                               :ofType {:kind "NON_NULL"
+                                               :ofType {:kind :NON_NULL
                                                         :name nil
-                                                        :ofType {:kind "INTERFACE"
+                                                        :ofType {:kind :INTERFACE
                                                                  :name "character"}}}}}
                               {:args []
                                :deprecationReason nil
                                :description nil
                                :isDeprecated false
                                :name "enemies"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "NON_NULL"
+                                      :ofType {:kind :NON_NULL
                                                :name nil
-                                               :ofType {:kind "INTERFACE"
+                                               :ofType {:kind :INTERFACE
                                                         :name "character"
                                                         :ofType nil}}}}
                               {:args []
@@ -905,11 +905,11 @@
                                :description nil
                                :isDeprecated false
                                :name "family"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "LIST"
+                                      :ofType {:kind :LIST
                                                :name nil
-                                               :ofType {:kind "INTERFACE"
+                                               :ofType {:kind :INTERFACE
                                                         :name "character"
                                                         :ofType nil}}}}
                               {:args []
@@ -917,9 +917,9 @@
                                :description nil
                                :isDeprecated false
                                :name "foo"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "SCALAR"
+                                      :ofType {:kind :SCALAR
                                                :name "String"
                                                :ofType nil}}}
                               {:args []
@@ -927,7 +927,7 @@
                                :description nil
                                :isDeprecated false
                                :name "forceSide"
-                               :type {:kind "OBJECT"
+                               :type {:kind :OBJECT
                                       :name "force"
                                       :ofType nil}}
                               {:args []
@@ -935,9 +935,9 @@
                                :description nil
                                :isDeprecated false
                                :name "friends"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "INTERFACE"
+                                      :ofType {:kind :INTERFACE
                                                :name "character"
                                                :ofType nil}}}
                               {:args []
@@ -945,7 +945,7 @@
                                :description nil
                                :isDeprecated false
                                :name "id"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "String"
                                       :ofType nil}}
                               {:args []
@@ -953,7 +953,7 @@
                                :description nil
                                :isDeprecated false
                                :name "incept_date"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "Int"
                                       :ofType nil}}
                               {:args []
@@ -961,7 +961,7 @@
                                :description nil
                                :isDeprecated false
                                :name "name"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "String"
                                       :ofType nil}}
                               {:args []
@@ -969,16 +969,16 @@
                                :description nil
                                :isDeprecated false
                                :name "primary_function"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "SCALAR"
+                                      :ofType {:kind :SCALAR
                                                :name "String"
                                                :ofType nil}}}]
                      :inputFields []
-                     :interfaces [{:kind "INTERFACE"
+                     :interfaces [{:kind :INTERFACE
                                    :name "character"
                                    :ofType nil}]
-                     :kind "OBJECT"
+                     :kind :OBJECT
                      :name "droid"
                      :possibleTypes []}
                     {:description nil
@@ -988,7 +988,7 @@
                                :description nil
                                :isDeprecated false
                                :name "inputObject"
-                               :type {:kind "INPUT_OBJECT"
+                               :type {:kind :INPUT_OBJECT
                                       :name "testInputObject"
                                       :ofType nil}}
                               {:args []
@@ -996,7 +996,7 @@
                                :description nil
                                :isDeprecated false
                                :name "integer"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "Int"
                                       :ofType nil}}
                               {:args []
@@ -1004,14 +1004,14 @@
                                :description nil
                                :isDeprecated false
                                :name "integerArray"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "SCALAR"
+                                      :ofType {:kind :SCALAR
                                                :name "Int"
                                                :ofType nil}}}]
                      :inputFields []
                      :interfaces []
-                     :kind "OBJECT"
+                     :kind :OBJECT
                      :name "echoArgs"
                      :possibleTypes []}
                     {:description "The episodes of the original Star Wars trilogy."
@@ -1030,7 +1030,7 @@
                      :fields []
                      :inputFields []
                      :interfaces []
-                     :kind "ENUM"
+                     :kind :ENUM
                      :name "episode"
                      :possibleTypes []}
                     {:description nil
@@ -1040,7 +1040,7 @@
                                :description nil
                                :isDeprecated false
                                :name "id"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "String"
                                       :ofType nil}}
                               {:args []
@@ -1048,9 +1048,9 @@
                                :description nil
                                :isDeprecated false
                                :name "members"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "INTERFACE"
+                                      :ofType {:kind :INTERFACE
                                                :name "character"
                                                :ofType nil}}}
                               {:args []
@@ -1058,12 +1058,12 @@
                                :description nil
                                :isDeprecated false
                                :name "name"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "String"
                                       :ofType nil}}]
                      :inputFields []
                      :interfaces []
-                     :kind "OBJECT"
+                     :kind :OBJECT
                      :name "force"
                      :possibleTypes []}
                     {:description nil
@@ -1073,12 +1073,12 @@
                                :description nil
                                :isDeprecated false
                                :name "date"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "Date"
                                       :ofType nil}}]
                      :inputFields []
                      :interfaces []
-                     :kind "OBJECT"
+                     :kind :OBJECT
                      :name "galaxy-date"
                      :possibleTypes []}
                     {:description nil
@@ -1088,9 +1088,9 @@
                                :description nil
                                :isDeprecated false
                                :name "appears_in"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "ENUM"
+                                      :ofType {:kind :ENUM
                                                :name "episode"
                                                :ofType nil}}}
                               {:args []
@@ -1098,9 +1098,9 @@
                                :description nil
                                :isDeprecated false
                                :name "arch_enemy"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "INTERFACE"
+                                      :ofType {:kind :INTERFACE
                                                :name "character"
                                                :ofType nil}}}
                               {:args []
@@ -1108,7 +1108,7 @@
                                :description nil
                                :isDeprecated false
                                :name "bar"
-                               :type {:kind "INTERFACE"
+                               :type {:kind :INTERFACE
                                       :name "character"
                                       :ofType nil}}
                               {:args []
@@ -1116,7 +1116,7 @@
                                :description nil
                                :isDeprecated false
                                :name "best_friend"
-                               :type {:kind "INTERFACE"
+                               :type {:kind :INTERFACE
                                       :name "character"
                                       :ofType nil}}
                               {:args []
@@ -1124,24 +1124,24 @@
                                :description nil
                                :isDeprecated false
                                :name "droids"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "LIST"
+                                      :ofType {:kind :LIST
                                                :name nil
-                                               :ofType {:kind "NON_NULL"
+                                               :ofType {:kind :NON_NULL
                                                         :name nil
-                                                        :ofType {:kind "INTERFACE"
+                                                        :ofType {:kind :INTERFACE
                                                                  :name "character"}}}}}
                               {:args []
                                :deprecationReason nil
                                :description nil
                                :isDeprecated false
                                :name "enemies"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "NON_NULL"
+                                      :ofType {:kind :NON_NULL
                                                :name nil
-                                               :ofType {:kind "INTERFACE"
+                                               :ofType {:kind :INTERFACE
                                                         :name "character"
                                                         :ofType nil}}}}
                               {:args []
@@ -1149,7 +1149,7 @@
                                :description nil
                                :isDeprecated false
                                :name "error_field"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "String"
                                       :ofType nil}}
                               {:args []
@@ -1157,11 +1157,11 @@
                                :description nil
                                :isDeprecated false
                                :name "family"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "LIST"
+                                      :ofType {:kind :LIST
                                                :name nil
-                                               :ofType {:kind "INTERFACE"
+                                               :ofType {:kind :INTERFACE
                                                         :name "character"
                                                         :ofType nil}}}}
                               {:args []
@@ -1169,9 +1169,9 @@
                                :description nil
                                :isDeprecated false
                                :name "foo"
-                               :type {:kind "NON_NULL"
+                               :type {:kind :NON_NULL
                                       :name nil
-                                      :ofType {:kind "SCALAR"
+                                      :ofType {:kind :SCALAR
                                                :name "String"
                                                :ofType nil}}}
                               {:args []
@@ -1179,7 +1179,7 @@
                                :description nil
                                :isDeprecated false
                                :name "forceSide"
-                               :type {:kind "OBJECT"
+                               :type {:kind :OBJECT
                                       :name "force"
                                       :ofType nil}}
                               {:args []
@@ -1187,9 +1187,9 @@
                                :description nil
                                :isDeprecated false
                                :name "friends"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "INTERFACE"
+                                      :ofType {:kind :INTERFACE
                                                :name "character"
                                                :ofType nil}}}
                               {:args []
@@ -1197,7 +1197,7 @@
                                :description nil
                                :isDeprecated false
                                :name "homePlanet"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "String"
                                       :ofType nil}}
                               {:args []
@@ -1205,7 +1205,7 @@
                                :description nil
                                :isDeprecated false
                                :name "id"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "String"
                                       :ofType nil}}
                               {:args []
@@ -1213,7 +1213,7 @@
                                :description nil
                                :isDeprecated false
                                :name "multiple_errors_field"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "String"
                                       :ofType nil}}
                               {:args []
@@ -1221,7 +1221,7 @@
                                :description nil
                                :isDeprecated false
                                :name "name"
-                               :type {:kind "SCALAR"
+                               :type {:kind :SCALAR
                                       :name "String"
                                       :ofType nil}}
                               {:args []
@@ -1229,16 +1229,16 @@
                                :description nil
                                :isDeprecated false
                                :name "primary_function"
-                               :type {:kind "LIST"
+                               :type {:kind :LIST
                                       :name nil
-                                      :ofType {:kind "SCALAR"
+                                      :ofType {:kind :SCALAR
                                                :name "String"
                                                :ofType nil}}}]
                      :inputFields []
-                     :interfaces [{:kind "INTERFACE"
+                     :interfaces [{:kind :INTERFACE
                                    :name "character"
                                    :ofType nil}]
-                     :kind "OBJECT"
+                     :kind :OBJECT
                      :name "human"
                      :possibleTypes []}
                     {:description nil
@@ -1247,19 +1247,19 @@
                      :inputFields [{:defaultValue nil
                                     :description nil
                                     :name "date"
-                                    :type {:kind "SCALAR"
+                                    :type {:kind :SCALAR
                                            :name "Date"
                                            :ofType nil}}
                                    {:defaultValue nil
                                     :description nil
                                     :name "integerArray"
-                                    :type {:kind "LIST"
+                                    :type {:kind :LIST
                                            :name nil
-                                           :ofType {:kind "SCALAR"
+                                           :ofType {:kind :SCALAR
                                                     :name "Int"
                                                     :ofType nil}}}]
                      :interfaces []
-                     :kind "INPUT_OBJECT"
+                     :kind :INPUT_OBJECT
                      :name "nestedInputObject"
                      :possibleTypes []}
                     {:description nil
@@ -1268,23 +1268,23 @@
                      :inputFields [{:defaultValue nil
                                     :description nil
                                     :name "integer"
-                                    :type {:kind "SCALAR"
+                                    :type {:kind :SCALAR
                                            :name "Int"
                                            :ofType nil}}
                                    {:defaultValue nil
                                     :description nil
                                     :name "nestedInputObject"
-                                    :type {:kind "INPUT_OBJECT"
+                                    :type {:kind :INPUT_OBJECT
                                            :name "nestedInputObject"
                                            :ofType nil}}
                                    {:defaultValue nil
                                     :description nil
                                     :name "string"
-                                    :type {:kind "SCALAR"
+                                    :type {:kind :SCALAR
                                            :name "String"
                                            :ofType nil}}]
                      :interfaces []
-                     :kind "INPUT_OBJECT"
+                     :kind :INPUT_OBJECT
                      :name "testInputObject"
                      :possibleTypes []}]}
            (-> (execute q) :data :__schema)))))
@@ -1313,14 +1313,14 @@
             ofType { name kind }
           }"]
     (is (= {:data {:__schema {:queryType {:fields [{:args [{:name "term"
-                                                            :type {:kind "NON_NULL"
+                                                            :type {:kind :NON_NULL
                                                                    :name nil
-                                                                   :ofType {:kind "SCALAR"
+                                                                   :ofType {:kind :SCALAR
                                                                             :name "String"}}}]
                                                     :name "search"
-                                                    :type {:kind "NON_NULL"
+                                                    :type {:kind :NON_NULL
                                                            :name nil
-                                                           :ofType {:kind "SCALAR"
+                                                           :ofType {:kind :SCALAR
                                                                     :name "ID"}}}]
                                           :name "QueryRoot"}}}}
            (simplify (lacinia/execute schema q nil nil))))))

--- a/test/com/walmartlabs/lacinia/enums_test.clj
+++ b/test/com/walmartlabs/lacinia/enums_test.clj
@@ -17,6 +17,13 @@
   [query]
   (simplify (execute compiled-schema query nil nil)))
 
+(deftest returns-enums-as-keywords
+  (is (= {:data {:hero {:appears_in [:NEWHOPE
+                                     :EMPIRE
+                                     :JEDI]
+                        :name "R2-D2"}}}
+         (q "{ hero { name appears_in }}"))))
+
 (deftest can-provide-enum-as-bare-name
   (let [response (q "{ hero(episode: NEWHOPE) { name }}")
         hero-name (-> response :data :hero :name)]
@@ -29,17 +36,17 @@
         first-error (first errors)]
     (is (-> result (contains? :data) not))
     (is (= 1 (count errors)))
-    (is (= {:allowed-values #{"EMPIRE"
-                              "JEDI"
-                              "NEWHOPE"}
+    (is (= {:allowed-values #{:EMPIRE
+                              :JEDI
+                              :NEWHOPE}
             :argument :episode
             :enum-type :episode
             :field :hero
             :locations [{:column 0
                          :line 1}]
-            :message "Exception applying arguments to field `hero': For argument `episode', provided argument value is not member of enum type."
+            :message "Exception applying arguments to field `hero': For argument `episode', provided argument value `CLONES' is not member of enum type."
             :query-path []
-            :value "CLONES"}
+            :value :CLONES}
            first-error))))
 
 (deftest enum-values-must-be-unique

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -34,7 +34,7 @@
   (let [q "{ hero { id name appears_in } }"]
     (is (= {:data {:hero {:id "2001"
                           :name "R2-D2"
-                          :appears_in ["NEWHOPE" "EMPIRE" "JEDI"]}}}
+                          :appears_in [:NEWHOPE :EMPIRE :JEDI]}}}
            (execute default-schema q {} nil)))
     (is (= (json/write-str (lacinia/execute default-schema q {} nil))
            "{\"data\":{\"hero\":{\"id\":\"2001\",\"name\":\"R2-D2\",\"appears_in\":[\"NEWHOPE\",\"EMPIRE\",\"JEDI\"]}}}")))
@@ -133,18 +133,18 @@
             }"]
     (is (= {:data {:hero {:name "R2-D2"
                           :friends [{:name "Luke Skywalker"
-                                     :appears_in ["NEWHOPE" "EMPIRE" "JEDI"]
+                                     :appears_in [:NEWHOPE :EMPIRE :JEDI]
                                      :friends [{:name "Han Solo"}
                                                {:name "Leia Organa"}
                                                {:name "C-3PO"}
                                                {:name "R2-D2"}]}
                                     {:name "Han Solo"
-                                     :appears_in ["NEWHOPE" "EMPIRE" "JEDI"]
+                                     :appears_in [:NEWHOPE :EMPIRE :JEDI]
                                      :friends [{:name "Luke Skywalker"}
                                                {:name "Leia Organa"}
                                                {:name "R2-D2"}]}
                                     {:name "Leia Organa"
-                                     :appears_in ["NEWHOPE" "EMPIRE" "JEDI"]
+                                     :appears_in [:NEWHOPE :EMPIRE :JEDI]
                                      :friends [{:name "Luke Skywalker"}
                                                {:name "Han Solo"}
                                                {:name "C-3PO"}
@@ -171,12 +171,14 @@
                            :friends [{:name "Darth Vader"}]}}}
            (execute default-schema q nil nil))))
   (let [q "mutation { addHeroEpisodes(id: \"1004\", episodes: []) { name appears_in } }"]
-    (is (= {:data {:addHeroEpisodes {:name "Wilhuff Tarkin" :appears_in ["NEWHOPE"]}}}
+    (is (= {:data {:addHeroEpisodes {:name "Wilhuff Tarkin" :appears_in [:NEWHOPE]}}}
            (execute default-schema q nil nil)))))
 
 (deftest enum-query
   (let [q "mutation { addHeroEpisodes(id: \"1004\", episodes: [JEDI]) { name appears_in } }"]
-    (is (= {:data {:addHeroEpisodes {:name "Wilhuff Tarkin" :appears_in ["NEWHOPE" "JEDI"]}}}
+    (is (= {:data {:addHeroEpisodes {:appears_in [:NEWHOPE
+                                                  :JEDI]
+                                     :name "Wilhuff Tarkin"}}}
            (execute default-schema q nil nil)))))
 
 (deftest not-found-query
@@ -309,7 +311,7 @@
                           :homePlanet "Tatooine"}
                    :leia {:name "Leia Organa"
                           :homePlanet "Alderaan"
-                          :appears_in ["NEWHOPE" "EMPIRE" "JEDI"]}}}
+                          :appears_in [:NEWHOPE :EMPIRE :JEDI]}}}
            (execute default-schema q nil nil))))
   (let [q "query UseFragment {
              luke: human(id: \"1000\") {
@@ -328,8 +330,8 @@
            }"]
     (is (= {:data {:luke {:name "Luke Skywalker"
                           :homePlanet "Tatooine"
-                          :appears_in ["NEWHOPE" "EMPIRE" "JEDI"]}
-                   :leia {:appears_in ["NEWHOPE" "EMPIRE" "JEDI"]}}}
+                          :appears_in [:NEWHOPE :EMPIRE :JEDI]}
+                   :leia {:appears_in [:NEWHOPE :EMPIRE :JEDI]}}}
            (execute default-schema q nil nil))))
   (let [q "query InvalidInlineFragment {
              human(id: \"1001\") {
@@ -647,12 +649,12 @@
                                             {:name "Han Solo"}
                                             {:name "Leia Organa"}
                                             {:name "R2-D2"}]
-                                  :appears_in ["NEWHOPE" "EMPIRE" "JEDI"]}
+                                  :appears_in [:NEWHOPE :EMPIRE :JEDI]}
                        :r2d2 {:name "R2-D2"
                               :friends [{:name "Luke Skywalker"}
                                         {:name "Han Solo"}
                                         {:name "Leia Organa"}]
-                              :appears_in ["NEWHOPE" "EMPIRE" "JEDI"]}}}
+                              :appears_in [:NEWHOPE :EMPIRE :JEDI]}}}
                (execute default-schema q nil nil))))
       (testing "Should use the value provided by user"
         (let [q "{ droid(id: \"2000\") {

--- a/test/com/walmartlabs/test_schema.clj
+++ b/test/com/walmartlabs/test_schema.clj
@@ -23,34 +23,34 @@
          :name       "Luke Skywalker"
          :friends    ["1002", "1003", "2000", "2001"]
          :enemies    ["1002"]
-         :appears-in ["NEWHOPE" "EMPIRE" "JEDI"]
+         :appears-in [:NEWHOPE :EMPIRE :JEDI]
          :homePlanet "Tatooine"
          :force-side  "3001"}
         {:id         "1001"
          :name       "Darth Vader"
          :friends    ["1004"]
          :enemes     ["1000"]
-         :appears-in ["NEWHOPE" "EMPIRE" "JEDI"]
+         :appears-in [:NEWHOPE :EMPIRE :JEDI]
          :homePlanet "Tatooine"
          :force-side  "3000"}
         {:id         "1003"
          :name       "Leia Organa"
          :friends    ["1000", "1002", "2000", "2001"]
          :enemies    ["1001"]
-         :appears-in ["NEWHOPE" "EMPIRE" "JEDI"]
+         :appears-in [:NEWHOPE :EMPIRE :JEDI]
          :homePlanet "Alderaan"
          :force-side  "3001"}
         {:id         "1002"
          :name       "Han Solo"
          :friends    ["1000", "1003", "2001"]
          :enemies    ["1001"]
-         :appears-in ["NEWHOPE" "EMPIRE" "JEDI"]
+         :appears-in [:NEWHOPE :EMPIRE :JEDI]
          :force-side  "3001"}
         {:id         "1004"
          :name       "Wilhuff Tarkin"
          :friends    ["1001"]
          :enemies    ["1000"]
-         :appears-in ["NEWHOPE"]
+         :appears-in [:NEWHOPE]
          :force-side  "3000"}
         ]
        (hash-map-by :id)
@@ -60,12 +60,12 @@
   (->> [{:id               "2001"
          :name             "R2-D2"
          :friends          ["1000", "1002", "1003"]
-         :appears-in       ["NEWHOPE" "EMPIRE" "JEDI"]
+         :appears-in       [:NEWHOPE :EMPIRE :JEDI]
          :primary-function "ASTROMECH"}
         {:id               "2000"
          :name             "C-3PO"
          :friends          ["1000", "1002", "1003", "2001"]
-         :appears-in       ["NEWHOPE" "EMPIRE" "JEDI"]
+         :appears-in       [:NEWHOPE :EMPIRE :JEDI]
          :primary-function "PROTOCOL"}
         ]
        (hash-map-by :id)
@@ -117,7 +117,7 @@
 (defn get-hero
   "Usually retrieves the undisputed hero of the Star Wars trilogy, R2-D2."
   [episode]
-  (get-character (if (= "NEWHOPE" episode)
+  (get-character (if (= :NEWHOPE episode)
                    "1000"                                   ; luke
                    "2001"                                   ; r2d2
                    )))
@@ -133,7 +133,7 @@
   {:enums
    {:episode
     {:description "The episodes of the original Star Wars trilogy."
-     :values ["NEWHOPE" "EMPIRE" "JEDI"]}}
+     :values [:NEWHOPE :EMPIRE :JEDI]}}
 
    :scalars
    {:Date


### PR DESCRIPTION
This builds on https://github.com/walmartlabs/lacinia/pull/31 (which should be merged first) to convert the internal representation of enums to keywords, which is a more natural fit for Clojure.

This affects existing applications: they can expect to see keywords in field arguments that are of an enum type.  That's alpha for you.

