### PR TITLE
Add an API for identifying operations in the query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ The decorator is a callback applied to all non-default field resolvers.
 The primary use case is to adapt the return value of a field resolver,
 for example, from a core.async channel to a Lacinia ResolverResult.
 
+New function: `com.walmartlabs.lacinia.parser/operations`: extracts
+from a parsed query the type (mutation or query) and the set of
+operations.
+
 ## 0.16.0 -- 3 May 2017
 
 The function `com.walmartlabs.lacinia.schema/as-conformer` is now public.

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -1160,7 +1160,9 @@
   "Given a previously parsed query, this returns a map of two keys:
 
   :type
-  : Either :query or :mutation.
+  : The type of request: currently, either :query or :mutation, but
+    other values (such as :subscription) could concievably be added
+    in the future.
 
   :operations
   : The names of the top-level operations, as set of keywords."

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -1155,3 +1155,19 @@
                (throw (ex-info "Failed to parse GraphQL query."
                                {:errors failures})))))]
      (xform-query schema antlr-tree operation-name))))
+
+(defn operations
+  "Given a previously parsed query, this returns a map of two keys:
+
+  :type
+  : Either :query or :mutation.
+
+  :operations
+  : The names of the top-level operations, as set of keywords."
+  {:added "0.17.0"}
+  [parsed-query]
+  (let [{:keys [mutation? selections]} parsed-query]
+    {:type (if mutation? :mutation :query)
+     :operations (->> selections
+                      (map (comp :field-name :field-definition))
+                      set)}))

--- a/test/com/walmartlabs/lacinia/parser_test.clj
+++ b/test/com/walmartlabs/lacinia/parser_test.clj
@@ -1,0 +1,35 @@
+(ns com.walmartlabs.lacinia.parser-test
+  (:require
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.test-schema :refer [test-schema]]
+    [com.walmartlabs.lacinia.schema :as schema]
+    [com.walmartlabs.lacinia.parser :as parser]))
+
+(def ^:private compiled-schema
+  (schema/compile test-schema {:default-field-resolver schema/hyphenating-default-field-resolver}))
+
+(defn ^:private ops
+  [query]
+  (->> query
+       (parser/parse-query compiled-schema)
+       (parser/operations)))
+
+(deftest single-query
+  (is (= {:operations #{:hero}
+          :type :query}
+         (ops "{ hero { name }}"))))
+
+(deftest multiple-operations
+  (is (= {:operations #{:hero
+                        :human}
+          :type :query}
+         (ops "{ luke: hero { name }
+                 leia: human { name }}"))))
+
+(deftest mutations
+  (is (= {:operations #{:changeHeroHomePlanet}
+          :type :mutation}
+         (ops "mutation { changeHeroHomePlanet(id: \"1234\", newHomePlanet: \"Gallifrey\") {
+               name
+             }
+           }"))))


### PR DESCRIPTION
Fixed #64

This is a quicky; it extracts the root fields and type of query (query or mutation) from the parsed query.

Perhaps in the future, there will be subscriptions as well, so it isn't just a boolean for mutation?.