### PR TITLE
Fix NullPointerException in Selections API

### DIFF
--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -488,12 +488,14 @@
             (case (:selection-type selection)
 
               :field
-              (assoc m (to-field-name selection)
-                     (let [arguments (:arguments selection)
-                           nested-map (build-selections-map parsed-query (:selections selection))]
-                       (cond-> nil
-                         (not (empty? arguments)) (assoc :args arguments)
-                         (not (empty? nested-map)) (assoc :selections nested-map))))
+              (if-some [field-name (to-field-name selection)]
+                (assoc m field-name
+                       (let [arguments (:arguments selection)
+                             nested-map (build-selections-map parsed-query (:selections selection))]
+                         (cond-> nil
+                           (not (empty? arguments)) (assoc :args arguments)
+                           (not (empty? nested-map)) (assoc :selections nested-map))))
+                m)
 
               :inline-fragment
               (merge m (build-selections-map parsed-query (:selections selection)))

--- a/test/com/walmartlabs/lacinia/selections_tests.clj
+++ b/test/com/walmartlabs/lacinia/selections_tests.clj
@@ -39,6 +39,14 @@
           :character/name]                                  ; enemies
          (root-selections "{ human { name friends { name appears_in } enemies { name }}}"))))
 
+(deftest introspection-cases
+  (is (= []
+         (root-selections "{ hero { __typename }}")))
+  (is (= [:character/name]
+         (root-selections "{ hero { name __typename }}")))
+  (is (= {:character/name nil}
+         (tree "{ hero { name __typename }}"))))
+
 (deftest mutations
   (is (= [:human/name :human/homePlanet]
          (root-selections "mutation { changeHeroHomePlanet (id: \"123\",


### PR DESCRIPTION
Queries that include introspective fields like `__typeName` are currently throwing NullPointerExceptions when using the selections API because they don't have `type-name` or `field-name`.

It's difficult to establish what the type-name or field-name should be for these meta style fields (moreso the type-name), so let's just guard against nils in the selections API for now.