### PR TITLE
Make schema/as-conformer public

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 0.16.0 -- UNRELEASED
 
+The function `com.walmartlabs.lacinia.schema/as-conformer' is now public.
+
 ## 0.15.0 -- 19 Apr 2017
 
 Field resolvers can now operate synchronously or asynchronously.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ requests; this typically occurs inside a Ring handler function:
 
 Lacinia doesn't know about the web tier at all, it just knows about
 parsing and executing queries against a compiled schema.
+A companion library, [pedestal-lacinia](https://github.com/walmartlabs/pedestal-lacinia),
+is one way to expose your schema on the web.
 
 User queries are provided as the body of a request with the content type application/graphql.
 It looks a lot like JSON.
@@ -207,12 +209,12 @@ fields in the response:
 ```
 
 ```clojure
-{:data {:hero {:movies [:NEWHOPE :EMPIRE :JEDI"]}}}
+{:data {:hero {:movies [:NEWHOPE :EMPIRE :JEDI]}}}
 ```
 
 ## Status
 
-Although this library is used internally, in production, it is
+Although this library is used in production at Walmart, it is
 still considered alpha software - subject to change.
 We expect to stabilize it in the near future.
 

--- a/docs/_examples/custom-scalars.edn
+++ b/docs/_examples/custom-scalars.edn
@@ -13,13 +13,15 @@
 
 (def schema
   (schema/compile
-    {:scalars {
-               :Date {:parse (s/conformer #(.parse date-formatter %))
-                      :serialize (s/conformer #(.format date-formatter %))}}
+    {:scalars
+     {:Date
+      {:parse (schema/as-conformer #(.parse date-formatter %))
+       :serialize (schema/as-conformer #(.format date-formatter %))}}
 
-     :queries {
-               :today {:type :Date
-                       :resolve (fn [ctx args v] (Date.))}}}))
+     :queries
+     {:today
+      {:type :Date
+       :resolve (fn [ctx args v] (Date.))}}}))
 
 (g/execute schema "{today}" nil nil)
 => {:data {:today "2016-12-09"}}

--- a/docs/custom-scalars.rst
+++ b/docs/custom-scalars.rst
@@ -37,3 +37,5 @@ Here is an example that defines and uses a custom ``:Date`` scalar type:
    the ``SimpleDateFormat`` class is not thread safe. It does not properly report
    unparseable values.
 
+The function ``com.walmartlabs.lacinia.schema/as-conformer`` is an easy way to wrap a function as a conformer.
+

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -71,10 +71,13 @@
        ;; all the values have been filtered out.
        (filter-vals seq)))
 
-(defn ^:private conformer
-  "Creates a conformer that returns
-  :clojure.spec/invalid when the value fails
-  to conform."
+(defn as-conformer
+  "Creates a clojure.spec/conformer as a wrapper around the supplied function.
+
+  The function is only invoked if the value to be conformed is non-nil.
+
+  Any exception thrown by the function is silently caught and the returned conformer
+  will return :clojure.spec/invalid."
   [f]
   (s/conformer
     (fn [x]
@@ -105,16 +108,16 @@
     (string? v) (Boolean/parseBoolean v)))
 
 (def default-scalar-transformers
-  {:String {:parse (conformer str)
-            :serialize (conformer str)}
-   :Float {:parse (conformer #(Double/parseDouble %))
-           :serialize (conformer coerce-to-float)}
-   :Int {:parse (conformer #(Integer/parseInt %))
-         :serialize (conformer coerce-to-int)}
-   :Boolean {:parse (conformer coerce-to-boolean)
-             :serialize (conformer #(Boolean/valueOf %))}
-   :ID {:parse (conformer str)
-        :serialize (conformer str)}})
+  {:String {:parse (as-conformer str)
+            :serialize (as-conformer str)}
+   :Float {:parse (as-conformer #(Double/parseDouble %))
+           :serialize (as-conformer coerce-to-float)}
+   :Int {:parse (as-conformer #(Integer/parseInt %))
+         :serialize (as-conformer coerce-to-int)}
+   :Boolean {:parse (as-conformer coerce-to-boolean)
+             :serialize (as-conformer #(Boolean/valueOf %))}
+   :ID {:parse (as-conformer str)
+        :serialize (as-conformer str)}})
 
 (defn ^:private error
   ([message]


### PR DESCRIPTION
I've noticed that every app we write has cut-and-pasted this, so it must be generally useful.

@sashton @bcarrell 