### PR TITLE
Add function c.w.l/execute-parsed-query-async

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 The function `com.walmartlabs.lacinia.schema/as-conformer' is now public.
 
+New function `com.walmartlabs.lacinia/execute-parsed-query-async`.
+
 ## 0.15.0 -- 19 Apr 2017
 
 Field resolvers can now operate synchronously or asynchronously.

--- a/src/com/walmartlabs/lacinia/resolve.clj
+++ b/src/com/walmartlabs/lacinia/resolve.clj
@@ -10,7 +10,7 @@
     The callback is passed the ResolverResult's value and errors.
 
     `on-deliver!` should only be invoked once.
-    It returns the ResolverResult.
+    It returns `this`.
 
     On a simple ResolverResult (not a ResolverResultPromise), the callback is invoked
     immediately.
@@ -25,7 +25,7 @@
     [this value errors]
     "Invoked to realize the ResolverResult, triggering the callback to receive the value and errors.
 
-    Returns the deferred resolver result."))
+    Returns `this`."))
 
 (defrecord ^:private ResolverResultImpl [resolved-value resolve-errors]
 


### PR DESCRIPTION
Adds a new function, `execute-parsed-query-async` that returns a ResolverResult.  This is a good bridge for pedestal-lacinia to use in order to provide an async handler for executing queries.