### PR TITLE
Use the term 'result map' instead of 'response'

### DIFF
--- a/docs/custom-scalars.rst
+++ b/docs/custom-scalars.rst
@@ -44,7 +44,7 @@ Handling Invalid Values
 Especially when parsing an input string into a value, there can be problems, including invalid user input.
 
 When using ``as-conformer``, any exception thrown by the function will be consumed and converted into ``:clojure.spec/invalid-value``.
-Lacinia will generate a default error message, and an error map will be added to the ``:errors`` response key.
+Lacinia will generate a default error message, and an error map will be added to the ``:errors`` key of the result.
 
 If you want more control, you can use the function ``com.walmartlabs.lacinia.schema/coercion-failure``, which allows you
 to provide a customized message and even additional data for the error map.

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -8,7 +8,7 @@ Queries and mutations are a special kind of field.
 
 **Fields are functions**. Or, more specifically, fields are a kind of operation
 that begins with some data, adds in other details (such as field arguments provided
-in the query), and produces new data that can be incorporated into a response.
+in the query), and produces new data that can be incorporated into the overall result.
 
 Field Definition
 ----------------
@@ -68,7 +68,7 @@ The ``:resolve`` key identifies the field resolver function, used to provide the
 
 This data, the *resolved value*, is never directly returned to the client; this is because
 in GraphQL, the client query identifies which fields from the resolved value are selected
-(and often, renamed) to form the response value.
+(and often, renamed) to form the result value.
 
 ``:resolve`` is optional; when not provided it is assumed that the containing field's
 resolved value is a map containing a key exactly matching the field's name.
@@ -90,7 +90,7 @@ The return value may be a scalar type, or a structured type, as defined by the
 field's ``:type``.
 
 For composite (non-scalar) types, the client query **must** include a nested set of fields
-to be returned in the response.
+to be returned in the result map.
 The query is a tree, and the leaves of that tree will always be simple scalar values.
 
 Arguments

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,7 +84,7 @@ These are attached to the schema after it is read from an EDN file, using
 the placeholder keywords in the schema, such as ``:resolve :droid``.
 
 The client uses the GraphQL query language to specify exactly what data
