### PR TITLE
Change list type check to sequential? to allow syntax quoted list types

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "0.22.1"
+(defproject com.walmartlabs/lacinia "0.22.1-SNAPSHOT"
   :description "A GraphQL server implementation in Clojure"
   :license {:name "Apache, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -437,7 +437,7 @@
   ;; cheap: just use last.
   [type]
   (cond
-    (list? type)
+    (sequential? type)
     (let [[modifier next-type & anything-else] type
           kind (get {'list :list
                      'non-null :non-null} modifier)]


### PR DESCRIPTION
This change enables generating schema type definitions using syntax quoted lists like so:
```clojure
:queries
   (into {}
     (for [f [:one :two :three]]
       [f {:type `(~'list ~f)
           :resolve :generated-resolver}]))
```