### PR TITLE
Allow false to be used as a :default-value

### DIFF
--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -231,7 +231,7 @@
   [field-map]                                               ; also works with arguments
   (->> field-map
        (map-vals :default-value)
-       (filter-vals identity)))
+       (filter-vals some?)))
 
 (defn ^:private use-nested-type
   "Replaces the :type of the def with the nested type; this is used to strip off a


### PR DESCRIPTION
This PR resolves #143.

It changes the `com.walmartlabs.lacinia.parser/collect-default-values` method to filter out `:default-value` with the `some?` function instead of using the `identity` function.