### PR TITLE
Double exception reporting unknown field argument type

### DIFF
--- a/dev-resources/unknown-argument-type-schema.edn
+++ b/dev-resources/unknown-argument-type-schema.edn
@@ -1,0 +1,6 @@
+{:queries
+ {:example
+  {:type String
+   :args
+   ;; Note: UUID is not declared, but it inside the `list` qualifier:
+   {:id {:type (list UUID)}}}}}

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -676,7 +676,7 @@
                                   (q arg-name)
                                   (q field-name)
                                   (q object-type-name)
-                                  (-> arg-def :type q))
+                                  (q arg-type-name))
                           {:field-name field-name
                            :object-type object-type-name
                            :arg-name arg-name

--- a/test/com/walmartlabs/lacinia/arguments_test.clj
+++ b/test/com/walmartlabs/lacinia/arguments_test.clj
@@ -1,0 +1,29 @@
+(ns com.walmartlabs.lacinia.arguments-test
+  (:require
+    [clojure.test :refer [deftest is]]
+    [clojure.edn :as edn]
+    [com.walmartlabs.lacinia.schema :as schema]
+    [clojure.java.io :as io])
+  (:import (clojure.lang ExceptionInfo)))
+
+
+(deftest reports-unknown-argument-type
+  (when-let [e (is (thrown? ExceptionInfo
+                            (-> "unknown-argument-type-schema.edn"
+                                io/resource
+                                slurp
+                                edn/read-string
+                                schema/compile)))]
+    (is (= "Argument `id' of field `example' in type `QueryRoot' references unknown type `UUID'."
+           (.getMessage e)))
+    (is (= {:arg-name :id
+            :field-name :example
+            :object-type :QueryRoot
+            :schema-types {:object [:MutationRoot
+                                    :QueryRoot]
+                           :scalar [:Boolean
+                                    :Float
+                                    :ID
+                                    :Int
+                                    :String]}}
+           (ex-data e)))))


### PR DESCRIPTION
When the argument to a field is of an unknown type, a schema compilation exception is thrown.

However, creating the message for that exception throws a new exception, in certain circumstances.

This was due to the type system changes; I've checked for other incorrect uses of the :type keyword,
and the rest look to be legit.