### PR TITLE
Collect timing information from resolvers (optionally)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ The function `com.walmartlabs.lacinia.schema/as-conformer' is now public.
 
 New function `com.walmartlabs.lacinia/execute-parsed-query-async`.
 
+Lacinia can now, optionally, collect timing information about
+field resolver functions. This information is returned in the
+`:extensions :timings` key of the response.
+
 ## 0.15.0 -- 19 Apr 2017
 
 Field resolvers can now operate synchronously or asynchronously.

--- a/dev-resources/timing-schema.edn
+++ b/dev-resources/timing-schema.edn
@@ -1,0 +1,16 @@
+{:objects
+ {:Fast
+  {:fields {:simple {:type String}
+            :slow {:type :Slow
+                   :resolve :resolve-slow}}}
+  :Slow
+  {:fields {:simple {:type String}}}}
+
+ :queries
+ {:root {:type (non-null Fast)
+         :args {:delay {:type Int}
+                :value {:type String
+                        :default-value "fast!"}
+                :nested-value {:type String
+                               :default-value "slow!!"}}
+         :resolve :resolve-fast}}}

--- a/docs/_examples/timings.edn
+++ b/docs/_examples/timings.edn
@@ -8,12 +8,21 @@
 }" nil
   {::lacinia/enable-timing? true})
 =>
-{:data {:luke {:friends [{:name "Han Solo"} {:name "Leia Organa"} {:name "C-3PO"} {:name "R2-D2"}]},
-        :leia {:name "Leia Organa"}},
+{:data {:luke {:friends [{:name "Han Solo"}
+                         {:name "Leia Organa"}
+                         {:name "C-3PO"}
+                         {:name "R2-D2"}]}
+        :leia {:name "Leia Organa"}}
  :extensions
  {:timing
+  {:QueryRoot
+   {:human [{:start 1493245557504
+             :finish 1493245557504
+             :elapsed 0}
+            {:start 1493245557507
+             :finish 1493245557507
+             :elapsed 0}]}}
   {:human
-   {:execution/timings [{:start 1493245557504, :finish 1493245557504, :elapsed 0}
-                        {:start 1493245557507, :finish 1493245557507, :elapsed 0}],
-    :friends
-    {:execution/timings [{:start 1493245557505, :finish 1493245557505, :elapsed 0}]}}}}}
+   {:friends [{:start 1493245557505
+               :finish 1493245557505
+               :elapsed 0}]}}}}

--- a/docs/_examples/timings.edn
+++ b/docs/_examples/timings.edn
@@ -8,21 +8,12 @@
 }" nil
   {::lacinia/enable-timing? true})
 =>
-{:data {:luke {:friends [{:name "Han Solo"}
-                         {:name "Leia Organa"}
-                         {:name "C-3PO"}
-                         {:name "R2-D2"}]}
-        :leia {:name "Leia Organa"}}
+{:data {:luke {:friends [{:name "Han Solo"} {:name "Leia Organa"} {:name "C-3PO"} {:name "R2-D2"}]},
+        :leia {:name "Leia Organa"}},
  :extensions
  {:timing
-  {:QueryRoot
-   {:human [{:start 1493245557504
-             :finish 1493245557504
-             :elapsed 0}
-            {:start 1493245557507
-             :finish 1493245557507
-             :elapsed 0}]}}
   {:human
-   {:friends [{:start 1493245557505
-               :finish 1493245557505
-               :elapsed 0}]}}}}
+   {:execution/timings [{:start 1493245557504, :finish 1493245557504, :elapsed 0}
+                        {:start 1493245557507, :finish 1493245557507, :elapsed 0}],
+    :friends
+    {:execution/timings [{:start 1493245557505, :finish 1493245557505, :elapsed 0}]}}}}}

--- a/docs/_examples/timings.edn
+++ b/docs/_examples/timings.edn
@@ -1,0 +1,19 @@
+(require '[com.walmartlabs.lacinia :as lacinia])
+
+(lacinia/execute
+  star-wars-schema
+  "{
+  luke: human(id: \"1000\") { friends { name }}
+  leia: human(id: \"1003\") { name }
+}" nil
+  {::lacinia/enable-timing true})
+=>
+{:data {:luke {:friends [{:name "Han Solo"} {:name "Leia Organa"} {:name "C-3PO"} {:name "R2-D2"}]},
+        :leia {:name "Leia Organa"}},
+ :extensions
+ {:timing
+  {:human
+   {:execution/timings [{:start 1493245557504, :finish 1493245557504, :elapsed 0}
+                        {:start 1493245557507, :finish 1493245557507, :elapsed 0}],
+    :friends
+    {:execution/timings [{:start 1493245557505, :finish 1493245557505, :elapsed 0}]}}}}}

--- a/docs/_examples/timings.edn
+++ b/docs/_examples/timings.edn
@@ -6,7 +6,7 @@
   luke: human(id: \"1000\") { friends { name }}
   leia: human(id: \"1003\") { name }
 }" nil
-  {::lacinia/enable-timing true})
+  {::lacinia/enable-timing? true})
 =>
 {:data {:luke {:friends [{:name "Han Solo"} {:name "Leia Organa"} {:name "C-3PO"} {:name "R2-D2"}]},
         :leia {:name "Leia Organa"}},

--- a/docs/resolve/index.rst
+++ b/docs/resolve/index.rst
@@ -25,4 +25,5 @@ In some cases, a field resolver may need to perform additional queries against a
     attach
     resolve-as
     async
+    timing
     examples

--- a/docs/resolve/timing.rst
+++ b/docs/resolve/timing.rst
@@ -1,0 +1,34 @@
+Timing Resolvers
+================
+
+It can be very interesting to know where your queries are spending their time; Lacinia
+can help you here; when enabled, Lacinia will collect start/stop and elapsed time for each
+resolver function that gets invoked.
+
+Timing collection is enabled using the key, ``:com.walmartlabs.lacinia/enable-timing``, in the application context:
+
+.. literalinclude:: /_examples/timings.edn
+   :language: clojure
+
+.. sidebar:: Extension key?
+
+   GraphQL supports a third response key, ``extensions``, as
+   described in `the spec <https://facebook.github.io/graphql/#sec-Response-Format>`_.
+   It exists just for this kind of extra information in the response.
+
+Timings are returned in a tree structure below the ``:extensions`` key of the response.
+The tree structure reflects the structure of the *query* (not the schema).
+
+We can see here that the ``human`` query operation's resolver was invoked twice, and the ``friends`` field's
+resolver was invoked just once.
+Only explicitly added resolve functions are timed; default resolve functions are trivial and not included.
+
+For each invocation, values are identified for the start and finish time (in standard format, milliseconds since the epoch),
+and elapsed time (also in milliseconds).
+
+Since our sample data is all in-memory, execution is instantaneous, so the elapsed time is 0.
+In real applications, making requests to a database or other resources, there would be some amount of elapsed time.
+
+When the field resolvers are :doc:`asynchronous <async>`, you'll see start and finish times for each
+invocation overlap.  The finish time is calculated not when the resolver function returns, but
+when it produces a value (that is, when the ResolverResult is realized).

