### PR TITLE
Prevent a runtime error when using the :default-field-resolver option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## 0.21.0 -- UNRELEASED
+
+Simplified a clojure.spec to prevent a potential runtime error
+`Could not locate clojure/test/check/generators__init.class or clojure/test/check/generators.clj on classpath`.
+This would occur when the :default-field-resolver option was specified, and org.clojure/test.check was
+not on the classpath (it is a side-effect of having `com.walmartlabs.lacina/compile`
+be always instrumented).
+
 ## 0.20.0 -- 1 Aug 2017
 
 Object fields and field arguments may now inherit their description from corresponding

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "0.20.0"
+(defproject com.walmartlabs/lacinia "0.21.0"
   :description "A GraphQL server implementation in Clojure"
   :license {:name "Apache, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -349,15 +349,9 @@
                    ::mutations
                    ::subscriptions]))
 
-(s/def ::resolver
-  (s/fspec :args (s/cat ::context (s/keys)
-                        ::arguments (s/map-of keyword? any?)
-                        ::value any?)
-           :ret any?))
-
-(s/def ::default-field-resolver
-  (s/fspec :args (s/cat :field keyword?)
-           :ret ::resolver))
+;; Again, this can be fleshed out once we have a handle on defining specs for
+;; functions:
+(s/def ::default-field-resolver fn?)
 
 (s/def ::compile-options (s/keys :opt-un [::default-field-resolver]))
 


### PR DESCRIPTION
Let's leave this as "defining functions as spec values is hard".  I believe what's going on is that clojure.spec is trying to create a function that returns a field resolver according to the fspec and that needs a library that isn't available at runtime. As with field resolvers and streamers, reducing the spec to just `fn?` fixes the problem.

When we're more comfortable w/ spec I'd like to revisit this; I believe it could be addressed by explicitly providing a generator as part of the spec.