### PR TITLE
Add CircleCI 2.0 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+
+jobs:
+  test:
+    docker:
+      - image: clojure:lein-2.7.1
+    working_directory: /root/lacinia
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - &cache_key v1-dependency-jars-{{ checksum "project.clj" }}
+            - v1-dependency-jars
+      - run:
+          command: lein deps
+      - save_cache:
+          key: *cache_key
+          paths:
+            - /root/.m2
+      - run:
+          command: lein test2junit
+      - store_test_results:
+          path: /root/lacinia/target/test2junit
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-test:
-  override:
-    - lein test2junit


### PR DESCRIPTION
This config enables the use of CircleCI 2.0, which grants an increase in reliability and a decrease in build time from 2 minutes+ to about 12 seconds.