### PR TITLE
Error maps may include parsed arguments, causing failures if those parsed values are not JSON serializable

### DIFF
--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -14,9 +14,9 @@
    (ex-info-map field-selection {}))
   ([field-selection m]
    (merge m
-          {:locations [(:location field-selection)]}
-          (->> (select-keys field-selection [:query-path :arguments])
-               (remove-vals nil?)))))
+          (remove-vals nil? {:locations [(:location field-selection)]
+                             :query-path (:query-path field-selection)
+                             :arguments (:reportable-arguments field-selection)}))))
 
 (defn ^:private assert-and-wrap-error
   "An error returned by a resolver should be nil, a map, or a collection

--- a/test/com/walmartlabs/lacinia/custom_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/custom_scalars_test.clj
@@ -276,7 +276,7 @@
               :errors [{:message "Non-nullable field was null.",
                         :locations [{:line 1, :column 33}],
                         :query-path [:shout],
-                        :arguments {:words [[[nil]]]}}]}
+                        :arguments {:words '$words}}]}
              (execute schema "query ($words: [[[CustomType]]]) {
                               shout(words: $words)
                             }"


### PR DESCRIPTION
This PR will prevent returning conformed scalar arguments when resolvers return an error.