### PR TITLE
[20170717]  Allow single values on list type input

### DIFF
--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -509,7 +509,6 @@
     :let [nested-type (:type argument-type)
           kind (:kind argument-type)]
 
-
     ;; we can only hit this if we iterate over list members
     (and (nil? result) (= :non-null kind))
     (throw-exception (format "Variable %s contains null members but supplies the value for a list that can't have any null members."
@@ -518,15 +517,17 @@
 
     (= :list kind)
     (cond
+      (and (= :list (:kind nested-type))
+           (not (sequential? (first result))))
+      (throw-exception (format "Variable %s doesn't contain the correct number of (nested) lists."
+                               (q arg-value))
+                       {:variable-name arg-value})
+
       ;; variables of a list type allow for a single value input
       (and (some? result)
            (not (sequential? result)))
       [:array (mapv #(construct-literal-argument schema % nested-type arg-value) [result])]
 
-      (not (sequential? result))
-      (throw-exception (format "Variable %s doesn't contain the correct number of (nested) lists."
-                               (q arg-value))
-                       {:variable-name arg-value})
       :else
       [:array (mapv #(construct-literal-argument schema % nested-type arg-value) result)])
 

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -517,10 +517,17 @@
                      {:variable-name arg-value})
 
     (= :list kind)
-    (if (not (sequential? result))
+    (cond
+      ;; variables of a list type allow for a single value input
+      (and (some? result)
+           (not (sequential? result)))
+      [:array (mapv #(construct-literal-argument schema % nested-type arg-value) [result])]
+
+      (not (sequential? result))
       (throw-exception (format "Variable %s doesn't contain the correct number of (nested) lists."
                                (q arg-value))
                        {:variable-name arg-value})
+      :else
       [:array (mapv #(construct-literal-argument schema % nested-type arg-value) result)])
 
     (nil? result)

--- a/test/com/walmartlabs/lacinia/custom_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/custom_scalars_test.clj
@@ -183,7 +183,7 @@
                               sundays(between: $between)
                             }"
                     {:between ["2017-03-06" "2017-03-07"]}
-                    nil))
+                   nil))
         "should return empty list")
     (is (= {:data {:sundays []}}
            (execute schema "query ($between: [Date!]!) {
@@ -360,14 +360,13 @@
                       {:words [[["foo"]]]}
                       nil))
           "should return data")
-      (is (= {:errors [{:message "Variable `words' doesn't contain the correct number of (nested) lists.",
-                        :variable-name :words}]}
+      (is (= {:data {:shout [[[] ["FOO"]]]}}
              (execute schema "query ($words: [[[CustomType]!]!]!) {
                               shout(words: $words)
                             }"
-                      {:words [[[] "foo"]]}
+                      {:words [[[] ["foo"]]]}
                       nil))
-          "should return an error"))))
+          "should coerece single value to a list of size one"))))
 
 (deftest use-of-coercion-error
   (let [schema (-> "custom-scalar-serialize-schema.edn"

--- a/test/com/walmartlabs/lacinia/custom_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/custom_scalars_test.clj
@@ -183,7 +183,7 @@
                               sundays(between: $between)
                             }"
                     {:between ["2017-03-06" "2017-03-07"]}
-                   nil))
+                    nil))
         "should return empty list")
     (is (= {:data {:sundays []}}
            (execute schema "query ($between: [Date!]!) {

--- a/test/com/walmartlabs/lacinia/validator_test.clj
+++ b/test/com/walmartlabs/lacinia/validator_test.clj
@@ -274,12 +274,37 @@
                                       string: \"five\",
                                       nestedInputObject: {integerArray: \"hello world\",
                                                           date: \"1983-08-13\"}}) { integer }}"]
-      (is (= {:errors [{:argument :inputObject
-                        :field :echoArgs
-                        :locations [{:column 0
-                                     :line 1}]
-                        :message "Exception applying arguments to field `echoArgs': For argument `inputObject', a single argument value was provided for a list argument."
-                        :query-path []}]}
+      (is (= {:errors
+              [{:message
+                "Exception applying arguments to field `echoArgs': For argument `inputObject', scalar value is not parsable as type `Int'.",
+                :query-path [],
+                :locations [{:line 1, :column 0}],
+                :field :echoArgs,
+                :argument :inputObject,
+                :value "hello world",
+                :type-name :Int}]}
+
+             (execute compiled-schema q {} nil)))))
+
+  (testing "valid deeply nested input-object property of type list but of single value"
+    (let [q "{ echoArgs(integer: 1,
+                        integerArray: [2, 3],
+                        inputObject: {integer: 4,
+                                      string: \"five\",
+                                      nestedInputObject: {integerArray: 6,
+                                                          date: \"1983-08-13\"}}) {
+                integer,
+                inputObject {
+                   integer
+                   nestedInputObject {
+                      integerArray
+                   }
+                }
+              }
+            }"]
+      (is (= {:data {:echoArgs {:integer 1,
+                                :inputObject {:integer 4,
+                                              :nestedInputObject {:integerArray [6]}}}}}
              (execute compiled-schema q {} nil)))))
 
   (testing "invalid array element"

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -660,9 +660,10 @@
                 }
              }"]
       (is (= {:data {:echoArgs {:inputObject {:nestedInputObject {:integerArray [6]}}}}}
-             (execute default-schema q {} nil)))))
+             (execute default-schema q {} nil))
+          "should accept single value and coerce it to a list of size one")))
 
