### PR TITLE
Allow field resolvers to identify nested fields in the selection tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,12 @@ The decorator is a callback applied to all non-default field resolvers.
 The primary use case is to adapt the return value of a field resolver,
 for example, from a core.async channel to a Lacinia ResolverResult.
 
+New functions `com.walmartlabs.lacinia.executor/selects-field` and
+`selections-seq` allow a field resolver to determine what fields will be
+accessed in the selection tree.
+This allows field resolvers to optimize data they may fetch from an
+external resource.
+
 ## 0.16.0 -- 3 May 2017
 
 The function `com.walmartlabs.lacinia.schema/as-conformer` is now public.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,7 @@ New function: `com.walmartlabs.lacinia.parser/operations`: extracts
 from a parsed query the type (mutation or query) and the set of
 operations.
 
-Several new functions were added to `com.walmartlabs.lacinia.executor` to
+Several new *experimental* functions were added to `com.walmartlabs.lacinia.executor` to
 expose details about the selections tree; this functions can be invoked
 from a field resolver to preview what fields will be selected below
 the field.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,15 +19,14 @@ The decorator is a callback applied to all non-default field resolvers.
 The primary use case is to adapt the return value of a field resolver,
 for example, from a core.async channel to a Lacinia ResolverResult.
 
-New functions `com.walmartlabs.lacinia.executor/selects-field?` and
-`selections-seq` allow a field resolver to determine what fields will be
-accessed in the selection tree.
-This allows field resolvers to optimize data they may fetch from an
-external resource.
-
 New function: `com.walmartlabs.lacinia.parser/operations`: extracts
 from a parsed query the type (mutation or query) and the set of
 operations.
+
+Several new functions were added to `com.walmartlabs.lacinia.executor` to
+expose details about the selections tree; this functions can be invoked
+from a field resolver to preview what fields will be selected below
+the field.
 
 ## 0.16.0 -- 3 May 2017
 

--- a/dev-resources/com/walmartlabs/test_utils.clj
+++ b/dev-resources/com/walmartlabs/test_utils.clj
@@ -7,7 +7,8 @@
     [clojure.edn :as edn]
     [com.walmartlabs.lacinia :as lacinia]
     [com.walmartlabs.lacinia.util :as util]
-    [com.walmartlabs.lacinia.schema :as schema])
+    [com.walmartlabs.lacinia.schema :as schema]
+    [com.walmartlabs.test-schema :refer [test-schema]])
   (:import
     (clojure.lang IPersistentMap)))
 
@@ -82,3 +83,7 @@
     (execute compiled-schema query nil nil))
   ([compiled-schema query vars context]
     (simplify (lacinia/execute compiled-schema query vars context))))
+
+
+(def default-schema
+  (schema/compile test-schema {:default-field-resolver schema/hyphenating-default-field-resolver}))

