### PR TITLE
Deep merge fragments/fields

### DIFF
--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -871,12 +871,16 @@
   "The selection key only applies to fields (not fragments) and
   consists of the field name or alias, and the arguments."
   [selection]
-  (let [{:keys [:selection-type :alias]} selection]
-    (if (= selection-type :field)
+  (let [{:keys [:selection-type :alias :concrete-types :fragment-name]} selection]
+    (case selection-type
+      :field
       alias
-      ;; TODO: This may be too simplified ... worried about loss of data when merging things together
-      ;; at runtime.
-      (gensym "fragment-"))))
+
+      :inline-fragment
+      (keyword (str "inline-fragment-" (str/join concrete-types "-")))
+
+      :fragment-spread
+      fragment-name)))
 
 (declare ^:private coalesce-selections)
 

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -872,12 +872,14 @@
   consists of the field name or alias, and the arguments."
   [selection]
   (let [{:keys [:selection-type :alias :concrete-types :fragment-name]} selection]
+    ;; TODO: This may be too simplified ... worried about loss of data when merging things together
+    ;; at runtime.
     (case selection-type
       :field
       alias
 
       :inline-fragment
-      (keyword (str "inline-fragment-" (str/join concrete-types "-")))
+      (keyword (str "inline-fragment-" (str/join "-" concrete-types)))
 
       :fragment-spread
       fragment-name)))

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -437,6 +437,8 @@
                ...on droid {
                  best_friend {
                    name
+                 }
+                 best_friend {
                    forceSide {
                      name
                    }
@@ -447,6 +449,56 @@
                    name
                  }
                }
+             }
+           }"]
+    (is (= {:data {:hero {:best_friend {:name "Luke Skywalker"
+                                        :forceSide {:name "light"}}}}}
+           (execute default-schema q {} nil))))
+  (let [q "query {
+             hero {
+               ...DroidWithBestFriendName
+               ...DroidWithBestFriendNameAndForceSide
+             }
+           }
+           fragment DroidWithBestFriendNameAndForceSide on droid {
+             best_friend {
+              name
+             }
+             best_friend {
+               forceSide {
+                 name
+               }
+             }
+           }
+
+           fragment DroidWithBestFriendName on droid {
+             best_friend {
+               name
+             }
+           }"]
+    (is (= {:data {:hero {:best_friend {:name "Luke Skywalker"
+                                        :forceSide {:name "light"}}}}}
+           (execute default-schema q {} nil))))
+  (let [q "query {
+             hero {
+               ...DroidWithBestFriendNameAndForceSide
+               ...DroidWithBestFriendName
+             }
+           }
+           fragment DroidWithBestFriendNameAndForceSide on droid {
+             best_friend {
+              name
+             }
+             best_friend {
+               forceSide {
+                 name
+               }
+             }
+           }
+
+           fragment DroidWithBestFriendName on droid {
+             best_friend {
+               name
              }
            }"]
     (is (= {:data {:hero {:best_friend {:name "Luke Skywalker"

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -45,8 +45,6 @@
     (is (= (json/write-str (lacinia/execute default-schema q {} nil))
            "{\"data\":{\"hero\":{\"appears_in\":[\"NEWHOPE\",\"EMPIRE\",\"JEDI\"],\"name\":\"R2-D2\",\"id\":\"2001\"}}}"))))
 
-
-
 (deftest mutation-query
   (let [q "mutation ($from : String, $to: String) { changeHeroName(from: $from, to: $to) { name } }"]
     (is (= {:data {:changeHeroName {:name "Solo"}}}
@@ -362,6 +360,46 @@
                           :appears_in [:NEWHOPE :EMPIRE :JEDI]}
                    :leia {:appears_in [:NEWHOPE :EMPIRE :JEDI]}}}
            (execute default-schema q nil nil))))
+  (let [q "query {
+             hero {
+               ...on droid {
+                 best_friend {
+                   name
+                 }
+               }
+               ...on droid {
+                 best_friend {
+                   name
+                   forceSide {
+                     name
+                   }
+                 }
+               }
+             }
+           }"]
+    (is (= {:data {:hero {:best_friend {:name "Luke Skywalker"
+                                        :forceSide {:name "light"}}}}}
+           (execute default-schema q {} nil))))
+  (let [q "query {
+             hero {
+               ...on droid {
+                 best_friend {
+                   name
+                   forceSide {
+                     name
+                   }
+                 }
+               }
+               ...on droid {
+                 best_friend {
+                   name
+                 }
+               }
+             }
+           }"]
+    (is (= {:data {:hero {:best_friend {:name "Luke Skywalker"
+                                        :forceSide {:name "light"}}}}}
+           (execute default-schema q {} nil))))
   (let [q "query InvalidInlineFragment {
              human(id: \"1001\") {
                ... on foo {

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -396,6 +396,7 @@
     (is (= {:data {:hero {:best_friend {:name "Luke Skywalker"
                                         :forceSide {:name "light"}}}}}
            (execute default-schema q {} nil))))
+  ;; FIXME: test below fails
   (let [q "query {
              hero {
                best_friend {
@@ -414,6 +415,7 @@
     (is (= {:data {:hero {:best_friend {:name "Luke Skywalker"
                                         :forceSide {:name "light"}}}}}
            (execute default-schema q {} nil))))
+  ;; FIXME: test below fails
   (let [q "query {
              hero {
                ...on droid {
@@ -479,6 +481,7 @@
     (is (= {:data {:hero {:best_friend {:name "Luke Skywalker"
                                         :forceSide {:name "light"}}}}}
            (execute default-schema q {} nil))))
+  ;; FIXME: test below fails
   (let [q "query {
              hero {
                ...DroidWithBestFriendNameAndForceSide

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -367,6 +367,22 @@
                    name
                  }
                }
+               best_friend {
+                 name
+                 forceSide {
+                   name
+                 }
+               }
+             }
+           }"]
+    (is (= {:data {:hero {:best_friend {:name "Luke Skywalker"
+                                        :forceSide {:name "light"}}}}}
+           (execute default-schema q {} nil))))
+  (let [q "query {
+             hero {
+               best_friend {
+                 name
+               }
                ...on droid {
                  best_friend {
                    name
@@ -374,6 +390,42 @@
                      name
                    }
                  }
+               }
+             }
+           }"]
+    (is (= {:data {:hero {:best_friend {:name "Luke Skywalker"
+                                        :forceSide {:name "light"}}}}}
+           (execute default-schema q {} nil))))
+  (let [q "query {
+             hero {
+               best_friend {
+                 name
+                 forceSide {
+                   name
+                 }
+               }
+               ...on droid {
+                 best_friend {
+                   name
+                 }
+               }
+             }
+           }"]
+    (is (= {:data {:hero {:best_friend {:name "Luke Skywalker"
+                                        :forceSide {:name "light"}}}}}
+           (execute default-schema q {} nil))))
+  (let [q "query {
+             hero {
+               ...on droid {
+                 best_friend {
+                   name
+                   forceSide {
+                     name
+                   }
+                 }
+               }
+               best_friend {
+                 name
                }
              }
            }"]


### PR DESCRIPTION
I've run into a few more problems with selections from several fragments which should be merged, but aren't. I've include a few tests that show the kind of cases we should be able to handle, and you can see they either pass or fail depending on the order of the fragments.

I've tried my hand at fixing the problem, and was able to merge selections for inline fragments on the same concrete-type, but even fragments on different types could run into this issue. And that still leaves out the problem of named fragments and merging between fragments and fields.

I won't be able to pursue this in the near future, so if the mantainers or anyone wants to take a shot at solving this, please do!