### PR TITLE
Check that arguments on the field are compatible with arguments on the interface field

### DIFF
--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1015,7 +1015,7 @@
       (doseq [additional-arg-name additional-args
               :let [arg-kind (get-in object-field-args [additional-arg-name :type :kind])]]
         (when (= arg-kind :non-null)
-          (throw (ex-info "Additional arguments on an object field cannot be required."
+          (throw (ex-info "Additional arguments on an object field that are not defined in extended interface cannot be required."
                           {:object type-name
                            :interface-name interface-name
                            :field-name field-name

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -971,24 +971,43 @@
   [schema object options]
   (verify-fields-and-args schema object)
   (doseq [interface-name (:implements object)
-          :let [interface (get schema interface-name)]
+          :let [interface (get schema interface-name)
+                type-name (:type-name object)]
           [field-name interface-field] (:fields interface)
-          :let [object-field (get-in object [:fields field-name])]]
-
-    ;; TODO: I believe we are missing a check that arguments on the field are
-    ;; compatible with arguments on the interface field.
+          :let [object-field (get-in object [:fields field-name])
+                interface-field-args (:args interface-field)
+                object-field-args (:args object-field)]]
 
     (when-not object-field
       (throw (ex-info "Missing interface field in object definition."
-                      {:object (:type-name object)
+                      {:object type-name
                        :field-name field-name
                        :interface-name interface-name})))
 
     (when-not (is-assignable? schema interface-field object-field)
       (throw (ex-info "Object field is not compatible with extended interface type."
-                      {:object (:type-name object)
+                      {:object type-name
                        :interface-name interface-name
-                       :field-name field-name}))))
+                       :field-name field-name})))
+
+    (when interface-field-args
+      (doseq [interface-field-arg interface-field-args
+              :let [[arg-name interface-arg-def] interface-field-arg
+                    object-field-arg-def (get object-field-args arg-name)]]
+
+        (when-not object-field-arg-def
+          (throw (ex-info "Missing interface field argument in object definition."
+                          {:object type-name
+                           :field-name field-name
+                           :interface-name interface-name
+                           :argument-name arg-name})))
+
+        (when-not (is-assignable? schema interface-arg-def object-field-arg-def)
+          (throw (ex-info "Object field's argument is not compatible with extended interface's argument type."
+                          {:object type-name
+                           :interface-name interface-name
+                           :field-name field-name
+                           :argument-name arg-name}))))))
 
   (update object :fields #(reduce-kv (fn [m field-name field]
                                        (assoc m field-name

--- a/test/com/walmartlabs/lacinia/interfaces_test.clj
+++ b/test/com/walmartlabs/lacinia/interfaces_test.clj
@@ -161,4 +161,4 @@
                      (update-in [:objects :starship :fields :length :args]
                                 #(assoc % :precision {:type '(non-null Int)})))]
       (is-thrown [e (schema/compile schema {:default-field-resolver schema/hyphenating-default-field-resolver})]
-                 (is (= (.getMessage e) "Additional arguments on an object field cannot be required."))))))
+                 (is (= (.getMessage e) "Additional arguments on an object field that are not defined in extended interface cannot be required."))))))