-should be returned in the response::
+should be returned in the result map::
 
 
    {

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -75,7 +75,7 @@ With that in place, we can now execute queries.
 
 .. sidebar:: Ordered Map?
 
-   The `#ordered/map` indicates that the fields in the response are returned in the
+   The ``#ordered/map`` indicates that the fields in the result map are returned in the
    `same order` [#order]_ as they are specified in the query document.
 
    In most examples, for conciseness, a standard (unordered) map is shown.
@@ -89,7 +89,7 @@ exactly which fields
 of the matching objects are to be returned.
 This query can be stated as `just provide the name of the human with id '1001'`.
 
-This is a successful query, it returns a map with a ``:data`` key.
+This is a successful query, it returns a result map [#result]_ with a ``:data`` key.
 A failed query would return a map with an ``:errors`` key.
 A query can even be partially successful, returning as much data as it can, but also errors.
 
@@ -101,4 +101,8 @@ Since we requested just a slice of a full human object, just the human's name, t
 .. [#order] This shouldn't be strictly necessary (JSON and EDN don't normally care about key order, and
    keys can appear in arbitrary order),
    but having consistent ordering makes writing tests involving GraphQL queries easier: you can
-   typically check the textual, not parsed, version of the response directly against an expected string value.
+   typically check the textual, not parsed, version of the result map directly against an expected string value.
+
+.. [#result] In GraphQL's specification, this is referred to as the "response"; in practice,
+   this result data forms the body of a response map (when using Ring or Pedestal). Lacinia
+   uses the terms `result map` or `result data` to keep these ideas distinct.

--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -6,7 +6,7 @@ Queries
    Read about `operations <https://facebook.github.io/graphql/#sec-Executing-Operations>`_.
 
 Queries are responsible for generating the initial resolved values that will be
-picked apart to form the response.
+picked apart to form the result map.
 
 Other than that, queries are just the same as any other field.
 Queries have a type, and accept arguments.

--- a/docs/resolve/async.rst
+++ b/docs/resolve/async.rst
@@ -44,7 +44,7 @@ On normal queries, Lacinia will execute as much as it can in parallel.
 This is controlled by how many of your field resolvers return a promise rather than
 a direct result.
 
-Despite the order of execution, Lacinia ensures that the order of keys in the response
+Despite the order of execution, Lacinia ensures that the order of keys in the result map
 matches the order in the query.
 
 .. sidebar:: GraphQL Spec

--- a/docs/resolve/examples.rst
+++ b/docs/resolve/examples.rst
@@ -5,7 +5,7 @@ Formatting a Date
 -----------------
 
 This is a common scenario: you have a Date or Timestamp value and it needs to be
-in a specific format in the response.
+in a specific format in the result map.
 
 In this example, the field resolver will extract the key from the
 container's resolved value, and format it:

--- a/docs/resolve/exceptions.rst
+++ b/docs/resolve/exceptions.rst
@@ -5,7 +5,7 @@ Field resolvers are responsible for catching any exceptions that occur.
 
 Uncaught exceptions will bubble up out of Lacinia code entirely.
 
-This is not desirable: better to return a partial response along with errors.
+This is not desirable: better to return a partial result along with errors.
 
 Field resolvers should catch exceptions and use :doc:`ResolverResults <resolve-as>`
 to communicate errors back to Lacinia for inclusion in the ``:errors`` key of the result.

--- a/docs/resolve/overview.rst
+++ b/docs/resolve/overview.rst
@@ -6,7 +6,7 @@ Every field inside the query, mutation, or other object will have
 a field resolver: if an explicit one is not provided, Lacinia creates
 a default one.
 
-As you might guess, the processing of queries into responses is quite recursive.
+As you might guess, the processing of queries into result map data is quite recursive.
 The initial query (or mutation) will invoke a top-level field resolver.
 Here, the resolved value passed to the root field resolver will be nil.
 
@@ -32,7 +32,7 @@ The rules of field resolvers:
    It is possible to :doc:`preview nested selections <selections>` in a field resolver, which can enable
    some important optimizations.
 
-Meanwhile, the selected data from the resolved value is added to the response.
+Meanwhile, the selected data from the resolved value is added to the result map.
 
 If the value is a scalar type, it is added as-is.
 

--- a/docs/resolve/resolve-as.rst
+++ b/docs/resolve/resolve-as.rst
@@ -25,7 +25,7 @@ Errors will be exposed as the top-level ``:errors`` key of the execution result.
 
 Error maps contain at a minimum a ``:message`` key of type String.
 You may specify other keys and values as you wish, but these values will be part of the ultimate
-client response, so they should be both concise and safe for the transport medium.
+result map, so they should be both concise and safe for the transport medium.
 Generally, this means not to include values that can't be converted into JSON values.
 
 Lacinia will add additional keys to the error map, to identify the query selection active when the
@@ -36,7 +36,7 @@ When using ``resolve-as``, you may pass the error map as the second parameter (w
 You may pass a single map, or a seq of error maps.
 This first parameter is the resolved value, which may be ``nil``.
 
-The order in which errors appear in the ``:errors`` key of the response is not specified;
+The order in which errors appear in the ``:errors`` key of the result map is not specified;
 however, Lacinia does remove duplicate errors.
 
 Tagging Resolvers

--- a/docs/resolve/selections.rst
+++ b/docs/resolve/selections.rst
@@ -87,7 +87,7 @@ In execution order, resolution occurs top to bottom, so the ``hero`` selection o
 first, then (potentially :doc:`in parallel <async>`) ``friends``, ``home_planet``, and (hero) ``name``.
 These last two are leaf nodes, because they are scalar values.
 The list of ``characters`` (from the ``friends`` field) then has its ``name`` field selected.
-The response then constructs up bottom to top.
+The result map then constructs from bottom to top.
 
 Previewing Selections
 ---------------------

--- a/docs/resolve/timing.rst
+++ b/docs/resolve/timing.rst
@@ -17,11 +17,11 @@ Timing collection is enabled using the key, ``:com.walmartlabs.lacinia/enable-ti
 
 .. sidebar:: Extensions key?
 
-   GraphQL supports a third response key, ``extensions``, as
+   GraphQL supports a third result key, ``extensions``, as
    described in `the spec <https://facebook.github.io/graphql/#sec-Response-Format>`_.
    It exists just for this kind of extra information in the response.
 
-Timings are returned in a tree structure below the ``:extensions`` key of the response.
+Timings are returned in a tree structure below the ``:extensions`` key of the result.
 The tree structure reflects the structure of the *query* (not the schema).
 
 We can see here that the ``human`` query operation's resolver was invoked twice, and the ``friends`` field's

--- a/docs/subscriptions/streamer.rst
+++ b/docs/subscriptions/streamer.rst
@@ -56,8 +56,8 @@ Timing
 The source stream callback will return immediately.
 It must return nil.
 
-The provided value will be used to generate a GraphQL response, which will be streamed to the client.
-Typically, the response will be generated asynchronously, on another thread.
+The provided value will be used to generate a GraphQL result map, which will be streamed to the client.
+Typically, the result map will be generated asynchronously, on another thread.
 
 Implementations of the source stream callback may set different guarantees on when or if values in the source stream
 are converted to responses in the response stream.

--- a/docs/unions.rst
+++ b/docs/unions.rst
@@ -30,8 +30,8 @@ is to be returned based on the runtime type of object:
      ... on photo { imageURL title }
    }}
 
-This breaks down what will be returned in the response data based on the type of the value produced
-by the ``:search`` query.  Sometimes there will be a ``:name`` key in the response, and other times
+This breaks down what will be returned in the result map based on the type of the value produced
+by the ``:search`` query.  Sometimes there will be a ``:name`` key in the result, and other times
 an ``:image-url`` and ``:title`` key.
 This may vary result by result even within a single request:
 

--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -16,7 +16,7 @@
   "Prepares a query, by applying query variables to it, resulting in a prepared
   query which is then executed.
 
-  Returns a [[ResolverResult]] around the response value (with :data and/or :errors keys)."
+  Returns a [[ResolverResult]] that will deliver the result map.."
   {:added "0.16.0"}
   [parsed-query variables context]
   {:pre [(map? parsed-query)
@@ -44,20 +44,20 @@
   "Prepares a query, by applying query variables to it, resulting in a prepared
   query which is then executed.
 
-  Returns a response value with :data and/or :errors keys."
+  Returns a result map (with :data and/or :errors keys)."
   [parsed-query variables context]
-  (let [response-promise (promise)
-        response-result (execute-parsed-query-async parsed-query variables context)]
-    (resolve/on-deliver! response-result
-                         (fn [response]
-                           (deliver response-promise response)))
+  (let [result-promise (promise)
+        execution-result (execute-parsed-query-async parsed-query variables context)]
+    (resolve/on-deliver! execution-result
+                         (fn [result]
+                           (deliver result-promise result)))
     ;; Block on that deliver, then return the final result.
-    @response-promise))
+    @result-promise))
 
 (defn execute
   "Given a compiled schema and a query string, attempts to execute it.
 
-  Returns a map with up-to two keys:  :data is the main result of the
+  Returns a result map with up-to two keys:  :data is the main result of the
   execution, and :errors are any errors generated during execution.
 
   In the case where there's a parse or validation problem for the query,
@@ -71,7 +71,7 @@
 
   variables
   : compile-time variables that can be referenced inside the query using the
-    `$variable-name` production.
+    `$variable-name` production. A map of keyword keys and values.
 
   context (optional)
   : Additional data that will ultimately be passed to resolver functions.

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -398,7 +398,7 @@
 
   Expects the context to contain the schema and parsed query.
 
-  Returns a ResolverResult whose value is the query result, with :data and/or :errors keys.
+  Returns a ResolverResult that will deliver the result map.
 
   This should generally not be invoked by user code; see [[execute-parsed-query]]."
   [context]
@@ -420,15 +420,15 @@
         operation-result (if (= :mutation operation-type)
                            (execute-nested-selections-sync execution-context enabled-selections)
                            (execute-nested-selections execution-context enabled-selections))
-        response-result (resolve/resolve-promise)]
+        result-promise (resolve/resolve-promise)]
     (resolve/on-deliver! operation-result
                          (fn [selected-data]
                            (let [data (propogate-nulls false selected-data)]
-                             (resolve/deliver! response-result
+                             (resolve/deliver! result-promise
                                                (cond-> {:data data}
                                                  timings (assoc-in [:extensions :timing] @timings)
                                                  (seq @errors) (assoc :errors (distinct @errors)))))))
-    response-result))
+    result-promise))
 
 (defn invoke-streamer
   "Given a parsed and prepared query (inside the context, as with [[execute-query]]),

--- a/test/com/walmartlabs/lacinia/async_test.clj
+++ b/test/com/walmartlabs/lacinia/async_test.clj
@@ -79,7 +79,7 @@
                    :n5 {:name "n5"}}}
            (simplify result)))
     ;; Even though we have proof that the field resolvers ran in a different order,
