### PR TITLE
Fix bug (related to #114) that caused named operations to not work

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 0.22.1 -- UNRELEASED
+
+Fixes a bug that prevented operation names from working when a query
+defined only a single operation.
+
+[Closed Issues](https://github.com/walmartlabs/lacinia/milestone/10?closed=1)
+
 ## 0.22.0 -- 24 Oct 2017
 
 Previously, the reserved words 'query', 'mutation', and 'subscription'

--- a/dev-resources/com/walmartlabs/test_utils.clj
+++ b/dev-resources/com/walmartlabs/test_utils.clj
@@ -74,4 +74,6 @@
   ([compiled-schema query]
     (execute compiled-schema query nil nil))
   ([compiled-schema query vars context]
-    (simplify (lacinia/execute compiled-schema query vars context))))
+   (execute compiled-schema query vars context nil))
+  ([compiled-schema query vars context options]
+   (simplify (lacinia/execute compiled-schema query vars context options))))

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "0.22.0"
+(defproject com.walmartlabs/lacinia "0.23.0"
   :description "A GraphQL server implementation in Clojure"
   :license {:name "Apache, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}

--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -75,12 +75,17 @@
   context (optional)
   : Additional data that will ultimately be passed to resolver functions.
 
+  options (optional)
+  : The only option currently is `:operation-name`, used to identify which
+    operation to execute, when the query specifies more than one.
+
   This function parses the query and invokes [[execute-parsed-query]]."
   ([schema query variables context]
    (execute schema query variables context {}))
-  ([schema query variables context {:keys [operation-name] :as options}]
+  ([schema query variables context options]
    {:pre [(string? query)]}
-   (let [[parsed error-result] (try
+   (let [{:keys [operation-name]} options
+         [parsed error-result] (try
                                  [(parser/parse-query schema query operation-name)]
                                  (catch ExceptionInfo e
                                    [nil (as-errors e)]))]

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -51,6 +51,24 @@
                            (cond-> node
                              (-> arguments :if false?) (assoc :disabled? true)))}}))
 
+(defn ^:private name-string-from
+  "Converts a Parser node into a string. The node looks like
+  this:
+
+  [:name
+    [:nameid \"foo\"]]
+
+  OR
+
+  [:name
+    [:operationType [:'query' \"query\"]]]"
+  [node]
+  (let [inner (second node)
+        inner-type (first inner)]
+    (if (= :nameid inner-type)
+      (second inner)
+      (-> inner second second))))
+
 (defn ^:private name-from
   "Converts a Parser node into a keyword. The node looks like
   this:
@@ -63,12 +81,7 @@
   [:name
     [:operationType [:'query' \"query\"]]]"
   [node]
-  (let [inner (second node)
-        inner-type (first inner)
-        text (if (= :nameid inner-type)
-               (second inner)
-               (-> inner second second))]
-    (keyword text)))
+  (keyword (name-string-from node)))
 
 (declare ^:private xform-argument-map)
 
@@ -782,7 +795,7 @@
          operation-name
          (or (not (< 2 (count first-op)))
              (not= operation-name
-                   (-> first-op (nth 2) second))))
+                   (-> first-op (nth 2) name-string-from))))
 
     (throw-exception "Single operation did not provide a matching name."
                      {:op-name operation-name})

--- a/test/com/walmartlabs/lacinia/query_ops_test.clj
+++ b/test/com/walmartlabs/lacinia/query_ops_test.clj
@@ -1,0 +1,16 @@
+(ns com.walmartlabs.lacinia.query-ops-test
+  (:require
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.test-utils :refer [compile-schema execute]]
+    [com.walmartlabs.test-schema :refer [test-schema]]
+    [com.walmartlabs.lacinia.schema :as schema]))
+
+(def default-schema (schema/compile test-schema))
+
+(deftest may-identify-op-when-single-op
+  (is (= {:data {:human {:name "Han Solo"}}}
+         (execute default-schema
+                  "query solo($id: String!) { human(id: $id) { name } }"
+                  {:id "1002"}
+                  nil
+                  {:operation-name "solo"}))))


### PR DESCRIPTION
A trip up related to the code the ugly support for 'query' etc. as a operation/field/type name.