--- a/docs/resolve/timing.rst
+++ b/docs/resolve/timing.rst
@@ -1,5 +1,5 @@
-Timing Resolvers
-================
+Resolver Timing
+===============
 
 It can be very interesting to know where your queries are spending their time; Lacinia
 can help you here; when enabled, Lacinia will collect start/stop and elapsed time for each
@@ -10,17 +10,17 @@ Timing collection is enabled using the key, ``:com.walmartlabs.lacinia/enable-ti
 .. literalinclude:: /_examples/timings.edn
    :language: clojure
 
-.. sidebar:: Extension key?
+.. sidebar:: Extensions key?
 
    GraphQL supports a third response key, ``extensions``, as
    described in `the spec <https://facebook.github.io/graphql/#sec-Response-Format>`_.
    It exists just for this kind of extra information in the response.
 
 Timings are returned in a tree structure below the ``:extensions`` key of the response.
-The tree structure reflects the structure of the *query* (not the schema).
+The tree structure reflects the structure of the schema (not the query).
 
 We can see here that the ``human`` query operation's resolver was invoked twice, and the ``friends`` field's
-resolver was invoked just once.
+resolver (inside the ``human`` type) was invoked just once.
 Only explicitly added resolve functions are timed; default resolve functions are trivial and not included.
 
 For each invocation, values are identified for the start and finish time (in standard format, milliseconds since the epoch),

