### PR TITLE
Apply custom scalar's parse fn to resolved variables 

### DIFF
--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -500,7 +500,7 @@
       (process-literal-argument schema {:type argument-definition} [:scalar result])
 
       :else
-      nil)))
+      result)))
 
 (defmethod process-dynamic-argument :variable
   [schema argument-definition [_ arg-value]]

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -473,12 +473,12 @@
 (defn ^:private process-result
   "Checks result against variable kind, iterates over nested types, and applies respective
   actions, if necessary, e.g. parse for custom scalars."
-  [schema result argument-definition arg-value]
-  (let [next-type (:type argument-definition)
-        scalar-type? (and (= :root (:kind argument-definition))
-                          (scalar? (get schema next-type)))
-        list-type? (= :list (:kind argument-definition))
-        non-null-kind? (= :non-null (:kind argument-definition))]
+  [schema result argument-type arg-value]
+  (let [nested-type (:type argument-type)
+        scalar-type? (and (= :root (:kind argument-type))
+                          (scalar? (get schema nested-type)))
+        list-type? (= :list (:kind argument-type))
+        non-null-kind? (= :non-null (:kind argument-type))]
     (cond
       ;; we can only hit this if we iterate over list members
       (and (nil? result) non-null-kind?)
@@ -491,13 +491,13 @@
         (throw-exception (format "Variable %s doesn't contain the correct number of (nested) lists."
                                  (q arg-value))
                          {:variable-name arg-value})
-        (mapv #(process-result schema % next-type arg-value) result))
+        (mapv #(process-result schema % nested-type arg-value) result))
 
-      (and (some? result) (map? next-type))
-      (process-result schema result next-type arg-value)
+      (and (some? result) (map? nested-type))
+      (recur schema result nested-type arg-value)
 
       (and (some? result) scalar-type?)
-      (process-literal-argument schema {:type argument-definition} [:scalar result])
+      (process-literal-argument schema {:type argument-type} [:scalar result])
 
       :else
       result)))

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -109,6 +109,12 @@
     (string? v) (Double/parseDouble v)
     :else (throw (ex-info (str "Invalid Float value: " v) {:value v}))))
 
+(defn ^:private coerce-to-boolean
+  [v]
+  (cond
+    (instance? Boolean v) v
+    (string? v) (Boolean/parseBoolean v)))
+
 (def default-scalar-transformers
   {:String {:parse (conformer str)
             :serialize (conformer str)}
@@ -116,7 +122,7 @@
            :serialize (conformer coerce-to-float)}
    :Int {:parse (conformer #(Integer/parseInt %))
          :serialize (conformer coerce-to-int)}
-   :Boolean {:parse (conformer #(Boolean/parseBoolean %))
+   :Boolean {:parse (conformer coerce-to-boolean)
              :serialize (conformer #(Boolean/valueOf %))}
    :ID {:parse (conformer str)
         :serialize (conformer str)}})

--- a/test/com/walmartlabs/lacinia/custom_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/custom_scalars_test.clj
@@ -7,7 +7,9 @@
              [com.walmartlabs.test-schema :refer [test-schema]]
              [com.walmartlabs.test-utils :refer [is-thrown instrument-schema-namespace simplify]])
   (:import (java.text SimpleDateFormat)
-           (java.util Date)))
+           (java.util Date)
+           (org.joda.time DateTime DateTimeConstants)
+           (org.joda.time.format DateTimeFormatter DateTimeFormat)))
 
 (instrument-schema-namespace)
 
@@ -114,13 +116,14 @@
 
 (deftest custom-scalars-with-variables
   (let [date-formatter (SimpleDateFormat. "yyyy-MM-dd")
-        parse-fn (s/conformer (fn [input] (try (.parse date-formatter input)
-                                               (catch Exception e
-                                                 :clojure.spec/invalid))))
-        serialize-fn (s/conformer (fn [output] (.format date-formatter output)))
+        parse-conformer (s/conformer (fn [input]
+                                       (try (.parse date-formatter input)
+                                            (catch Exception e
+                                              :clojure.spec/invalid))))
+        serialize-conformer (s/conformer (fn [output] (.format date-formatter output)))
         schema (schema/compile
-                {:scalars {:Date {:parse parse-fn
-                                  :serialize serialize-fn}}
+                {:scalars {:Date {:parse parse-conformer
+                                  :serialize serialize-conformer}}
 
                  :queries {:today {:type :Date
                                    :args {:asOf {:type :Date}}
@@ -148,3 +151,228 @@
                     {:asOf "abc"}
                     nil))
         "should return error message")))
+
+(defn ^:private periodic-seq
+  [^Date start ^Date end]
+  (take-while (fn [^Date date]
+                (not (.isAfter date end)))
+              (map (fn [i] (.plusDays start i)) (iterate inc 0))))
+
+(defn ^:private  sunday? [t]
+  (= (.getDayOfWeek t) (DateTimeConstants/SUNDAY)))
+
+(defn ^:private sundays [start end]
+  (let [date-range (if (and start end) (periodic-seq start end) [])]
+    (filter sunday? date-range)))
+
+(deftest custom-scalars-with-complex-types
+  (let [date-formatter (DateTimeFormat/forPattern "yyyy-MM-dd")
+        parse-conformer (s/conformer (fn [input]
+                                       (try (DateTime. (.parseDateTime date-formatter input))
+                                            (catch Exception e
+                                              :clojure.spec/invalid))))
+        serialize-conformer (s/conformer (fn [output] (.print date-formatter output)))
+        schema (schema/compile {:scalars {:Date {:parse parse-conformer
+                                                  :serialize serialize-conformer}}
+                                :queries {:sundays {:type '(list (non-null :Date))
+                                                    :args {:between {:type '(non-null (list (non-null :Date)))}}
+                                                    :resolve (fn [ctx args v]
+                                                               (let [[start end] (:between args)]
+                                                                 (sundays start end)))}}})]
+    (is (= {:data {:sundays ["2017-03-05" "2017-03-12" "2017-03-19" "2017-03-26"]}}
+           (execute schema "query ($between: [Date!]!) {
+                              sundays(between: $between)
+                            }"
+                    {:between ["2017-03-05" "2017-03-30"]}
+                    nil))
+        "should return list of serialized dates")
+    (is (= {:data {:sundays []}}
+           (execute schema "query ($between: [Date!]!) {
+                              sundays(between: $between)
+                            }"
+                    {:between ["2017-03-06" "2017-03-07"]}
+                    nil))
+        "should return empty list")
+    (is (= {:data {:sundays []}}
+           (execute schema "query ($between: [Date!]!) {
+                              sundays(between: $between)
+                            }"
+                    {:between []}
+                    nil))
+        "should return empty list (:between can be an empty list) ")
+    (is (= {:errors [{:message "No value was provided for variable `between', which is non-nullable.",
+                      :variable-name :between}]}
+           (execute schema "query ($between: [Date!]!) {
+                              sundays(between: $between)
+                            }"
+                    {:between nil}
+                    nil))
+        "should return an error")
+    (is (= {:errors [{:message "Variable `between' contains null members but supplies the value for a list that can't have any null members."
+                      :variable-name :between}]}
+           (execute schema "query ($between: [Date!]!) {
+                              sundays(between: $between)
+                            }"
+                    {:between [nil]}
+                    nil))
+        "should return an error")
+    (is (= {:errors [{:message "Variable `between' contains null members but supplies the value for a list that can't have any null members."
+                      :variable-name :between}]}
+           (execute schema "query ($between: [Date!]!) {
+                              sundays(between: $between)
+                            }"
+                    {:between ["2017-03-01" nil]}
+                    nil))
+        "should return an error")
+    (is (= {:errors [{:message "No value was provided for variable `between', which is non-nullable."
+                      :variable-name :between}]}
+           (execute schema "query ($between: [Date!]!) {
+                              sundays(between: $between)
+                            }"
+                    nil
+                    nil))
+        "should return an error"))
+
+  (testing "nested lists"
+    (let [scalars {:CustomType {:parse (s/conformer (fn [x] (name x)))
+                                :serialize (s/conformer (fn [x] (.toUpperCase x)))}}
+          schema (schema/compile {:scalars scalars
+                                  :queries {:shout {:type '(list (list (list :CustomType)))
+                                                    :args {:words {:type '(list (list (list :CustomType)))}}
+                                                    :resolve (fn [ctx args v]
+                                                               (:words args))}}})]
+      (is (= {:data {:shout [[["FOO" "BAR"]]]}}
+             (execute schema "query ($words: [[[CustomType]]]) {
+                              shout(words: $words)
+                            }"
+                      {:words [[["foo" "bar"]]]}
+                      nil))
+          "should return nested list")
+      (is (= {:errors [{:message "Variable `words' doesn't contain the correct number of (nested) lists.",
+                        :variable-name :words}]}
+             (execute schema "query ($words: [[[CustomType]]]) {
+                              shout(words: $words)
+                            }"
+                      {:words [["foo" "bar"]]}
+                      nil))
+          "should return an error")
+      (is (= {:data {:shout []}}
+             (execute schema "query ($words: [[[CustomType]]]) {
+                              shout(words: $words)
+                            }"
+                      {:words nil}
+                      nil))
+          "should return empty list")))
+
+  (testing "nested list with a non-null root element in query result"
+    (let [scalars {:CustomType {:parse (s/conformer (fn [x] (name x)))
+                                :serialize (s/conformer (fn [x] (.toUpperCase x)))}}
+          schema (schema/compile {:scalars scalars
+                                  :queries {:shout {:type '(list (list (list (non-null :CustomType))))
+                                                    :args {:words {:type '(list (list (list :CustomType)))}}
+                                                    :resolve (fn [ctx args v]
+                                                               (:words args))}}})]
+      (is (= {:data {:shout [[[nil]]]},
+              :errors [{:message "Non-nullable field was null.",
+                        :locations [{:line 1, :column 33}],
+                        :query-path [:shout],
+                        :arguments {:words [[[nil]]]}}]}
+             (execute schema "query ($words: [[[CustomType]]]) {
+                              shout(words: $words)
+                            }"
+                      {:words [[[nil]]]}
+                      nil))
+          "should return an error")
+      (is (= {:errors [{:message"Variable `words' doesn't contain the correct number of (nested) lists.",
+                        :variable-name :words}]}
+             (execute schema "query ($words: [[[CustomType]]]) {
+                              shout(words: $words)
+                            }"
+                      {:words [[nil]]}
+                      nil))
+          "should return an error")
+      (is (= {:data {:shout [[["BAR"]]]}}
+             (execute schema "query ($words: [[[CustomType]]]) {
+                              shout(words: $words)
+                            }"
+                      {:words [[["bar"]]]}
+                      nil))
+          "should return data")))
+
+  (testing "nested list with a non-null root element in query args"
+    (let [scalars {:CustomType {:parse (s/conformer (fn [x] (name x)))
+                                :serialize (s/conformer (fn [x] (.toUpperCase x)))}}
+          schema (schema/compile {:scalars scalars
+                                  :queries {:shout {:type '(list (list (list :CustomType)))
+                                                    :args {:words {:type '(list (list (list (non-null :CustomType))))}}
+                                                    :resolve (fn [ctx args v]
+                                                               (:words args))}}})]
+      (is (= {:errors [{:message "Variable `words' contains null members but supplies the value for a list that can't have any null members.",
+                        :variable-name :words}]}
+             (execute schema "query ($words: [[[CustomType!]]]) {
+                              shout(words: $words)
+                            }"
+                      {:words [[[nil]]]}
+                      nil))
+          "should return an error")
+      (is (= {:errors [{:message"Variable `words' doesn't contain the correct number of (nested) lists.",
+                        :variable-name :words}]}
+             (execute schema "query ($words: [[[CustomType!]]]) {
+                              shout(words: $words)
+                            }"
+                      {:words [["foo"]]}
+                      nil))
+          "should return an error")
+      (is (= {:errors [{:message "Exception applying arguments to field `shout': For argument `words', variable and argument are not compatible types.",
+                        :query-path []
+                        :locations [{:line 1 :column 33}]
+                        :field :shout
+                        :argument :words
+                        :argument-type "[[[CustomType!]]]"
+                        :variable-type "[[[CustomType]]]"}]}
+             (execute schema "query ($words: [[[CustomType]]]) {
+                              shout(words: $words)
+                            }"
+                      {:words [["foo"]]}
+                      nil))
+          "should return an error")
+      (is (= {:data {:shout [[["FOO"]]]}}
+             (execute schema "query ($words: [[[CustomType!]]]) {
+                              shout(words: $words)
+                            }"
+                      {:words [[["foo"]]]}
+                      nil))
+          "should return an error")))
+
+  (testing "nested non-null lists with a root list allowed to contain nulls in query args"
+    (let [scalars {:CustomType {:parse (s/conformer (fn [x] (if (some? x)
+                                                              (name x)
+                                                              :clojure.spec/invalid)))
+                                :serialize (s/conformer (fn [x] (when x (.toUpperCase x))))}}
+          schema (schema/compile {:scalars scalars
+                                  :queries {:shout {:type '(list (list (list :CustomType)))
+                                                    :args {:words {:type '(non-null (list (non-null (list (non-null (list :CustomType))))))}}
+                                                    :resolve (fn [ctx args v]
+                                                               (:words args))}}})]
+      (is (= {:data {:shout [[[nil]]]}}
+             (execute schema "query ($words: [[[CustomType]!]!]!) {
+                              shout(words: $words)
+                            }"
+                      {:words [[[nil]]]}
+                      nil))
+          "should return data")
+      (is (= {:data {:shout [[["FOO"]]]}}
+             (execute schema "query ($words: [[[CustomType]!]!]!) {
+                              shout(words: $words)
+                            }"
+                      {:words [[["foo"]]]}
+                      nil))
+          "should return data")
+      (is (= {:errors [{:message "Variable `words' doesn't contain the correct number of (nested) lists.",
+                        :variable-name :words}]}
+             (execute schema "query ($words: [[[CustomType]!]!]!) {
+                              shout(words: $words)
+                            }"
+                      {:words [[[] "foo"]]}
+                      nil))
+          "should return an error"))))

