### PR TITLE
Simplify validation and hide the namespaces

### DIFF
--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -23,8 +23,7 @@
          (or (nil? context)
              (map? context))]}
   (cond-let
-    :let [schema (get parsed-query constants/schema-key)
-          [prepared error-result] (try
+    :let [[prepared error-result] (try
                                     [(parser/prepare-with-query-variables parsed-query variables)]
                                     (catch Exception e
                                       [nil (as-errors e)]))]
@@ -32,7 +31,7 @@
     (some? error-result)
     (resolve/resolve-as error-result)
 
-    :let [validation-errors (validator/validate schema prepared {})]
+    :let [validation-errors (validator/validate prepared)]
 
     (seq validation-errors)
     (resolve/resolve-as {:errors validation-errors})

--- a/src/com/walmartlabs/lacinia/validation/fragment_names.clj
+++ b/src/com/walmartlabs/lacinia/validation/fragment_names.clj
@@ -1,4 +1,7 @@
-(ns com.walmartlabs.lacinia.validation.fragment-names)
+(ns com.walmartlabs.lacinia.validation.fragment-names
+  {:no-doc true}
+  (:require
+    [com.walmartlabs.lacinia.internal-utils :refer [q]]))
 
 (defn ^:private fragment-defined?
   "Returns empty sequence if a fragment spread is defined
@@ -8,8 +11,8 @@
   (if (contains? fragment-defs
                  (:fragment-name fragment-spread))
     []
-    [{:message (format "Unknown fragment \"%s\". Fragment definition is missing."
-                       (name (:fragment-name fragment-spread)))
+    [{:message (format "Unknown fragment %s. Fragment definition is missing."
+                       (-> fragment-spread :fragment-name q))
       :locations [(:location fragment-spread)]}]))
 
 (defn ^:private validate-fragments
@@ -39,9 +42,9 @@
   ```
 
   and all fragments listed in selections."
-  [_ query-map]
-  (let [fragments (:fragments query-map)
-        selections (:selections query-map)]
+  [prepared-query]
+  (let [fragments (:fragments prepared-query)
+        selections (:selections prepared-query)]
     (concat
      ;; Validate nested fragments
      (mapcat (fn [[_ f-definition]]

--- a/src/com/walmartlabs/lacinia/validation/no_unused_fragments.clj
+++ b/src/com/walmartlabs/lacinia/validation/no_unused_fragments.clj
@@ -1,6 +1,8 @@
 (ns com.walmartlabs.lacinia.validation.no-unused-fragments
+  {:no-doc true}
   (:require
-    [clojure.set :as set]))
+    [clojure.set :as set]
+    [com.walmartlabs.lacinia.internal-utils :refer [q]]))
 
 (defn ^:private fragment-names-used
   "Returns a sequence of all fragment names
@@ -28,14 +30,14 @@
   "Validates if all fragment definitions are spread
   within operations, or spread within other fragments
   spread within operations."
-  [compiled-schema query-map]
-  (let [{:keys [fragments selections]} query-map
+  [prepared-query]
+  (let [{:keys [fragments selections]} prepared-query
         f-locations (into {} (map (fn [[f-name {location :location}]]
                                     {f-name location})
                                   fragments))
         f-definitions (set (keys fragments))
         f-names-used (all-fragments-used fragments selections)]
     (for [unused-f-definition (set/difference f-definitions f-names-used)]
-      {:message (format "Fragment \"%s\" is never used."
-                        (name unused-f-definition))
+      {:message (format "Fragment %s is never used."
+                        (q unused-f-definition))
        :locations [(unused-f-definition f-locations)]})))

--- a/src/com/walmartlabs/lacinia/validation/no_unused_fragments.clj
+++ b/src/com/walmartlabs/lacinia/validation/no_unused_fragments.clj
@@ -19,12 +19,9 @@
   throughout the entire query: selections and
   nested fragments."
   [fragments selections]
-  (set (apply concat
-              ;; fragment names in selections
-              (mapcat fragment-names-used selections)
-              ;; fragment names in fragments
-              ;; (nested fragments)
-              (map fragment-names-used (vals fragments)))))
+  (-> #{}
+      (into (mapcat fragment-names-used selections))
+      (into (mapcat fragment-names-used (vals fragments)))))
 
 (defn no-unused-fragments
   "Validates if all fragment definitions are spread

--- a/src/com/walmartlabs/lacinia/validator.clj
+++ b/src/com/walmartlabs/lacinia/validator.clj
@@ -1,6 +1,7 @@
 (ns com.walmartlabs.lacinia.validator
   "Implements query validation (eg. typechecking of vars, fragment types, etc.),
   but also a place where complexity analysis will occur."
+  {:no-doc true}
   (:require [com.walmartlabs.lacinia.validation.scalar-leafs :refer [scalar-leafs]]
             [com.walmartlabs.lacinia.validation.fragment-names :refer [known-fragment-names]]
             [com.walmartlabs.lacinia.validation.no-unused-fragments
@@ -21,9 +22,13 @@
 ;; ## Public API
 
 (defn validate
-  "Performs validation of the query against
+  "Performs validation of the parsed and prepared query against
   a set of default rules.
-  Returns empty sequence if no errors."
-  [compiled-schema query-map opts]
-  (mapcat #(% compiled-schema query-map)
-          default-rules))
+
+  Returns an sequence of error maps, which will be empty if there are no errors.
+
+  Note: the 3 argument version is deprecated and will be removed in a future release."
+  ([prepared-query]
+   (mapcat #(% prepared-query) default-rules))
+  ([_ prepared-query _]
+    (validate prepared-query)))

--- a/test/com/walmartlabs/lacinia/validator_test.clj
+++ b/test/com/walmartlabs/lacinia/validator_test.clj
@@ -13,11 +13,11 @@
 (deftest scalar-leafs-validations
   (testing "All leafs are scalar types or enums"
     (let [q "{ hero }"]
-      (is (= {:errors [{:message "Field \"hero\" of type \"character\" must have a sub selection.",
+      (is (= {:errors [{:message "Field `hero' (of type `character') must have at least one selection.",
                         :locations [{:line 1, :column 0}]}]}
              (execute compiled-schema q {} nil))))
     (let [q "{ hero { name friends } }"]
-      (is (= {:errors [{:message "Field \"friends\" of type \"character\" must have a sub selection.",
+      (is (= {:errors [{:message "Field `friends' (of type `character') must have at least one selection.",
                         :locations [{:line 1, :column 7}]}]}
              (execute compiled-schema q {} nil))))
     (let [q "query NestedQuery {
@@ -30,7 +30,7 @@
                }
              }
             }"]
-      (is (= {:errors [{:message "Field \"friends\" of type \"character\" must have a sub selection.",
+      (is (= {:errors [{:message "Field `friends' (of type `character') must have at least one selection.",
                         :locations [{:line 4, :column 23}]}]}
              (execute compiled-schema q {} nil))))
     (let [q "query NestedQuery {
@@ -45,8 +45,9 @@
                }
              }
             }"]
-      (is (= {:errors [{:message "Field \"friends\" of type \"character\" must have a sub selection.",
-                        :locations [{:line 7, :column 25}]}]}
+      (is (= {:errors [{:message "Field `friends' (of type `character') must have at least one selection."
+                        :locations [{:line 7
+                                     :column 25}]}]}
              (execute compiled-schema q {} nil))))
     (let [q "query NestedQuery {
              hero {
@@ -60,11 +61,11 @@
                }
              }
             }"]
-      (is (= {:errors [{:message "Field \"forceSide\" of type \"force\" must have a sub selection.",
+      (is (= {:errors [{:message "Field `forceSide' (of type `force') must have at least one selection.",
                         :locations [{:line 2, :column 18}]}
-                       {:message "Field \"friends\" of type \"character\" must have a sub selection.",
+                       {:message "Field `friends' (of type `character') must have at least one selection.",
                         :locations [{:line 5, :column 23}]}
-                       {:message "Field \"forceSide\" of type \"force\" must have a sub selection.",
+                       {:message "Field `forceSide' (of type `force') must have at least one selection.",
                         :locations [{:line 5, :column 23}]}]}
              (execute compiled-schema q {} nil))))
     (let [q "query NestedQuery {
@@ -81,11 +82,11 @@
                }
              }
             }"]
-      (is (= {:errors [{:message "Field \"forceSide\" of type \"force\" must have a sub selection.",
+      (is (= {:errors [{:message "Field `forceSide' (of type `force') must have at least one selection.",
                         :locations [{:line 2, :column 18}]}
-                       {:message "Field \"friends\" of type \"character\" must have a sub selection.",
+                       {:message "Field `friends' (of type `character') must have at least one selection.",
                         :locations [{:line 5, :column 23}]}
-                       {:message "Field \"members\" of type \"character\" must have a sub selection.",
+                       {:message "Field `members' (of type `character') must have at least one selection.",
                         :locations [{:line 9, :column 27}]}]}
              (execute compiled-schema q {} nil))))
     (let [q "query NestedQuery {
@@ -102,9 +103,9 @@
                }
              }
             }"]
-      (is (= {:errors [{:message "Field \"forceSide\" of type \"force\" must have a sub selection."
+      (is (= {:errors [{:message "Field `forceSide' (of type `force') must have at least one selection."
                         :locations [{:line 2, :column 18}]}
-                       {:message "Field \"friends\" of type \"character\" must have a sub selection.",
+                       {:message "Field `friends' (of type `character') must have at least one selection.",
                         :locations [{:line 5, :column 23}]}]}
              (execute compiled-schema q {} nil))))
     (let [q "{ hero { name { id } } }"]
@@ -141,7 +142,7 @@
              name
              homePlanet
            }"]
-    (is (= {:errors [{:message "Unknown fragment \"FooFragment\". Fragment definition is missing."
+    (is (= {:errors [{:message "Unknown fragment `FooFragment'. Fragment definition is missing."
                       :locations [{:line 2 :column 37}]}]}
            (execute compiled-schema q {} nil))))
   (let [q "query UseFragment {
@@ -156,11 +157,11 @@
              name
              homePlanet
            }"]
-    (is (= {:errors [{:message "Unknown fragment \"FooFragment\". Fragment definition is missing."
+    (is (= {:errors [{:message "Unknown fragment `FooFragment'. Fragment definition is missing."
                       :locations [{:line 2 :column 37}]}
-                     {:message "Unknown fragment \"BarFragment\". Fragment definition is missing."
+                     {:message "Unknown fragment `BarFragment'. Fragment definition is missing."
                       :locations [{:line 5 :column 37}]}
-                     {:message "Fragment \"HumanFragment\" is never used.",
+                     {:message "Fragment `HumanFragment' is never used.",
                       :locations [{:line 9, :column 11}]}]}
            (execute compiled-schema q {} nil))))
   (let [q "query withNestedFragments {
@@ -191,7 +192,7 @@
              name
              ...appearsInFragment
            }"]
-    (is (= {:errors [{:message "Unknown fragment \"appearsInFragment\". Fragment definition is missing."
+    (is (= {:errors [{:message "Unknown fragment `appearsInFragment'. Fragment definition is missing."
                       :locations [{:line 8 :column 50}]}]}
            (execute compiled-schema q {} nil)))))
 
@@ -238,7 +239,7 @@
            fragment appearsInFragment on human {
              appears_in
            }"]
-    (is (= {:errors [{:message "Fragment \"appearsInFragment\" is never used.",
+    (is (= {:errors [{:message "Fragment `appearsInFragment' is never used.",
                       :locations [{:line 12, :column 11}]}]}
            (execute compiled-schema q {} nil)))))
 


### PR DESCRIPTION
Validation is not, at least currently, extensible, or intended for application code to invoke. This PR changes those namespaces to be invisible in the documentation.

The signatures of the validation functions are a bit out of date; the parsed and prepared query has everything needed, including the full schema if that is required.  The functions now simply receive the prepared schema.