--- a/docs/resolve/timing.rst
+++ b/docs/resolve/timing.rst
@@ -1,5 +1,5 @@
-Resolver Timing
-===============
+Timing Resolvers
+================
 
 It can be very interesting to know where your queries are spending their time; Lacinia
 can help you here; when enabled, Lacinia will collect start and finish timestamps, and elapsed time, for each
@@ -10,17 +10,17 @@ Timing collection is enabled using the key, ``:com.walmartlabs.lacinia/enable-ti
 .. literalinclude:: /_examples/timings.edn
    :language: clojure
 
-.. sidebar:: Extensions key?
+.. sidebar:: Extension key?
 
    GraphQL supports a third response key, ``extensions``, as
    described in `the spec <https://facebook.github.io/graphql/#sec-Response-Format>`_.
    It exists just for this kind of extra information in the response.
 
 Timings are returned in a tree structure below the ``:extensions`` key of the response.
-The tree structure reflects the structure of the schema (not the query).
+The tree structure reflects the structure of the *query* (not the schema).
 
 We can see here that the ``human`` query operation's resolver was invoked twice, and the ``friends`` field's
-resolver (inside the ``human`` type) was invoked just once.
+resolver was invoked just once.
 Only explicitly added resolve functions are timed; default resolve functions are trivial and not included.
 
 For each invocation, values are identified for the start and finish time (in standard format, milliseconds since the epoch),

--- a/docs/resolve/timing.rst
+++ b/docs/resolve/timing.rst
@@ -2,7 +2,7 @@ Resolver Timing
 ===============
 
 It can be very interesting to know where your queries are spending their time; Lacinia
-can help you here; when enabled, Lacinia will collect start/stop and elapsed time for each
+can help you here; when enabled, Lacinia will collect start and finish timestamps, and elapsed time, for each
 resolver function that gets invoked.
 
 Timing collection is enabled using the key, ``:com.walmartlabs.lacinia/enable-timing?``, in the application context:

--- a/docs/resolve/timing.rst
+++ b/docs/resolve/timing.rst
@@ -1,9 +1,9 @@
-Timing Resolvers
-================
+Resolver Timing
+===============
 
-It can be very interesting to know where your queries are spending their time; Lacinia
+When scaling a service, it is invaluable to know where queries are spending their execution time; Lacinia
 can help you here; when enabled, Lacinia will collect start and finish timestamps, and elapsed time, for each
-resolver function that gets invoked.
+resolver function that is invoked during execution of the query.
 
 Timing collection is enabled using the key, ``:com.walmartlabs.lacinia/enable-timing?``, in the application context:
 
@@ -27,8 +27,8 @@ For each invocation, values are identified for the start and finish time (in sta
 and elapsed time (also in milliseconds).
 
 Since our sample data is all in-memory, execution is instantaneous, so the elapsed time is 0.
-In real applications, making requests to a database or other resources, there would be some amount of elapsed time.
+In real applications, making requests to a database or accessing other resources, there would be some amount of elapsed time.
 
-When the field resolvers are :doc:`asynchronous <async>`, you'll see start and finish times for each
+When the field resolvers are :doc:`asynchronous <async>`, you'll often see start and finish times for each
 invocation overlap.  The finish time is calculated not when the resolver function returns, but
 when it produces a value (that is, when the ResolverResult is realized).

--- a/docs/resolve/timing.rst
+++ b/docs/resolve/timing.rst
@@ -5,7 +5,7 @@ It can be very interesting to know where your queries are spending their time; L
 can help you here; when enabled, Lacinia will collect start/stop and elapsed time for each
 resolver function that gets invoked.
 
-Timing collection is enabled using the key, ``:com.walmartlabs.lacinia/enable-timing``, in the application context:
+Timing collection is enabled using the key, ``:com.walmartlabs.lacinia/enable-timing?``, in the application context:
 
 .. literalinclude:: /_examples/timings.edn
    :language: clojure

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -130,14 +130,10 @@
                                        timing {:start start-ms
                                                :finish finish-ms
                                                ;; This is just a convienience:
-                                               :elapsed elapsed-ms}]
-                                   ;; The extra key is to handle a case where we time, say, [:hero] and [:hero :friends]
-                                   ;; That will leave :friends as one child of :hero, and :execution/timings as another.
-                                   ;; The timings are always a list; we don't know if the field is resolved once,
-                                   ;; resolved multiple times because it is inside a nested value, or resolved multiple
-                                   ;; times because of multiple top-level operations.
+                                               :elapsed elapsed-ms}
+                                       {:keys [field-name containing-type-name]} (:field-definition field-selection)]
                                    (swap! timings
-                                          update-in (conj (:query-path field-selection) :execution/timings)
+                                          update-in [containing-type-name field-name]
                                           (fnil conj []) timing)))
 
                                (when-let [errors (-> resolve-errors

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -89,6 +89,12 @@
                          :value value
                          :value-meta (meta value)})))))
 