--- a/test/com/walmartlabs/lacinia/interfaces_test.clj
+++ b/test/com/walmartlabs/lacinia/interfaces_test.clj
@@ -1,0 +1,150 @@
+(ns com.walmartlabs.lacinia.interfaces-test
+  (:require [clojure.test :as test :refer [deftest is testing]]
+            [com.walmartlabs.lacinia :refer [execute]]
+            [com.walmartlabs.lacinia.schema :as schema]
+            [com.walmartlabs.test-utils :refer [is-thrown]]))
+
+(def starship-data
+  (->> [{:id "001"
+         :name "Millennium Falcon"
+         :length 34.37
+         :class "Light freighter"
+         ::type :starship}
+        {:id "002"
+         :name "X-wing"
+         :length 12.5
+         :class "Starfighter"
+         ::type :starship}
+        {:id "003"
+         :name "Executor"
+         :length 19000
+         :class "Star dreadnought"
+         ::type :starship}
+        {:id "004"
+         :name "Death Star"
+         :length 120000
+         :class "Deep Space Mobile Battlestation"
+         ::type :starship}]
+       (map (juxt :id identity))
+       (into {})))
+
+(defn ^:private get-starship
+  [id]
+  (get starship-data id))
+
+(def ^:private test-schema
+  {:enums
+   {:unit {:values [:METER :FOOT]}}
+
+   :interfaces
+   {:vehicle {:fields {:id {:type '(non-null String)}
+                       :name {:type '(non-null String)}
+                       :length {:type 'Float
+                                :args {:unit {:type :unit}}}
+                       :class {:type 'String}}}}
+   :objects
+   {:starship
+    {:implements [:vehicle]
+     :fields {:id {:type '(non-null String)}
+              :name {:type '(non-null String)}
+              :length {:type 'Float
+                       :args {:unit {:type :unit
+                                     :default-value :METER}}
+                       :resolve (fn [ctx args v]
+                                  (let [{:keys [unit]} args
+                                        length (:length v)]
+                                    (if-not (= unit :METER)
+                                      (when length
+                                        (* length 3.28))
+                                      length)))}
+              :class {:type 'String}}}}
+
+   :queries
+   {:starship
+    {:type :starship
+     :args {:id {:type '(non-null String)}}
+     :resolve (fn [ctx args v]
+                (let [{:keys [id]} args]
+                  (get-starship id)))}}})
+
+(deftest compatible-arguments
+  (testing "field argument is optional and had default value"
+    (let [compiled-schema (schema/compile test-schema {:default-field-resolver schema/hyphenating-default-field-resolver})
+          q1 "query FetchStarship {
+                 starship(id: \"001\") {
+                    name
+                    class
+                    length(unit: FOOT)
+                 }
+              }"
+          q2 "query FetchStarship {
+                starship(id: \"001\") {
+                   name
+                   class
+                   length
+                }
+             }"]
+      (is (= {:data {:starship {:name "Millennium Falcon"
+                                :class "Light freighter"
+                                :length 112.73359999999998}}}
+             (execute compiled-schema q1 nil nil))
+          "schema should compile and query is successful")
+      (is (= {:data {:starship {:name "Millennium Falcon"
+                                :class "Light freighter"
+                                :length 34.37}}}
+             (execute compiled-schema q2 nil nil))
+          "schema should compile and query is successful")))
+
+  (testing "field argument is required by the interface and not present in the object"
+    (let [invalid-schema (-> test-schema
+                             (assoc-in [:interfaces :vehicle :fields :length :args :unit :type]
+                                       '(non-null :unit))
+                             (assoc-in [:objects :speeder]
+                                       {:implements [:vehicle]
+                                        :fields {:id {:type '(non-null String)}
+                                                 :name {:type '(non-null String)}
+                                                 ;; :length field is missing argument :unit
+                                                 :length {:type 'Float}
+                                                 :class {:type 'String}}}))]
+      (is-thrown [e (schema/compile invalid-schema {:default-field-resolver schema/hyphenating-default-field-resolver})]
+                 (is (= (.getMessage e) "Missing interface field argument in object definition.")))))
+
+  (testing "field argument is not required by the interface and is not present in the object"
+    (let [invalid-schema (-> test-schema
+                             (assoc-in [:interfaces :vehicle :fields :length :args :unit :type] :unit)
+                             (assoc-in [:objects :speeder]
+                                       {:implements [:vehicle]
+                                        :fields {:id {:type '(non-null String)}
+                                                 :name {:type '(non-null String)}
+                                                 ;; :length field is missing argument :unit
+                                                 :length {:type 'Float}
+                                                 :class {:type 'String}}}))]
+      (is-thrown [e (schema/compile invalid-schema {:default-field-resolver schema/hyphenating-default-field-resolver})]
+                 (is (= (.getMessage e) "Missing interface field argument in object definition.")))))
+
+  (testing "field argument in the interface has a different type to field argument in the object"
+    (let [invalid-schema (-> test-schema
+                             (assoc-in [:objects :speeder]
+                                       {:implements [:vehicle]
+                                        :fields {:id {:type '(non-null String)}
+                                                 :name {:type '(non-null String)}
+                                                 :length {:type 'Float
+                                                          ;; invalid type of :unit arg
+                                                          :args {:unit {:type 'String}}}
+                                                 :class {:type 'String}}}))]
+      (is-thrown [e (schema/compile invalid-schema {:default-field-resolver schema/hyphenating-default-field-resolver})]
+                 (is (= (.getMessage e) "Object field's argument is not compatible with extended interface's argument type."))))
+
+    (let [invalid-schema (-> test-schema
+                             (assoc-in [:interfaces :vehicle :fields :length :args :unit :type]
+                                       '(non-null :unit))
+                             (assoc-in [:objects :speeder]
+                                       {:implements [:vehicle]
+                                        :fields {:id {:type '(non-null String)}
+                                                 :name {:type '(non-null String)}
+                                                 :length {:type 'Float
+                                                          ;; invalid type of :unit arg (it's nullable)
+                                                          :args {:unit {:type :unit}}}
+                                                 :class {:type 'String}}}))]
+      (is-thrown [e (schema/compile invalid-schema {:default-field-resolver schema/hyphenating-default-field-resolver})]
+                 (is (= (.getMessage e) "Object field's argument is not compatible with extended interface's argument type."))))))

--- a/test/com/walmartlabs/lacinia/interfaces_test.clj
+++ b/test/com/walmartlabs/lacinia/interfaces_test.clj
@@ -147,4 +147,11 @@
                                                           :args {:unit {:type :unit}}}
                                                  :class {:type 'String}}}))]
       (is-thrown [e (schema/compile invalid-schema {:default-field-resolver schema/hyphenating-default-field-resolver})]
-                 (is (= (.getMessage e) "Object field's argument is not compatible with extended interface's argument type."))))))
+                 (is (= (.getMessage e) "Object field's argument is not compatible with extended interface's argument type.")))))
+
+  (testing "object includes additional field arguments that are not defined in the interface field"
+    (let [schema (-> test-schema
+                     (update-in [:objects :starship :fields :length :args]
+                                #(assoc % :precision {:type 'Int})))]
+      (is (map? (schema/compile schema {:default-field-resolver schema/hyphenating-default-field-resolver}))
+          "should compile schema without any errors"))))

--- a/test/com/walmartlabs/lacinia/interfaces_test.clj
+++ b/test/com/walmartlabs/lacinia/interfaces_test.clj
@@ -149,9 +149,16 @@
       (is-thrown [e (schema/compile invalid-schema {:default-field-resolver schema/hyphenating-default-field-resolver})]
                  (is (= (.getMessage e) "Object field's argument is not compatible with extended interface's argument type.")))))
 
-  (testing "object includes additional field arguments that are not defined in the interface field"
+  (testing "object includes additional (optional) field arguments that are not defined in the interface field"
     (let [schema (-> test-schema
                      (update-in [:objects :starship :fields :length :args]
                                 #(assoc % :precision {:type 'Int})))]
       (is (map? (schema/compile schema {:default-field-resolver schema/hyphenating-default-field-resolver}))
-          "should compile schema without any errors"))))
+          "should compile schema without any errors")))
+
+  (testing "object includes additional (required) field argument that is not defined in the interface field"
+    (let [schema (-> test-schema
+                     (update-in [:objects :starship :fields :length :args]
+                                #(assoc % :precision {:type '(non-null Int)})))]
+      (is-thrown [e (schema/compile schema {:default-field-resolver schema/hyphenating-default-field-resolver})]
+                 (is (= (.getMessage e) "Additional arguments on an object field cannot be required."))))))


### PR DESCRIPTION
This PR fixes issue #17 

>The object field must include an argument of the same name for every argument defined in the interface field.
The object field may include additional arguments not defined in the interface field, but any additional argument must not be required.