--- a/dev-resources/selections-schema.edn
+++ b/dev-resources/selections-schema.edn
@@ -1,5 +1,5 @@
 {:objects
- {:root
+ {:Root
   {:fields
    {:tree {:type String}
     :detail {:type String
@@ -7,5 +7,5 @@
              {:int_arg {:type Int}
               :string_arg {:type String}}}}}}
  :queries
- {:get_root {:type :root
+ {:get_root {:type :Root
              :resolve :root-resolve}}}

--- a/dev-resources/selections-schema.edn
+++ b/dev-resources/selections-schema.edn
@@ -1,0 +1,11 @@
+{:objects
+ {:root
+  {:fields
+   {:tree {:type String}
+    :detail {:type String
+             :args
+             {:int_arg {:type Int}
+              :string_arg {:type String}}}}}}
+ :queries
+ {:get_root {:type :root
+             :resolve :root-resolve}}}

--- a/dev-resources/user.clj
+++ b/dev-resources/user.clj
@@ -1,12 +1,3 @@
 (ns user
   (:require [criterium.core :as c]
-            [com.walmartlabs.lacinia :as g]
-            [org.example.schema :refer [star-wars-schema]]))
-
-(def schema (star-wars-schema))
-
-(defn q
-  ([query]
-    (q query nil))
-  ([query vars]
-   (g/execute schema query vars nil)))
+            [com.walmartlabs.lacinia :as l]))

--- a/docs/_examples/selections-tree.edn
+++ b/docs/_examples/selections-tree.edn
@@ -1,0 +1,4 @@
+{:character/friends {:selections
+                     {:character/name nil}}
+ :human/home_planet nil
+ :character/name nil}

--- a/docs/_examples/selects-field.edn
+++ b/docs/_examples/selects-field.edn
@@ -1,0 +1,9 @@
+
+(require
+  '[com.walmartlabs.lacinia.executor :as executor])
+
+(defn resolve-hero
+  [context args _]
+  (if (executor/selects-field? context :character/friends)
+    (fetch-hero-with-friends args)
+    (fetch-hero args)))

--- a/docs/resolve/index.rst
+++ b/docs/resolve/index.rst
@@ -25,6 +25,7 @@ In some cases, a field resolver may need to perform additional queries against a
     attach
     resolve-as
     async
+    selections
     decorator
     timing
     examples

--- a/docs/resolve/overview.rst
+++ b/docs/resolve/overview.rst
@@ -54,22 +54,7 @@ It allows some global state to be passed down into field resolvers; the
 context is initially provided to ``com.walmartlabs.lacinia/execute``.
 The initial application context may even be nil.
 
-Before invoking a field resolver, the context is extended with an additional key:
-
-``:com.walmartlabs.lacinia/selection``
-    The field selection from the parsed GraphQL query.
-
-The field selection can be used to optimize what data is needed from an external store; in SQL terms,
-knowing what data the client needs means that unnecessary table joins can be avoided, or the
-queries otherwise optimized.
-
-.. warning::
-
-    An example of this is forthcoming.
-
-    A forthcoming API will allow the field selection to be queried for relevant data.
-
-Many resolvers can ignore the context.
+Many resolvers can simply ignore the context.
 
 Field Arguments
 ```````````````
@@ -113,6 +98,9 @@ of the resolved value.
 When the ``:resolve`` key for a field is not specified, a default resolver
 is provided automatically; this default resolver simply expects the resolved value to be a map
 containing a key that exactly matches the field name.
+
+It is even possible to customize this default field resolver, as an option passed to
+`com.walmartlabs.lacina.schema/compile`.
  
 Nested Fields
 -------------

--- a/docs/resolve/selections.rst
+++ b/docs/resolve/selections.rst
@@ -92,6 +92,10 @@ The response then constructs up bottom to top.
 Previewing Selections
 ---------------------
 
+.. warning::
+
+   This functionality is new and somewhat experimental, and so subject to change. Feedback is encouraged!
+
 A field resolver can "preview" what fields will be selected below it in the selections tree.
 This is a tool frequently used to optimize data retrieval operations.
 

--- a/docs/resolve/selections.rst
+++ b/docs/resolve/selections.rst
@@ -60,6 +60,7 @@ The query can be visualized as a tree of selections:
       sname [label="name"]
       shriends [label="friends"]
       shappears_in [label="appears_in"]
+      shname[label="name"]
       splanet [label="home_planet"]
 
       sqr -> shero

--- a/docs/resolve/selections.rst
+++ b/docs/resolve/selections.rst
@@ -1,0 +1,120 @@
+Nested Selections
+=================
+
+To review: executing a GraphQL query is highly recursive, where a field resolver will be responsible for
+obtaining data from an external resource or data store, and nested fields will refine the root data
+and make selections.
+
+Consider a simple GraphQL query::
+
+   {
+     hero
+     {
+       name
+       friends { name }
+       ... on human {
+         home_planet
+       }
+     }
+   }
+
+The query can be visualized as a tree of selections:
+
+.. graphviz::
+
+   digraph {
+
+
+    subgraph cluster_query {
+
+      label="Selections"
+
+      hero
+      name
+      friends
+      fname [label="name"]
+      humanfrag[label="... on human"]
+      planet[label="home_planet"]
+
+      hero -> {name; humanfrag, friends}
+      friends -> fname
+      humanfrag -> planet
+    }
+
+    subgraph cluster_schema {
+
+      label="Schema"
+
+      node[shape=rectangle]
+      sqr [label="QueryRoot"]
+      shuman [label="human"]
+
+      schar [label="character"]
+
+      node[shape=ellipse]
+      shero [label="hero"]
+
+      sfriends [label="friends"]
+      sappears_in [label="appears_in"]
+
+      sname [label="name"]
+      shriends [label="friends"]
+      shappears_in [label="appears_in"]
+      splanet [label="home_planet"]
+
+      sqr -> shero
+      schar -> { sname, sfriends, sappears_in}
+      shuman -> { shname, shriends, shappears_in, splanet }
+
+    }
+
+      edge[style=dashed]
+
+      name -> sname
+      hero -> shero
+      planet -> splanet
+      friends -> sfriends
+      fname -> sname
+
+   }
+
+Nodes in the selections tree relate to fields in the schema.
+Remember that the type of query ``hero`` is the interface type ``character`` (and so can be either a ``human``
+or a ``droid``).
+
+In execution order, resolution occurs top to bottom, so the ``hero`` selection occurs
+first, then (potentially :doc:`in parallel <async>`) ``friends``, ``home_planet``, and (hero) ``name``.
+These last two are leaf nodes, because they are scalar values.
+The list of ``characters`` (from the ``friends`` field) then has its ``name`` field selected.
+The response then constructs up bottom to top.
+
+Optimizing
+----------
+
+A field resolver can "preview" what fields will be selected below it in the selections tree.
+
+As an example, lets assume a starting configuration where the ``hero`` field resolver fetches just the
+basic data for a hero (``id``, ``name``, ``home_planet``, etc.) and the
+``friends`` resolver does a second query against the database to fetch the list of friends.
+
+That's two database queries. Perhaps we can simplify by getting rid of the
+``friends`` resolver, and doing a join to fetch the hero and friends at the same time.
+The ``hero`` resolver can just make sure there's a ``:friends`` key in the map, and
+the default field resolver for the ``friends`` field will access it.
+
+That's simpler, but costly when ``friends`` is not part of the query.
+
+The function ``com.walmartlabs.lacinia.executor/selects-field?`` can help here:
+
+.. literalinclude:: ../_examples/selects-field.edn
+   :language: clojure
+
+Here, inside the application context (provided to the ``resolve-hero`` function)
+is information about the selections, and ``selects-field?``
+can determine if a particular field appears `anywhere` below ``hero`` in the selection tree.
+
+``selects-field?`` identifies fields even inside nested or named fragments,
+``(executor/selects-field? context :human/home_planet)`` would return true.
+
+
+

--- a/docs/resolve/selections.rst
+++ b/docs/resolve/selections.rst
@@ -89,18 +89,19 @@ These last two are leaf nodes, because they are scalar values.
 The list of ``characters`` (from the ``friends`` field) then has its ``name`` field selected.
 The response then constructs up bottom to top.
 
-Optimizing
-----------
+Previewing Selections
+---------------------
 
 A field resolver can "preview" what fields will be selected below it in the selections tree.
+This is a tool frequently used to optimize data retrieval operations.
 
 As an example, lets assume a starting configuration where the ``hero`` field resolver fetches just the
 basic data for a hero (``id``, ``name``, ``home_planet``, etc.) and the
 ``friends`` resolver does a second query against the database to fetch the list of friends.
 
-That's two database queries. Perhaps we can simplify by getting rid of the
+That's two database queries. Perhaps we can optimize things by getting rid of the
 ``friends`` resolver, and doing a join to fetch the hero and friends at the same time.
-The ``hero`` resolver can just make sure there's a ``:friends`` key in the map, and
+The ``hero`` resolver can just ensures there's a ``:friends`` key in the map (with the fetched friend values), and
 the default field resolver for the ``friends`` field will access it.
 
 That's simpler, but costly when ``friends`` is not part of the query.
@@ -117,5 +118,26 @@ can determine if a particular field appears `anywhere` below ``hero`` in the sel
 ``selects-field?`` identifies fields even inside nested or named fragments,
 ``(executor/selects-field? context :human/home_planet)`` would return true.
 
+It is also possible to get `all` the fields that will be selected, using ``selections-seq``.
+This a lazy, breadth-first navigation of all fields in the selection tree.
+
+In the sequence of field names, any fragments are collapsed into their containing fields.
+
+This level of detail may be insufficient, in which case the function ``selections-tree``
+can be used.
+
+This function builds a recursive structure that identifies the entire tree structure.
+For the above query, it would return the following structure:
+
+.. literalinclude:: ../_examples/selections-tree.edn
+   :language: clojure
+
+This shows, for example, that ``:character/name`` is used in two different ways (inside the
+``hero`` query itself, and within the ``friends`` field).
+
+For fields with arguments, an ``:args`` key is present, with the exact values which will be
+supplied to the the nested field's resolver.
+
+Fields with neither arguments nor sub-selections are represented as nil.
 
 

--- a/src/com/walmartlabs/lacinia/constants.clj
+++ b/src/com/walmartlabs/lacinia/constants.clj
@@ -16,3 +16,7 @@
 (def parsed-query-key
   "Context key storing the parsed and prepared query."
   ::parsed-query)
+
+(def ^{:added "0.17.0"} selection-key
+  "Context key storing the current selection."
+  :com.walmartlabs.lacinia/selection)

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -7,7 +7,8 @@
     [com.walmartlabs.lacinia.schema :as schema]
     [com.walmartlabs.lacinia.resolve :as resolve
      :refer [resolve-as]]
-    [com.walmartlabs.lacinia.constants :as constants]))
+    [com.walmartlabs.lacinia.constants :as constants])
+  (:import (clojure.lang PersistentQueue)))
 
 (defn ^:private ex-info-map
   ([field-selection]
@@ -108,7 +109,7 @@
         resolved-type (:resolved-type execution-context)
         resolve-context (assoc context
                                :com.walmartlabs.lacinia/container-type-name resolved-type
-                               :com.walmartlabs.lacinia/selection field-selection)
+                               constants/selection-key field-selection)
         field-resolver (field-selection-resolver schema field-selection resolved-type container-value)
         start-ms (when (and (some? timings)
                             (not (-> field-resolver meta ::schema/default-resolver?)))
@@ -432,3 +433,48 @@
                                                  timings (assoc-in [:extensions :timing] @timings)
                                                  (seq @errors) (assoc :errors (distinct @errors)))))))
     response-result))
+
+(defn ^:private node-selections
+  [parsed-query node]
+  (case (:selection-type node)
+
+    (:field :inline-fragment) (:selections node)
+
+    :fragment-spread
+    (let [{:keys [fragment-name]} node]
+      (get-in parsed-query [:fragments fragment-name :selections]))))
+
+(defn selections-seq
+  "A width-first traversal of selections tree, returning a lazy sequence
+  of qualified field names.  A qualified field name is a namespaced keyword,
+  the namespace is the containing type, e.g. :User/name."
+  {:added "0.17.0"}
+  [context]
+  (let [parsed-query (get context constants/parsed-query-key)
+        selection (get context constants/selection-key)
+        step (fn step [queue]
+               (when (seq queue)
+                 (let [node (peek queue)]
+                   (cons node
+                         (step (into (pop queue)
+                                     (node-selections parsed-query node)))))))
+        to-field-name (fn [node]
+                        (let [field-def (:field-definition node)]
+                          (keyword
+                            (-> field-def :type-name name)
+                            (-> field-def :field-name name))))]
+    (->> (conj PersistentQueue/EMPTY selection)
+         step
+         ;; remove the first node (the selection); just interested
+         ;; in what's beneath the selection
+         next
+         (filter #(= :field (:selection-type %)))
+         (map to-field-name))))
+
+(defn selects-field?
+  "Invoked by a field resolver to determine if a particular field is selected anywhere within the selection
+   tree (that is, at any depth)."
+  {:added "0.17.0"}
+  [context field-name]
+  (boolean (some #(= field-name %) (selections-seq context))))
+

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -533,13 +533,15 @@
   (let [provided-resolver (:resolve field)
         {:keys [default-field-resolver decorator]} options
         field-name (:field-name field)
+        type-name (:type-name containing-type)
         base-resolver (if provided-resolver
-                        (decorator (:type-name containing-type) field-name provided-resolver)
+                        (decorator type-name field-name provided-resolver)
                         (default-field-resolver field-name))
         selector (assemble-selector schema containing-type field (:type field))
         wrapped-resolver (cond-> (wrap-resolver-to-ensure-resolver-result base-resolver)
                            (nil? provided-resolver) (vary-meta assoc ::default-resolver? true))]
     (assoc field
+           :type-name type-name
            :resolve wrapped-resolver
            :selector selector)))
 
@@ -751,9 +753,11 @@
                        implementors (->> objects
                                          (filter #(-> % :implements interface-name))
                                          (map :type-name)
-                                         set)]
+                                         set)
+                       fields' (map-vals #(assoc % :type-name interface-name)
+                                         (:fields interface))]
                    (-> interface
-                       (assoc :members implementors)
+                       (assoc :members implementors :fields fields')
                        (dissoc :resolve)))))))
 
 (defn ^:private prepare-and-validate-object

--- a/test/com/walmartlabs/lacinia/selections_tests.clj
+++ b/test/com/walmartlabs/lacinia/selections_tests.clj
@@ -1,0 +1,83 @@
+(ns com.walmartlabs.lacinia.selections-tests
+  (:require
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.lacinia.parser :as parser]
+    [com.walmartlabs.lacinia.executor :as executor]
+    [com.walmartlabs.test-utils :refer [default-schema]]
+    [com.walmartlabs.lacinia.constants :as constants]))
+
+(defn ^:private app-context
+  [query]
+  (let [parsed-query (parser/parse-query default-schema query)]
+    {constants/parsed-query-key parsed-query
+     constants/selection-key (-> parsed-query :selections first)}))
+
+
+(defn ^:private root-selections
+  [query]
+  (-> query
+      app-context
+      executor/selections-seq))
+
+(deftest simple-cases
+  (is (= [:character/name]
+         (root-selections "{ hero { name }}")))
+
+  (is (= [:human/name :human/homePlanet]
+         (root-selections "{ human { name homePlanet }}")))
+
+  (is (= [:human/name :human/friends :human/enemies
+          :character/name                                   ; friends
+          :character/appears_in
+          :character/name]                                  ; enemies
+         (root-selections "{ human { name friends { name appears_in } enemies { name }}}"))))
+
+(deftest mutations
+  (is (= [:human/name :human/homePlanet]
+         (root-selections "mutation { changeHeroHomePlanet (id: \"123\",
+            newHomePlanet: \"Venus\") {
+            name homePlanet
+          }
+         }"))))
+
+(deftest inline-fragments
+  (is (= [:character/name
+          :human/homePlanet
+          :droid/primary_function]
+         (root-selections
+           "{
+              hero {
+                name
+
+                ... on human { homePlanet }
+
+                ... on droid { primary_function }
+              }
+            }"))))
+
+(deftest named-fragments
+  (is (= [:character/name
+          :human/homePlanet
+          :droid/primary_function]
+         (root-selections
+           "query {
+              hero {
+                name
+
+                ... ifHuman
+                ... ifDroid
+              }
+            }
+
+            fragment ifHuman on human { homePlanet }
+
+            fragment ifDroid on droid { primary_function }
+            "))))
+
+(deftest is-selected
+  (let [context (app-context "{ human { name homePlanet }}")]
+    (is (executor/selects-field? context
+                                 :human/name))
+    (is (executor/selects-field? context :human/homePlanet))
+
+    (is (not (executor/selects-field? context :character/name)))))

--- a/test/com/walmartlabs/lacinia/selections_tests.clj
+++ b/test/com/walmartlabs/lacinia/selections_tests.clj
@@ -3,8 +3,9 @@
     [clojure.test :refer [deftest is]]
     [com.walmartlabs.lacinia.parser :as parser]
     [com.walmartlabs.lacinia.executor :as executor]
-    [com.walmartlabs.test-utils :refer [default-schema]]
-    [com.walmartlabs.lacinia.constants :as constants]))
+    [com.walmartlabs.test-utils :refer [default-schema compile-schema execute]]
+    [com.walmartlabs.lacinia.constants :as constants]
+    [clojure.edn :as edn]))
 
 (defn ^:private app-context
   [query]
@@ -18,6 +19,12 @@
   (-> query
       app-context
       executor/selections-seq))
+
+(defn ^:private tree
+  [query]
+  (-> query
+      app-context
+      executor/selections-tree))
 
 (deftest simple-cases
   (is (= [:character/name]
@@ -81,3 +88,89 @@
     (is (executor/selects-field? context :human/homePlanet))
 
     (is (not (executor/selects-field? context :character/name)))))
+
+(deftest basic-tree
+  (is (= {:human/name nil}
+         (tree "{ human { name }}")))
+
+  (is (= {:droid/appears_in nil
+          :droid/friends {:selections {:character/name nil}}
+          :droid/name nil}
+         (tree "{ droid { name appears_in friends { name }}}"))))
+
+(deftest inline-fragments-are-flattened-in-tree
+  (is (= {:character/name nil
+          :droid/primary_function nil
+          :human/friends {:selections {:character/name nil}}
+          :human/homePlanet nil}
+         (tree "{
+              hero {
+                name
+
+                ... on human { homePlanet friends { name } }
+
+                ... on droid { primary_function }
+              }
+            }"))))
+
+(deftest named-fragments-are-flattened-in-tree
+  (is (= {:character/name nil
+          :character/friends {:selections {:character/name nil
+                                           :droid/primary_function nil
+                                           :human/homePlanet nil}}}
+         (tree "query {
+              hero {
+              name
+                friends {
+                  name
+
+                  ... ifHuman
+                  ... ifDroid
+                }
+              }
+            }
+
+            fragment ifHuman on human { homePlanet }
+
+            fragment ifDroid on droid { primary_function }
+            "))))
+
+(def ^:private selections-schema
+  (compile-schema "selections-schema.edn"
+                  {:root-resolve
+                   (fn [context _ _]
+                     {:tree (pr-str (executor/selections-tree context))
+                      :detail "<detail>"})}))
+
+(defn ^:private extract-tree
+  [query vars]
+  (-> (execute selections-schema query vars nil)
+      (get-in [:data :root :tree])
+      edn/read-string))
+
+(deftest captures-arguments
+  (is (= {:root/detail {:args {:int_arg 5
+                               :string_arg "frodo"}}
+          :root/tree nil}
+         (extract-tree "{ root: get_root {
+              tree
+              detail(int_arg: 5, string_arg: \"frodo\")
+            }
+          }"
+                       nil))))
+
+(deftest captures-arguments-from-vars
+  ;; Because the tree is prepared, the actual values are visible
+  ;; even for variable-driven fields.
+  (is (= {:root/detail {:args {:int_arg 42
+                               :string_arg "samwise"}}
+          :root/tree nil}
+         (extract-tree "query($int_var: Int, $string_var: String) {
+           root: get_root {
+             tree
+             detail(int_arg: $int_var, string_arg: $string_var)
+           }
+         }"
+                       ;; Should be able to specify the int value as 42, not string
+                       {:int_var "42"                       ; bug!
+                        :string_var "samwise"}))))

--- a/test/com/walmartlabs/lacinia/selections_tests.clj
+++ b/test/com/walmartlabs/lacinia/selections_tests.clj
@@ -149,9 +149,9 @@
       edn/read-string))
 
 (deftest captures-arguments
-  (is (= {:root/detail {:args {:int_arg 5
+  (is (= {:Root/detail {:args {:int_arg 5
                                :string_arg "frodo"}}
-          :root/tree nil}
+          :Root/tree nil}
          (extract-tree "{ root: get_root {
               tree
               detail(int_arg: 5, string_arg: \"frodo\")
@@ -162,9 +162,9 @@
 (deftest captures-arguments-from-vars
   ;; Because the tree is prepared, the actual values are visible
   ;; even for variable-driven fields.
-  (is (= {:root/detail {:args {:int_arg 42
+  (is (= {:Root/detail {:args {:int_arg 42
                                :string_arg "samwise"}}
-          :root/tree nil}
+          :Root/tree nil}
          (extract-tree "query($int_var: Int, $string_var: String) {
            root: get_root {
              tree

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -3,12 +3,9 @@
             [clojure.data.json :as json]
             [com.walmartlabs.lacinia :as lacinia]
             [com.walmartlabs.lacinia.schema :as schema]
-            [com.walmartlabs.test-schema :refer [test-schema]]
-            [com.walmartlabs.test-utils :refer [is-thrown instrument-schema-namespace simplify]]))
+            [com.walmartlabs.test-utils :refer [is-thrown instrument-schema-namespace simplify default-schema]]))
 
 (instrument-schema-namespace)
-
-(def default-schema (schema/compile test-schema {:default-field-resolver schema/hyphenating-default-field-resolver}))
 
 (defn execute
   "Executes the query but reduces ordered maps to normal maps, which makes


### PR DESCRIPTION
Fixes #65 

We've been doing this in our apps by pulling apart the selections context key, even though its structure is explicitly private and subject to change. This provides the missing API needed to determine whether a field is present.