### PR TITLE
Use metadata again, when possible, for type tagging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## 0.18.0 -- UNRELEASED
 
+`com.walmartlabs.lacinia.schema/tag-with-type` now uses metadata in the majority of cases
+(as it did in 0.16.0), resorting to a wrapper type only when
+the value is a Java object that doesn't support metadata.
+
 ## 0.17.0 -- 22 May 2017
 
 Lacinia now better implements the specification, in terms of parsing

--- a/dev-resources/fixes-types-schema.edn
+++ b/dev-resources/fixes-types-schema.edn
@@ -1,0 +1,34 @@
+{:unions
+ {:Characters
+  {:members [:Human :Droid]}}
+ :objects
+ {:Human
+  {:fields
+   {:first_name {:type String
+                 :resolve [:prop :firstName]}
+    :last_name {:type String
+                :resolve [:prop :lastName]}}}
+
+  :Droid
+  {:fields
+   {:designation {:type String
+                  :resolve [:prop :designation]}
+    :function {:type String
+               :resolve [:prop :function]}}}}
+
+ :queries
+ {:human
+  {:type :Human
+   :resolve :resolve-human}
+
+  :droid
+  {:type :Droid
+   :resolve :resolve-droid}
+
+  :astromech
+  {:type :Droid
+   :resolve :resolve-astromech}
+
+  :characters
+  {:type (list :Characters)
+   :resolve :resolve-characters}}}

--- a/docs/resolve/index.rst
+++ b/docs/resolve/index.rst
@@ -23,6 +23,7 @@ In some cases, a field resolver may need to perform additional queries against a
 
     overview
     attach
+    type-tags
     resolve-as
     async
     selections

--- a/docs/resolve/overview.rst
+++ b/docs/resolve/overview.rst
@@ -110,27 +110,8 @@ In each case, the container's resolved value is passed to the nested field so th
 nested resolved value.
 This continues as deeply as the query specifies.
 
-Explicit Types
---------------
-
-For structured types, Lacinia needs to know what type of data is returned by the field resolver,
-so that it can, as necessary, process query fragments.
-
-When the type of field is a concrete object type, Lacinia automatically tags the value with
-the schema type.
-
-When the type of a field is an interface or union, it is necessary for the field resolver
-to explicitly tag the value with its object type.
-The function ``com.walmartlabs.lacinia.schema/tag-with-type`` exists for this purpose.
-The tag value is a keyword matching an object definition.
-
-When a field returns a list of an interface, or a list of a union,
-then each individual resolved value must be tagged with its concrete type.
-It is allowed and expected that different values in the collection will have
-different concrete types.
-
-When a field resolver is invoked, the context value for key ``:com.walmartlabs.lacinia/container-type-name``
-will be the name of the concrete type (a keyword) for the resolved value.
+It is possible to :doc:`preview nested selections <selections>` in a field resolver, which can enable
+some important optimizations.
 
 .. [#root-value] Or, in practice, a sequence of maps.
    In theory, an operation type could be a scalar, but use cases for this are rare.

--- a/docs/resolve/type-tags.rst
+++ b/docs/resolve/type-tags.rst
@@ -1,0 +1,26 @@
+Explicit Types
+--------------
+
+For structured types, Lacinia needs to know what type of data is returned by the field resolver,
+so that it can, as necessary, process query fragments.
+
+When the type of field is a concrete object type, Lacinia automatically tags the value with
+the schema type.
+
+When the type of a field is an interface or union, it is necessary for the field resolver
+to explicitly tag the value with its object type.
+The function ``com.walmartlabs.lacinia.schema/tag-with-type`` exists for this purpose.
+The tag value is a keyword matching an object definition.
+
+When a field returns a list of an interface, or a list of a union,
+then each individual resolved value must be tagged with its concrete type.
+It is allowed and expected that different values in the collection will have
+different concrete types.
+
+When a field resolver is invoked, the context value for key ``:com.walmartlabs.lacinia/container-type-name``
+will be the name of the concrete type (a keyword) for the resolved value.
+
+Generally, type tagging is just metadata added to a map (or Clojure record type).
+However, Lacinia supports tagging of arbitrary objects that don't support Clojure metadata
+... but ``tag-with-type`` will return a wrapper type in that case.  When using Java types,
+make sure that ``tag-with-type`` is the last thing a field resolver does.

--- a/test/com/walmartlabs/lacinia/fixed_types_test.clj
+++ b/test/com/walmartlabs/lacinia/fixed_types_test.clj
@@ -1,0 +1,77 @@
+(ns com.walmartlabs.lacinia.fixed-types-test
+  "In most cases, field resolvers return maps, but there's also support for returning fixed Java types that don't
+  support metadata."
+  (:require
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.lacinia.schema :refer [tag-with-type]]
+    [com.walmartlabs.test-utils :refer [compile-schema execute]]))
+
+(defprotocol Human
+  (^String getFirstName [this])
+  (^String getLastName [this]))
+
+(defprotocol Droid
+  (^String getDesignation [this])
+  (^String getFunction [this]))
+
+(deftype HumanImpl [first-name last-name]
+
+  Human
+  (getFirstName [_] first-name)
+  (getLastName [_] last-name))
+
+(deftype DroidImpl [designation function]
+
+  Droid
+  (getDesignation [_] designation)
+  (getFunction [_] function))
+
+(def ^:private luke (->HumanImpl "Luke" "Skywalker"))
+(def ^:private c3p0 (->DroidImpl "C3P0" "protocol"))
+;; This executes some logic for redundant tagging: Sidekick gets replaced
+;; with the proper value, :Droid.
+(def ^:private r2d2 (tag-with-type (->DroidImpl "R2D2" "astromech") :Sidekick))
+
+(defn ^:private prop-resolver
+  [prop-name]
+  (fn [_ _ value]
+    ;; This is a very inefficient way to do this, suitable just for
+    ;; testing!
+    (-> value bean (get prop-name))))
+
+(def ^:private schema
+  (compile-schema "fixes-types-schema.edn"
+                  {:prop prop-resolver
+                   :resolve-human (constantly luke)
+                   :resolve-droid (constantly c3p0)
+                   :resolve-astromech (constantly r2d2)
+                   :resolve-characters (constantly
+                                         [(tag-with-type luke :Human)
+                                          (tag-with-type c3p0 :Droid)])}))
+
+(deftest tag-not-needed
+  (is (= {:data {:c3p0 {:designation "C3P0"
+                        :function "protocol"}
+                 :r2d2 {:designation "R2D2"
+                        :function "astromech"}
+                 :luke {:first_name "Luke"
+                        :last_name "Skywalker"}}}
+         (execute schema "
+{
+  luke: human { first_name last_name }
+  c3p0: droid { designation function }
+  r2d2: astromech { designation function }
+}"))))
+
+(deftest tag-needed-inside-union
+  (is (= {:data {:characters [{:first_name "Luke"}
+                              {:designation "C3P0"}]}}
+         (execute schema "
+{
+  characters {
+    ... on Human { first_name }
+    ... on Droid { designation }
+  }
+}"))))
+
+


### PR DESCRIPTION
This restores the simpler behavior from 0.16.0 (it uses metadata nearly all the time), but still supports Java objects as resolved values (which apparently is really needed when using Datomic's API).

Fixes #74 