+(defmacro ^:private now
+  []
+  `(System/currentTimeMillis))
+
+(def ^:private conj-nil
+  (fnil conj []))
 
 (defn ^:private invoke-resolver-for-field
   "Resolves the value for a field selection node, by passing the value to the
@@ -98,16 +104,24 @@
   The final ResolverResult will always contain just a resolved value; errors are handled here,
   and not passed back in the returned ResolverResult.
 
+  Optinally updates the timings inside the execution-context with start/finish/elapsed time
+  (in milliseconds). Timing checks only occur when enabled (timings is non-nil)
+  and not for default resolvers.
+
   Any resolve errors are enhanced with details about the selection and accumulated in
   the execution context."
   [execution-context field-selection]
   (let [container-value (:resolved-value execution-context)]
     (if (= :field (:selection-type field-selection))
-      (let [{:keys [arguments]} field-selection
+      (let [timings (:timings execution-context)
+            {:keys [arguments]} field-selection
             {:keys [context]} execution-context
             schema (get context constants/schema-key)
             resolve-context (assoc context :com.walmartlabs.lacinia/selection field-selection)
             field-resolver (field-selection-resolver schema field-selection container-value)
+            start-ms (when (and (some? timings)
+                                (not (-> field-resolver meta ::schema/default-resolver)))
+                       (now))
             resolver-result (try
                               (field-resolver resolve-context arguments container-value)
                               (catch Throwable t
@@ -117,6 +131,22 @@
             final-result (resolve/resolve-promise)]
         (resolve/on-deliver! resolver-result
                              (fn [resolved-value resolve-errors]
+                               (when start-ms
+                                 (let [finish-ms (now)
+                                       elapsed-ms (- finish-ms start-ms)
+                                       timing {:start start-ms
+                                               :finish finish-ms
+                                               ;; This is just a convienience:
+                                               :elapsed elapsed-ms}]
+                                   ;; The extra key is to handle a case where we time, say, [:hero] and [:hero :friends]
+                                   ;; That will leave :friends as one child of :hero, and :execution/timings as another.
+                                   ;; The timings are always a list; we don't know if the field is resolved once,
+                                   ;; resolved multiple times because it is inside a nested value, or resolved multiple
+                                   ;; times because of multiple top-level operations.
+                                   (swap! timings
+                                          update-in (conj (:query-path field-selection) :execution/timings)
+                                          conj-nil timing)))
+
                                (when-let [errors (-> resolve-errors
                                                      assert-and-wrap-error
                                                      seq)]
@@ -133,7 +163,12 @@
 (declare ^:private resolve-and-select)
 
 (defrecord ExecutionContext
-  [context resolved-value errors])
+  ;; context and resolved-value change constantly during the process
+  ;; errors is an Atom containing a vector, which accumulates
+  ;; error-maps during execution.
+  ;; timings is usually nil, or may be an Atom containing an empty map, which
+  ;; accumulates timing data during execution.
+  [context resolved-value errors timings])
 
 (defn ^:private null-to-nil
   [v]
@@ -391,7 +426,9 @@
         {:keys [selections mutation?]} parsed-query
         enabled-selections (remove :disabled? selections)
         errors (atom [])
-        execution-context (->ExecutionContext context nil errors)
+        timings (when (:com.walmartlabs.lacinia/enable-timing context)
+                  (atom {}))
+        execution-context (->ExecutionContext context nil errors timings)
         operation-result (if mutation?
                            (execute-nested-selections-sync execution-context enabled-selections)
                            (execute-nested-selections execution-context enabled-selections))
@@ -401,5 +438,6 @@
                            (let [data (propogate-nulls false selected-data)]
                              (resolve/deliver! response-result
                                                (cond-> {:data data}
+                                                 timings (assoc-in [:extensions :timing] @timings)
                                                  (seq @errors) (assoc :errors (distinct @errors)))))))
     response-result))

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -130,10 +130,14 @@
                                        timing {:start start-ms
                                                :finish finish-ms
                                                ;; This is just a convienience:
-                                               :elapsed elapsed-ms}
-                                       {:keys [field-name containing-type-name]} (:field-definition field-selection)]
+                                               :elapsed elapsed-ms}]
+                                   ;; The extra key is to handle a case where we time, say, [:hero] and [:hero :friends]
+                                   ;; That will leave :friends as one child of :hero, and :execution/timings as another.
+                                   ;; The timings are always a list; we don't know if the field is resolved once,
+                                   ;; resolved multiple times because it is inside a nested value, or resolved multiple
+                                   ;; times because of multiple top-level operations.
                                    (swap! timings
-                                          update-in [containing-type-name field-name]
+                                          update-in (conj (:query-path field-selection) :execution/timings)
                                           (fnil conj []) timing)))
 
                                (when-let [errors (-> resolve-errors

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -97,7 +97,7 @@
   The final ResolverResult will always contain just a resolved value; errors are handled here,
   and not passed back in the returned ResolverResult.
 
-  Optinally updates the timings inside the execution-context with start/finish/elapsed time
+  Optionally updates the timings inside the execution-context with start/finish/elapsed time
   (in milliseconds). Timing checks only occur when enabled (timings is non-nil)
   and not for default resolvers.
 
@@ -113,7 +113,7 @@
             resolve-context (assoc context :com.walmartlabs.lacinia/selection field-selection)
             field-resolver (field-selection-resolver schema field-selection container-value)
             start-ms (when (and (some? timings)
-                                (not (-> field-resolver meta ::schema/default-resolver)))
+                                (not (-> field-resolver meta ::schema/default-resolver?)))
                        (System/currentTimeMillis))
             resolver-result (try
                               (field-resolver resolve-context arguments container-value)
@@ -419,7 +419,7 @@
         {:keys [selections mutation?]} parsed-query
         enabled-selections (remove :disabled? selections)
         errors (atom [])
-        timings (when (:com.walmartlabs.lacinia/enable-timing context)
+        timings (when (:com.walmartlabs.lacinia/enable-timing? context)
                   (atom {}))
         execution-context (->ExecutionContext context nil errors timings)
         operation-result (if mutation?

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -75,7 +75,7 @@
   "Creates a clojure.spec/conformer as a wrapper around the supplied function.
 
   The function is only invoked if the value to be conformed is non-nil.
-
+]
   Any exception thrown by the function is silently caught and the returned conformer
   will return :clojure.spec/invalid."
   [f]
@@ -488,11 +488,14 @@
   ensure it returns a ResolverResult.
   Adds a :selector function."
   [schema options containing-type field]
-  (let [base-resolver (or (:resolve field)
+  (let [provided-resolver (:resolve field)
+        base-resolver (or provided-resolver
                           ((:default-field-resolver options) (:field-name field)))
-        selector (assemble-selector schema containing-type field (:type field))]
+        selector (assemble-selector schema containing-type field (:type field))
+        wrapped-resolver (cond-> (wrap-resolver-to-ensure-resolver-result base-resolver)
+                           (nil? provided-resolver) (vary-meta assoc ::default-resolver true))]
     (assoc field
-           :resolve (wrap-resolver-to-ensure-resolver-result base-resolver)
+           :resolve wrapped-resolver
            :selector selector)))
 
 ;;-------------------------------------------------------------------------------

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -495,7 +495,6 @@
         wrapped-resolver (cond-> (wrap-resolver-to-ensure-resolver-result base-resolver)
                            (nil? provided-resolver) (vary-meta assoc ::default-resolver? true))]
     (assoc field
-           :containing-type-name (:type-name containing-type)
            :resolve wrapped-resolver
            :selector selector)))
 

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -495,6 +495,7 @@
         wrapped-resolver (cond-> (wrap-resolver-to-ensure-resolver-result base-resolver)
                            (nil? provided-resolver) (vary-meta assoc ::default-resolver? true))]
     (assoc field
+           :containing-type-name (:type-name containing-type)
            :resolve wrapped-resolver
            :selector selector)))
 

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -75,7 +75,7 @@
   "Creates a clojure.spec/conformer as a wrapper around the supplied function.
 
   The function is only invoked if the value to be conformed is non-nil.
-]
+
   Any exception thrown by the function is silently caught and the returned conformer
   will return :clojure.spec/invalid."
   [f]

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -493,7 +493,7 @@
                           ((:default-field-resolver options) (:field-name field)))
         selector (assemble-selector schema containing-type field (:type field))
         wrapped-resolver (cond-> (wrap-resolver-to-ensure-resolver-result base-resolver)
-                           (nil? provided-resolver) (vary-meta assoc ::default-resolver true))]
+                           (nil? provided-resolver) (vary-meta assoc ::default-resolver? true))]
     (assoc field
            :resolve wrapped-resolver
            :selector selector)))

--- a/src/com/walmartlabs/lacinia/timings_test.clj
+++ b/src/com/walmartlabs/lacinia/timings_test.clj
@@ -55,13 +55,13 @@
 
 (deftest does-not-collect-timing-for-default-resolvers
   (let [result (q "{ root(delay: 50) { simple slow { simple }}}" enable-timing)]
-    (is (= nil (-> result :extensions :timing :Fast :simple))
+    (is (= nil (-> result :extensions :timing :root :simple))
         "Some timings were collected.")))
 
 (deftest collects-timing-for-provided-resolvers
   (doseq [delay [25 50 75]
           :let [result (q (str "{ root(delay: " delay ") { slow { simple }}}") enable-timing)
-                timings (get-in result [:extensions :timing :Fast :slow])
+                timings (get-in result [:extensions :timing :root :slow :execution/timings])
                 elapsed-time (-> timings first :elapsed)]]
     ;; Allow for a bit of overhead; Thread/sleep is quite inexact.
     (is (<= delay elapsed-time (+ delay 10)))
@@ -75,7 +75,7 @@
                      tortoise: root(delay: 50) { slow { simple }}
                    }"
                   enable-timing)
-        elapsed-times (->> (get-in result [:extensions :timing :Fast :slow])
+        elapsed-times (->> (get-in result [:extensions :timing :root :slow :execution/timings])
                            (mapv :elapsed))]
     (is (= 2 (count elapsed-times)))
     (is (<= 5 (elapsed-times 0) 15))

--- a/src/com/walmartlabs/lacinia/timings_test.clj
+++ b/src/com/walmartlabs/lacinia/timings_test.clj
@@ -1,0 +1,83 @@
+(ns com.walmartlabs.lacinia.timings-test
+  "Tests for the optional timing logic."
+  (:require
+    [clojure.test :refer [deftest is]]
+    [clojure.java.io :as io]
+    [clojure.edn :as edn]
+    [com.walmartlabs.lacinia.util :as util]
+    [com.walmartlabs.lacinia.resolve :as resolve]
+    [com.walmartlabs.test-utils :refer [simplify]]
+    [com.walmartlabs.lacinia :refer [execute]]
+    [com.walmartlabs.lacinia.schema :as schema]))
+
+(def ^:private enable-timing {:com.walmartlabs.lacinia/enable-timing true})
+
+(defn ^:private resolve-fast
+  [_ args _]
+  {:simple (:value args)
+   ::slow {:simple (:nested-value args)}
+   ::delay (:delay args)})
+
+(defn ^:private resolve-slow
+  [_ _ value]
+  (let [resolved-value (resolve/resolve-promise)
+        f (fn []
+            (Thread/sleep (::delay value))
+            (resolve/deliver! resolved-value (::slow value)))
+        thread (Thread. ^Runnable f)]
+    (.start thread)
+    resolved-value))
+
+(def ^:private compiled-schema
+  (-> (io/resource "timing-schema.edn")
+      slurp
+      edn/read-string
+      (util/attach-resolvers {:resolve-fast resolve-fast
+                              :resolve-slow resolve-slow})
+      schema/compile))
+
+(defn ^:private q
+  ([query]
+   (q query nil))
+  ([query context]
+   (-> (execute compiled-schema query nil context)
+       simplify)))
+
+(deftest timings-are-off-by-default
+  (is (= {:data {:root {:simple "fast!"
+                        :slow {:simple "slow!!"}}}}
+         (q "{ root(delay: 50) { simple slow { simple }}}"))))
+
+(deftest timing-is-collected-when-enabled
+  (let [result (q "{ root(delay: 50) { simple slow { simple }}}" enable-timing)]
+    (is (-> result :extensions :timing empty? not)
+        "Some timings were collected.")))
+
+(deftest does-not-collect-timing-for-default-resolvers
+  (let [result (q "{ root(delay: 50) { simple slow { simple }}}" enable-timing)]
+    (is (= nil (-> result :extensions :timing :root :simple))
+        "Some timings were collected.")))
+
+(deftest collects-timing-for-provided-resolvers
+  (doseq [delay [25 50 75]
+          :let [result (q (str "{ root(delay: " delay ") { slow { simple }}}") enable-timing)
+                timings (get-in result [:extensions :timing :root :slow :execution/timings])
+                elapsed-time (-> timings first :elapsed)]]
+    ;; Allow for a bit of overhead; Thread/sleep is quite inexact.
+    (is (<= delay elapsed-time (+ delay 10)))
+    ;; Check that :start and :finish are both present and add up
+    (is (= elapsed-time
+           (- (-> timings first :finish)
+              (-> timings first :start))))))
+
+(deftest collects-timing-for-each-execution
+  (let [result (q "{ hare: root(delay: 5) { slow { simple }}
+                     tortoise: root(delay: 50) { slow { simple }}
+                   }"
+                  enable-timing)
+        elapsed-times (->> (get-in result [:extensions :timing :root :slow :execution/timings])
+                           (mapv :elapsed))]
+    (is (= 2 (count elapsed-times)))
+    (is (<= 5 (elapsed-times 0) 15))
+    (is (<= 50 (elapsed-times 1) 60))))
+

--- a/src/com/walmartlabs/lacinia/timings_test.clj
+++ b/src/com/walmartlabs/lacinia/timings_test.clj
@@ -55,13 +55,13 @@
 
 (deftest does-not-collect-timing-for-default-resolvers
   (let [result (q "{ root(delay: 50) { simple slow { simple }}}" enable-timing)]
-    (is (= nil (-> result :extensions :timing :root :simple))
+    (is (= nil (-> result :extensions :timing :Fast :simple))
         "Some timings were collected.")))
 
 (deftest collects-timing-for-provided-resolvers
   (doseq [delay [25 50 75]
           :let [result (q (str "{ root(delay: " delay ") { slow { simple }}}") enable-timing)
-                timings (get-in result [:extensions :timing :root :slow :execution/timings])
+                timings (get-in result [:extensions :timing :Fast :slow])
                 elapsed-time (-> timings first :elapsed)]]
     ;; Allow for a bit of overhead; Thread/sleep is quite inexact.
     (is (<= delay elapsed-time (+ delay 10)))
@@ -75,7 +75,7 @@
                      tortoise: root(delay: 50) { slow { simple }}
                    }"
                   enable-timing)
-        elapsed-times (->> (get-in result [:extensions :timing :root :slow :execution/timings])
+        elapsed-times (->> (get-in result [:extensions :timing :Fast :slow])
                            (mapv :elapsed))]
     (is (= 2 (count elapsed-times)))
     (is (<= 5 (elapsed-times 0) 15))

--- a/src/com/walmartlabs/lacinia/timings_test.clj
+++ b/src/com/walmartlabs/lacinia/timings_test.clj
@@ -10,7 +10,7 @@
     [com.walmartlabs.lacinia :refer [execute]]
     [com.walmartlabs.lacinia.schema :as schema]))
 
-(def ^:private enable-timing {:com.walmartlabs.lacinia/enable-timing true})
+(def ^:private enable-timing {:com.walmartlabs.lacinia/enable-timing? true})
 
 (defn ^:private resolve-fast
   [_ args _]


### PR DESCRIPTION
This builds on my prior PR, #49, which should be merged first.

This tracks time to resolve values in non-default resolver functions, and exposes it in the :extensions key of the response map.

I'm pretty happy with how this came out; I think that structuring the data in terms of the query tree, rather than the schema, is the right way to go.

*Update:* I'm starting to think that the query tree is not the right way to go, as it effectively prevents you from aggregating timing data between different queries; if the timings were organized instead by object and field, it would be simple to aggregate. Thoughts?
