### PR TITLE
Ensure that every query and mutation has a resolver function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,9 +17,8 @@ changed to only accept a single value.
 Previously, the callback received a resolved value and an nilable error map.
 This method is not intended for use in application code.
 
-The `com.walmartlabs.lacinia.schema/compile` function is now *always* instrumented
-and check enabled. This means that non-conforming schemas will fail with
-a spec verification exception.
+The `com.walmartlabs.lacinia.schema/compile` function is now *always* instrumented.
+This means that non-conforming schemas will fail with a spec verification exception.
 
 ## 0.18.0 -- 19 June 2017
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ changed to only accept a single value.
 Previously, the callback received a resolved value and an nilable error map.
 This method is not intended for use in application code.
 
+The `com.walmartlabs.lacinia.schema/compile` function is now *always* instrumented
+and check enabled. This means that non-conforming schemas will fail with
+a spec verification exception.
+
 ## 0.18.0 -- 19 June 2017
 
 `com.walmartlabs.lacinia.schema/tag-with-type` now uses metadata in the majority of cases

--- a/dev-resources/com/walmartlabs/test_utils.clj
+++ b/dev-resources/com/walmartlabs/test_utils.clj
@@ -1,7 +1,6 @@
 (ns com.walmartlabs.test-utils
   (:require
     [clojure.test :refer [is]]
-    [clojure.spec.test.alpha :as stest]
     [clojure.walk :as walk]
     [clojure.java.io :as io]
     [clojure.edn :as edn]
@@ -42,12 +41,6 @@
   `(let [~sym (is (~'thrown? Throwable ~exp))]
      (when (instance? Throwable ~sym)
        ~@body)))
-
-(defn instrument-schema-namespace
-  []
-  (-> (stest/enumerate-namespace 'com.walmartlabs.lacinia.schema)
-      stest/instrument
-      stest/check))
 
 (defn simplify
   "Converts all ordered maps nested within the map into standard hash maps, and

--- a/dev-resources/unknown-argument-type-schema.edn
+++ b/dev-resources/unknown-argument-type-schema.edn
@@ -1,6 +1,7 @@
 {:queries
  {:example
   {:type String
+   :resolve :example
    :args
    ;; Note: UUID is not declared, but it inside the `list` qualifier:
    {:id {:type (list UUID)}}}}}

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -974,16 +974,10 @@
 
 (defn ^:private verify-every-field-has-resolve-fn
   [category fields]
-  (doseq [[field-name field-def] fields
-          :let [{:keys [resolve]} field-def]]
-    (when (nil? resolve)
+  (doseq [[field-name field-def] fields]
+    (when (-> field-def :resolve nil?)
       (throw (IllegalArgumentException.
                (format "No resolve function provided for %s %s."
-                       (name category)
-                       (q field-name)))))
-    (when-not (fn? resolve)
-      (throw (IllegalArgumentException.
-               (format "Resolve for %s %s is not a function."
                        (name category)
                        (q field-name)))))))
 

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -279,7 +279,7 @@
 (s/def ::arg (s/keys :req-un [::type]
                      :opt-un [::description]))
 (s/def ::args (s/map-of ::schema-key ::arg))
-;; Defining these callback in spec has been a challenge. At some point,
+;; Defining these callbacks in spec has been a challenge. At some point,
 ;; we can expand this to capture a bit more about what a field resolver
 ;; is passed and should return.
 (s/def ::resolve fn?)

--- a/test/com/walmartlabs/introspection_test.clj
+++ b/test/com/walmartlabs/introspection_test.clj
@@ -1276,6 +1276,7 @@
 
 (deftest mixed-use-of-keywords
   (let [schema (schema/compile {:queries {:search {:type '(non-null :ID)
+                                                   :resolve identity
                                                    :args {:term {:type '(non-null String)}}}}})
         q "
         query { __schema { queryType {

--- a/test/com/walmartlabs/lacinia/arguments_test.clj
+++ b/test/com/walmartlabs/lacinia/arguments_test.clj
@@ -1,24 +1,18 @@
 (ns com.walmartlabs.lacinia.arguments-test
   (:require
     [clojure.test :refer [deftest is]]
-    [clojure.edn :as edn]
-    [com.walmartlabs.lacinia.schema :as schema]
-    [clojure.java.io :as io])
+    [com.walmartlabs.test-utils :refer [compile-schema]])
   (:import (clojure.lang ExceptionInfo)))
 
 
 (deftest reports-unknown-argument-type
   (when-let [e (is (thrown? ExceptionInfo
-                            (-> "unknown-argument-type-schema.edn"
-                                io/resource
-                                slurp
-                                edn/read-string
-                                schema/compile)))]
-    (is (= "Argument `id' of field `example' in type `QueryRoot' references unknown type `UUID'."
+                            (compile-schema "unknown-argument-type-schema.edn"
+                                            {:example identity})))]
+    (is (= "Argument `id' of field `QueryRoot/example' references unknown type `UUID'."
            (.getMessage e)))
     (is (= {:arg-name :id
-            :field-name :example
-            :object-type :QueryRoot
+            :field-name :QueryRoot/example
             :schema-types {:object [:MutationRoot
                                     :QueryRoot
                                     :SubscriptionRoot]

--- a/test/com/walmartlabs/lacinia/custom_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/custom_scalars_test.clj
@@ -3,7 +3,7 @@
             [clojure.test :refer [deftest is testing]]
             [com.walmartlabs.lacinia.schema :as schema]
             [com.walmartlabs.test-schema :refer [test-schema]]
-            [com.walmartlabs.test-utils :refer [is-thrown instrument-schema-namespace execute]]
+            [com.walmartlabs.test-utils :refer [is-thrown execute]]
             [clojure.java.io :as io]
             [clojure.edn :as edn]
             [com.walmartlabs.lacinia.util :as util])
@@ -11,8 +11,6 @@
            (java.util Date)
            (org.joda.time DateTime DateTimeConstants)
            (org.joda.time.format DateTimeFormat)))
-
-(instrument-schema-namespace)
 
 (def default-schema (schema/compile test-schema))
 

--- a/test/com/walmartlabs/lacinia/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/schema_test.clj
@@ -4,8 +4,7 @@
     [clojure.test :refer [deftest testing is are try-expr do-report]]
     [clojure.spec.alpha :as s]
     [com.walmartlabs.lacinia.schema :as schema]
-    [com.walmartlabs.test-utils :refer [is-thrown instrument-schema-namespace]])
-  (:import (clojure.lang ExceptionInfo)))
+    [com.walmartlabs.test-utils :refer [is-thrown instrument-schema-namespace]]))
 
 (instrument-schema-namespace)
 
