### PR TITLE
Simplify benchmark reporting

### DIFF
--- a/dev-resources/perf.clj
+++ b/dev-resources/perf.clj
@@ -237,12 +237,14 @@
 
 (def ^:private dataset-file "perf/benchmarks.csv")
 
-(defn read-dataset
+(defn ^:private read-dataset
   []
   (let [[header-row & raw-data]
         (-> (io/file dataset-file)
             io/reader
             csv/read-csv)
+        ;; read-csv reads all columns as strings, so we need to do some
+        ;; work to get them back to numbers.
         parse-double (fn [row ix]
                        (update row ix #(Double/parseDouble %)))]
     (into [header-row]
@@ -250,7 +252,8 @@
                (mapv #(parse-double % 3))
                (mapv #(parse-double % 4))))))
 
-(defn run-benchmarks [options]
+(defn ^:private run-benchmarks
+  [options]
   (let [prefix [(format "%tY%<tm%<td" (Date.))
                 (or (:commit options) (git-commit))]
         new-benchmarks (->> (map run-benchmark (keys benchmark-queries))

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
                  [org.flatland/ordered "1.5.4"
                   :exclusions [org.clojure/tools.macro]]]
   :profiles {:dev {:dependencies [[criterium "0.4.4"]
+                                  [clj-time "0.13.0"]
                                   [org.clojure/data.csv "0.1.3"]
                                   [org.clojure/tools.cli "0.3.5"]
                                   [org.clojure/data.json "0.2.6"]]}}

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [org.flatland/ordered "1.5.4"
                   :exclusions [org.clojure/tools.macro]]]
   :profiles {:dev {:dependencies [[criterium "0.4.4"]
-                                  [incanter "1.5.7"]
+                                  [org.clojure/data.csv "0.1.3"]
                                   [org.clojure/tools.cli "0.3.5"]
                                   [org.clojure/data.json "0.2.6"]]}}
   :aliases {"benchmarks" ["run" "-m" "perf"]}

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [org.flatland/ordered "1.5.4"
                   :exclusions [org.clojure/tools.macro]]]
   :profiles {:dev {:dependencies [[criterium "0.4.4"]
-                                  [clj-time "0.13.0"]
+                                  [joda-time "2.9.7"]
                                   [org.clojure/data.csv "0.1.3"]
                                   [org.clojure/tools.cli "0.3.5"]
                                   [org.clojure/data.json "0.2.6"]]}}


### PR DESCRIPTION
I've simplified the code inside perf.clj to just collect and store the benchmarks; this gets rid of Incanter as a dev dependency.

I'll follow up with R scripts to generate the desired graphs from the CSV file, once I have that figured out.