### PR TITLE
Allow Field and argument :description to inherit from implemented interface

### DIFF
--- a/dev-resources/doc-inheritance-schema.edn
+++ b/dev-resources/doc-inheritance-schema.edn
@@ -1,0 +1,45 @@
+{:interfaces
+ {:sierra
+  {:fields
+   {:alpha {:type String}
+    :bravo {:type String
+            :description "sierra/bravo"}}}
+  :tango
+  {:description "tango interface"
+   :fields
+   {:charlie
+    {:type String
+     :description "tango/charlie"
+     :args
+     {:delta
+      {:type String
+       :description "tango/charlie/delta"}
+      :echo
+      {:type String
+       :description "tango/charlie/echo"}}}}}}
+
+ :objects
+ {:ex1
+  {:implements [:sierra]
+   :fields
+   {:alpha {:type String
+            :description "ex1/alpha"}
+    :bravo {:type String}}}
+  :ex2
+  {:implements [:sierra]
+   :fields
+   {:alpha {:type String
+            :description "ex2/alpha"}
+    :bravo {:type String
+            :description "ex2/bravo"}}}
+  :ex3
+  {:implements [:tango]
+   :fields
+   {:charlie
+    {:type String
+     :args
+     {:delta
+      {:type String
+       :description "ex3/delta"}
+      :echo
+      {:type String}}}}}}}

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -20,5 +20,10 @@ or as the type of a field.
 
 An interface definition may include a ``:description`` key; the value is a string exposed through :doc:`introspection`.
 
+The description on an interface field, or on an argument of an interface field, will be inherited by
+the object field (or argument) unless overriden.
+This helps to elimiate duplication of documentation between an interface and the object implementing
+the interface.
+
 The :doc:`object definition <objects>` must include all the fields of all extended interfaces.
 

--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -61,5 +61,7 @@ Object Description
 
 An object definition may include a ``:description`` key; the value is a string exposed through :doc:`introspection`.
 
+When an object implement an interface, it may omit the ``:description`` of inherited fields, and on
+arguments of inherited fields to inherit the description from the interface.
 
 .. [#emptyschema] A schema that fails to define either queries or mutations is useful only as an example.

--- a/test/com/walmartlabs/lacinia/documentation_test.clj
+++ b/test/com/walmartlabs/lacinia/documentation_test.clj
@@ -1,0 +1,62 @@
+(ns com.walmartlabs.lacinia.documentation-test
+  "Tests that documentation for fields and field args can be inhertited from interfaces."
+  (:require
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.test-utils :as utils]))
+
+(def ^:private schema
+  (utils/compile-schema "doc-inheritance-schema.edn" {}))
+
+(defn ^:private q [query]
+  (utils/execute schema query))
+
+(deftest field-description-may-inherit-from-interface
+  (is (= {:data
+          {:ex1
+           {:fields
+            [{:description "ex1/alpha"
+              :name "alpha"}
+             {:description "sierra/bravo"
+              :name "bravo"}]}
+           :ex2
+           {:fields
+            [{:description "ex2/alpha"
+              :name "alpha"}
+             {:description "ex2/bravo"
+              :name "bravo"}]}}}
+         (q "
+     { ex1: __type (name: \"ex1\") {
+
+         fields {
+           name
+           description
+         }
+       }
+
+       ex2: __type(name: \"ex2\") {
+         fields {
+           name
+           description
+         }
+       }
+     }"))))
+
+(deftest arg-description-may-inherit-from-interface
+  (is (= {:data
+          {:ex3
+           {:fields
+            [{:args
+              [{:description "ex3/delta"
+                :name "delta"}
+               {:description "tango/charlie/echo"
+                :name "echo"}]}]}}}
+         (q "
+         { ex3: __type(name: \"ex3\") {
+           fields {
+             args {
+               name
+               description
+             }
+           }
+          }
+         }"))))


### PR DESCRIPTION
This will help considerably with removing duplicated documentation when an interface and an object's field/argument documentation is the same.