@@ -165,11 +164,4 @@
   (is-compile-exception
     {:mutations {:hopeless {:type :String}}}
     "No resolve function provided for mutation `hopeless'."
-    nil))
-
-(deftest resolve-must-be-a-function
-  (is-compile-exception
-    {:queries {:hopeless {:type :String
-                          :resolve :not-a-function}}}
-    "Resolve for query `hopeless' is not a function."
     nil))

--- a/test/com/walmartlabs/lacinia/subscription_tests.clj
+++ b/test/com/walmartlabs/lacinia/subscription_tests.clj
@@ -9,10 +9,7 @@
     [com.walmartlabs.lacinia.constants :as constants]
     [com.walmartlabs.lacinia.resolve :as resolve]
     [com.walmartlabs.lacinia.schema :as schema]
-    [com.walmartlabs.test-utils :as test-utils
-     :refer [simplify instrument-schema-namespace]]))
-
-(instrument-schema-namespace)
+    [com.walmartlabs.test-utils :as test-utils :refer [simplify]]))
 
 ;; There's not a whole lot we can do here, as most of the support has to come from the web tier code, e.g.,
 ;; pedestal-lacinia.

--- a/test/com/walmartlabs/lacinia/unions_test.clj
+++ b/test/com/walmartlabs/lacinia/unions_test.clj
@@ -5,8 +5,7 @@
     [com.walmartlabs.lacinia.schema :refer [compile tag-with-type]]
     [com.walmartlabs.lacinia :as ql]
     [com.walmartlabs.test-utils :refer [is-thrown]]