-    ;; this shows that the results from each FR was added to the response map in
+    ;; this shows that the results from each FR was added to the result map in
     ;; the user-requested order.
     (is (= [:n1 :n2 :n3 :n4 :n5]
            (-> result :data keys)))

--- a/test/com/walmartlabs/lacinia/enums_test.clj
+++ b/test/com/walmartlabs/lacinia/enums_test.clj
@@ -27,9 +27,9 @@
          (q "{ hero { name appears_in }}"))))
 
 (deftest can-provide-enum-as-bare-name
-  (let [response (q "{ hero(episode: NEWHOPE) { name }}")
-        hero-name (-> response :data :hero :name)]
-    (report response
+  (let [result (q "{ hero(episode: NEWHOPE) { name }}")
+        hero-name (-> result :data :hero :name)]
+    (report result
       (is (= "Luke Skywalker" hero-name)))))
 
 (deftest handling-of-invalid-enum-value

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -37,7 +37,7 @@
            (execute default-schema q {} nil)))
     (is (= (json/write-str (lacinia/execute default-schema q {} nil))
            "{\"data\":{\"hero\":{\"id\":\"2001\",\"name\":\"R2-D2\",\"appears_in\":[\"NEWHOPE\",\"EMPIRE\",\"JEDI\"]}}}")))
-  ;; Reordering fields should change response ordering
+  ;; Reordering fields should change ordering in the :data map
   (let [q "{ hero { name appears_in id }}"]
     (is (= (json/write-str (lacinia/execute default-schema q {} nil))
            "{\"data\":{\"hero\":{\"name\":\"R2-D2\",\"appears_in\":[\"NEWHOPE\",\"EMPIRE\",\"JEDI\"],\"id\":\"2001\"}}}")))


### PR DESCRIPTION
I've found the term 'response' (used in GraphQL specification) to be somewhat inaccurate, as we take that response as the body of a Ring/Pedestal response.  This PR simply updates the documentation to make this split more visible and consistent.