-  (testing ""
+  (testing "variable of a list type is a single integer"
     (let [q "query QueryWithVariable($intArray: [Int]) {
                 echoArgs(integerArray: $intArray) {
                    integerArray
@@ -670,7 +671,8 @@
              }"
           intArray 2]
       (is (= {:data {:echoArgs {:integerArray [2]}}}
-             (execute default-schema q {:intArray intArray} nil)))))
+             (execute default-schema q {:intArray intArray} nil))
+          "should accept single value and coerce it to a list of size one")))
 
   (testing "field argument of a list type is null"
     (let [q "{ echoArgs (integerArray: null) {

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -630,3 +630,43 @@
                  :default-value "0001"}}}}}]
     (is-thrown [e (schema/compile schema-non-nullable-with-defaults)]
       (is (= (.getMessage e) "Field `id' of type `person' is both non-nullable and has a default value.")))))
+
+(deftest allow-single-value-on-list-type-input
+
+  (testing "field argument of list type is a single integer"
+    (let [q "{ echoArgs (integerArray: 1) {
+                 integerArray
+               }
+             }"]
+      (is (= {:data {:echoArgs {:integerArray [1]}}}
+             (execute default-schema q nil nil))
+          "should accept single value and coerce it to a list of size one")))
+
+  (testing "field argument of a list type is a single enum"
+    (let [q "mutation { addHeroEpisodes(id: \"1004\", episodes: JEDI) { name appears_in } }"]
+      (is (= {:data {:addHeroEpisodes {:appears_in [:NEWHOPE
+                                                    :JEDI]
+                                       :name "Wilhuff Tarkin"}}}
+             (execute default-schema q nil nil))
+          "should accept single value and coerce it to a list of size one")))
+
+  (testing "field argument of a list type of an input object is a single integer"
+    (let [q "{ echoArgs (inputObject: { nestedInputObject: { integerArray: 6 }}) {
+                 inputObject {
+                   nestedInputObject {
+                     integerArray
+                   }
+                 }
+               }
+             }"]
+      (is (= {:data {:echoArgs {:inputObject {:nestedInputObject {:integerArray [6]}}}}}
+             (execute default-schema q {} nil)))))
+
+  (testing "field argument of a list type is null"
+    (let [q "{ echoArgs (integerArray: null) {
+                 integerArray
+               }
+             }"]
+      (is (= {:data {:echoArgs {:integerArray []}}}
+             (execute default-schema q nil nil))
+          "should coerce null to an empty array"))))

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -635,7 +635,7 @@
 
   (testing "field argument of list type is a single integer"
     (let [q "{ echoArgs (integerArray: 1) {
-                 integerArray
+                  integerArray
                }
              }"]
       (is (= {:data {:echoArgs {:integerArray [1]}}}
@@ -652,19 +652,29 @@
 
   (testing "field argument of a list type of an input object is a single integer"
     (let [q "{ echoArgs (inputObject: { nestedInputObject: { integerArray: 6 }}) {
-                 inputObject {
-                   nestedInputObject {
-                     integerArray
-                   }
-                 }
-               }
+                  inputObject {
+                    nestedInputObject {
+                      integerArray
+                    }
+                  }
+                }
              }"]
       (is (= {:data {:echoArgs {:inputObject {:nestedInputObject {:integerArray [6]}}}}}
              (execute default-schema q {} nil)))))
 
+  (testing ""
+    (let [q "query QueryWithVariable($intArray: [Int]) {
+                echoArgs(integerArray: $intArray) {
+                   integerArray
+                }
+             }"
+          intArray 2]
+      (is (= {:data {:echoArgs {:integerArray [2]}}}
+             (execute default-schema q {:intArray intArray} nil)))))
+
   (testing "field argument of a list type is null"
     (let [q "{ echoArgs (integerArray: null) {
-                 integerArray
+                  integerArray
                }
              }"]
       (is (= {:data {:echoArgs {:integerArray []}}}


### PR DESCRIPTION
Fixes issue #30 

Field arguments, fields of input objects and variables of type list will now allow input of a single value and will coerce it to a list of size one.