-    [com.walmartlabs.test-reporting :refer [report]]
-    [clojure.string :as str]))
+    [com.walmartlabs.test-reporting :refer [report]]))
 
 (def base-schema
   '{:objects {
@@ -19,8 +18,10 @@
     :unions {
              :searchable {:members [:business :employee]}}
     :queries {
-              :businesses {:type (list :business)}
-              :search {:type (list :searchable)}}})
+              :businesses {:type (list :business)
+                           :resolve identity}
+              :search {:type (list :searchable)
+                       :resolve identity}}})
 
 (def example-business {:id "1000"
                        :name "General Products"})

--- a/test/com/walmartlabs/lacinia/unions_test.clj
+++ b/test/com/walmartlabs/lacinia/unions_test.clj
@@ -8,20 +8,26 @@
     [com.walmartlabs.test-reporting :refer [report]]))
 
 (def base-schema
-  '{:objects {
-              :business {:fields {:id {:type ID}
-                                  :name {:type String}}}
-              :employee {:fields {:id {:type ID}
-                                  :employer {:type :business}
-                                  :given_name {:type String}
-                                  :family_name {:type String}}}}
-    :unions {
-             :searchable {:members [:business :employee]}}
-    :queries {
-              :businesses {:type (list :business)
-                           :resolve identity}
-              :search {:type (list :searchable)
-                       :resolve identity}}})
+  {:objects
+   {:business
+    {:fields
+     {:id {:type :ID}
+      :name {:type :String}}}
+    :employee
+    {:fields {:id {:type :ID}
+              :employer {:type :business}
+              :given_name {:type :String}
+              :family_name {:type :String}}}}
+   :unions
+   {:searchable
+    {:members [:business :employee]}}
+   :queries
+   {:businesses
+    {:type '(list :business)
+     :resolve identity}
+    :search
+    {:type '(list :searchable)
+     :resolve identity}}})
 
 (def example-business {:id "1000"
                        :name "General Products"})

--- a/test/com/walmartlabs/lacinia/validator_test.clj
+++ b/test/com/walmartlabs/lacinia/validator_test.clj
@@ -349,16 +349,11 @@
 
 (deftest invalid-type-for-query
   (let [e (is (thrown? Throwable
-                       (schema/compile {:queries {:unknown_type {:type :not_defined}}})))
+                       (schema/compile {:queries {:unknown_type {:type :not_defined
+                                                                 :resolve identity}}})))
         data (ex-data e)]
-    (is (= "Field `unknown_type' in type `QueryRoot' references unknown type `not_defined'." (.getMessage e)))
-    (is (= {:field {:args nil
-                    :qualified-field-name :QueryRoot/unknown_type
-                    :field-name :unknown_type
-                    :type {:kind :root
-                           :type :not_defined}}
-            :field-name :unknown_type
-            :object-type :QueryRoot
+    (is (= "Field `QueryRoot/unknown_type' references unknown type `not_defined'." (.getMessage e)))
+    (is (= {:field-name :QueryRoot/unknown_type
             :schema-types {:object [:MutationRoot
                                     :QueryRoot
                                     :SubscriptionRoot]

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -4,9 +4,7 @@
             [com.walmartlabs.lacinia :as lacinia]
             [com.walmartlabs.lacinia.schema :as schema]
             [com.walmartlabs.test-schema :refer [test-schema]]
-            [com.walmartlabs.test-utils :refer [is-thrown instrument-schema-namespace simplify]]))
-
-(instrument-schema-namespace)
+            [com.walmartlabs.test-utils :refer [is-thrown simplify]]))
 
 (def default-schema
   (schema/compile test-schema {:default-field-resolver schema/hyphenating-default-field-resolver}))


### PR DESCRIPTION
This is something that is hard to catch via spec, and we can't be sure the application is using spec (they should!).

This adds checks that :resolve is present AND a function.

Fixes #90  ... but this builds on PR #90 