--- a/test/com/walmartlabs/lacinia/custom_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/custom_scalars_test.clj
@@ -1,0 +1,151 @@
+(ns com.walmartlabs.lacinia.custom-scalars-test
+  (:require  [clojure.test :as t]
+             [clojure.spec :as s]
+             [clojure.test :refer [deftest is testing]]
+             [com.walmartlabs.lacinia :as lacinia]
+             [com.walmartlabs.lacinia.schema :as schema]
+             [com.walmartlabs.test-schema :refer [test-schema]]
+             [com.walmartlabs.test-utils :refer [is-thrown instrument-schema-namespace simplify]])
+  (:import (java.text SimpleDateFormat)
+           (java.util Date)))
+
+(instrument-schema-namespace)
+
+(def default-schema (schema/compile test-schema))
+
+(defn execute
+  "Executes the query but reduces ordered maps to normal maps, which makes
+  comparisons easier.  Other tests exist to ensure that order is maintained."
+  [schema q vars context]
+  (-> (lacinia/execute schema q vars context)
+      simplify))
+
+;;-------------------------------------------------------------------------------
+;; ## Tests
+
+(deftest custom-scalar-query
+  (let [q "{ now { date }}"]
+    (is (= {:data {:now {:date "A long time ago"}}}
+           (execute default-schema q nil nil)))))
+
+(deftest custom-scalars
+  (testing "custom scalars defined as conformers"
+    (let [parse-conformer (s/conformer
+                           (fn [x]
+                             (prn "qoooooooo")
+                             (if (and
+                                  (string? x)
+                                  (< (count x) 3))
+                               x
+                               :clojure.spec/invalid)))
+          serialize-conformer (s/conformer
+                               (fn [x]
+                                 (case x
+                                   "200" "OK"
+                                   "500" "ERROR"
+                                   :clojure.spec/invalid)))]
+      (testing "custom scalar's serializing option"
+        (let [schema (schema/compile {:scalars
+                                      {:Event {:parse parse-conformer
+                                               :serialize serialize-conformer}}
+
+                                      :objects
+                                      {:galaxy-event
+                                       {:fields {:lookup {:type :Event}}}}
+
+                                      :queries
+                                      {:events {:type :galaxy-event
+                                                :resolve (fn [ctx args v]
+                                                           {:lookup "200"})}}})
+              q "{ events { lookup }}"]
+          (is (= {:data {:events {:lookup "OK"}}} (execute schema q nil nil))
+              "should return conformed value")))
+      (testing "custom scalar's invalid value"
+        (let [schema (schema/compile {:scalars
+                                      {:Event {:parse parse-conformer
+                                               :serialize serialize-conformer}
+                                       :EventId {:parse parse-conformer
+                                                 :serialize (s/conformer str)}}
+
+                                      :objects
+                                      {:galaxy-event
+                                       {:fields {:lookup {:type :Event}}}
+                                       :human
+                                       {:fields {:id {:type :EventId}
+                                                 :name {:type 'String}}}}
+
+                                      :queries
+                                      {:events {:type :galaxy-event
+                                                :resolve (fn [ctx args v]
+                                                           ;; type of :lookup is :Event
+                                                           ;; that is a custom scalar with
+                                                           ;; a serialize function that
+                                                           ;; deems anything other than
+                                                           ;; "200" or "500" invalid.
+                                                           ;; So value 1 should cause
+                                                           ;; an error.
+                                                           {:lookup 1})}
+                                       :human {:type '(non-null :human)
+                                               :args {:id {:type :EventId}}
+                                               :resolve (fn [ctx args v]
+                                                          {:id "1000"
+                                                           :name "Luke Skywalker"})}}})
+              q1 "{ human(id: \"1003\") { id, name }}"
+              q2 "{ events { lookup }}"]
+          (is (= {:errors [{:argument :id
+                            :field :human
+                            :locations [{:column 0
+                                         :line 1}]
+                            :message "Exception applying arguments to field `human': For argument `id', scalar value is not parsable as type `EventId'."
+                            :query-path []
+                            :type-name :EventId
+                            :value "1003"}]}
+                 (execute schema q1 nil nil))
+              "should return error message")
+          (is (= {:data {:events {:lookup nil}}
+                  :errors [{:locations [{:column 9
+                                         :line 1}]
+                            :message "Invalid value for a scalar type."
+                            :query-path [:events
+                                         :lookup]
+                            :type :Event
+                            :value "1"}]}
+                 (execute schema q2 nil nil))
+              "should return error message"))))))
+
+(deftest custom-scalars-with-variables
+  (let [date-formatter (SimpleDateFormat. "yyyy-MM-dd")
+        parse-fn (s/conformer (fn [input] (try (.parse date-formatter input)
+                                               (catch Exception e
+                                                 :clojure.spec/invalid))))
+        serialize-fn (s/conformer (fn [output] (.format date-formatter output)))
+        schema (schema/compile
+                {:scalars {:Date {:parse parse-fn
+                                  :serialize serialize-fn}}
+
+                 :queries {:today {:type :Date
+                                   :args {:asOf {:type :Date}}
+                                   :resolve (fn [ctx args v] (:asOf args))}}})]
+    (is (= {:data {:today "2017-04-05"}}
+           (execute schema "query ($asOf : Date =  \"2017-04-05\") {
+                              today (asOf: $asOf)
+                            }"
+                    nil
+                    nil))
+        "should return parsed and serialized value")
+    (is (= {:data {:today "2017-04-05"}}
+           (execute schema "query ($asOf: Date) {
+                              today(asOf: $asOf)
+                            }"
+                    {:asOf "2017-04-05"}
+                    nil))
+        "should return parsed and serialized value")
+    (is (= {:errors [{:message "Scalar value is not parsable as type `Date'.",
+                      :value "abc",
+                      :type-name :Date}]}
+           (execute schema "query ($asOf: Date) {
+                              today(asOf: $asOf)
+                            }"
+                    {:asOf "abc"}
+                    nil))
+        "should return error message")))

--- a/test/com/walmartlabs/lacinia/custom_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/custom_scalars_test.clj
@@ -32,7 +32,6 @@
   (testing "custom scalars defined as conformers"
     (let [parse-conformer (s/conformer
                            (fn [x]
-                             (prn "qoooooooo")
                              (if (and
                                   (string? x)
                                   (< (count x) 3))


### PR DESCRIPTION
This PR fixes https://github.com/walmartlabs/lacinia/issues/34

Variables can be custom scalars, and so we should treat them as such when their value is resolved.