### PR TITLE
Prevent an exception calling ex-info that can (rarely) occur because of nil ex-data

### DIFF
--- a/src/com/walmartlabs/lacinia/internal_utils.clj
+++ b/src/com/walmartlabs/lacinia/internal_utils.clj
@@ -136,7 +136,7 @@
    (throw-exception message data nil))
   ([message data cause]
    (throw (ex-info message
-                   (merge *exception-context* (ex-data cause) data)
+                   (merge {} *exception-context* (ex-data cause) data)
                    cause))))
 
 (defmacro with-exception-context


### PR DESCRIPTION
Clojure's `ExceptionInfo` constructor expects the data map passed to it to be non-null.  I encountered a situation where all the arguments to `merge` where `nil` which returns `nil`.  The actual Lacinia exception message is lost and you see  "Additional data must be non-nil."