### PR TITLE
Fix null check for dynamic arguments

### DIFF
--- a/dev-resources/nested-non-nullable-fields-schema.edn
+++ b/dev-resources/nested-non-nullable-fields-schema.edn
@@ -1,0 +1,11 @@
+{:input-objects
+ {:game_template
+  {:fields {:id {:type (non-null Int)}
+            :name {:type String}}}}
+
+ :mutations
+ {:create_game
+  {:type String
+   :args
+   {:game_data {:type :game_template}}
+   :resolve :mutation/create-game}}}

--- a/test/com/walmartlabs/input_objects_test.clj
+++ b/test/com/walmartlabs/input_objects_test.clj
@@ -1,0 +1,43 @@
+(ns com.walmartlabs.input-objects-test
+  (:require
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.test-utils :refer [compile-schema execute]]
+    ))
+
+(deftest null-checks-within-nullable-field
+  (let [schema (compile-schema "nested-non-nullable-fields-schema.edn"
+                               {:mutation/create-game (fn [_ args _]
+                                                        (pr-str args))})]
+    (is (= {:data {:create_game "{:game_data {:id 50, :name \"Whist\"}}"}}
+           (execute schema "mutation { create_game (game_data: {id: 50, name: \"Whist\"}) }")))
+
+    ;; It's OK to omit the game_data argument entirely
+    (is (= {:data {:create_game "nil"}}
+           (execute schema "mutation { create_game }")))
+
+    (is (= {:errors [{:argument :game_data
+                      :field :create_game
+                      :locations [{:column 9
+                                   :line 1}]
+                      :message "Exception applying arguments to field `create_game': For argument `game_data', no value provided for non-nullable key `id' of input object `game_template'."
+                      :missing-key :id
+                      :query-path []
+                      :required-keys [:id]
+                      :schema-type :game_template}]}
+           (execute schema "mutation { create_game (game_data: { name: \"Hearts\" }) }")))
+
+    ;; TODO: Missing some needed context from above
+
+    (is (= {:errors [{:argument :game_data
+                      :field :create_game
+                      :locations [{:column 29
+                                   :line 1}]
+                      :message "No value provided for non-nullable key `id' of input object `game_template'."
+                      :missing-key :id
+                      :query-path []
+                      :required-keys [:id]
+                      :schema-type :game_template}]}
+           (execute schema
+                    "mutation($g : game_template) { create_game(game_data: $g) }"
+                    {:g {:name "Backgammon"}}
+                    nil)))))

--- a/test/com/walmartlabs/lacinia/custom_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/custom_scalars_test.clj
@@ -134,9 +134,14 @@
                     {:asOf "2017-04-05"}
                     nil))
         "should return parsed and serialized value")
-    (is (= {:errors [{:message "Scalar value is not parsable as type `Date'.",
-                      :value "abc",
-                      :type-name :Date}]}
+    (is (= {:errors [{:argument :asOf
+                      :field :today
+                      :locations [{:column 20
+                                   :line 1}]
+                      :message "Scalar value is not parsable as type `Date'."
+                      :query-path []
+                      :type-name :Date
+                      :value "abc"}]}
            (execute schema "query ($asOf: Date) {
                               today(asOf: $asOf)
                             }"
@@ -192,7 +197,12 @@
                     {:between []}
                     nil))
         "should return empty list (:between can be an empty list) ")
-    (is (= {:errors [{:message "No value was provided for variable `between', which is non-nullable.",
+    (is (= {:errors [{:argument :between
+                      :field :sundays
+                      :locations [{:column 27
+                                   :line 1}]
+                      :message "No value was provided for variable `between', which is non-nullable."
+                      :query-path []
                       :variable-name :between}]}
            (execute schema "query ($between: [Date!]!) {
                               sundays(between: $between)
@@ -200,7 +210,12 @@
                     {:between nil}
                     nil))
         "should return an error")
-    (is (= {:errors [{:message "Variable `between' contains null members but supplies the value for a list that can't have any null members."
+    (is (= {:errors [{:argument :between
+                      :field :sundays
+                      :locations [{:column 27
+                                   :line 1}]
+                      :message "Variable `between' contains null members but supplies the value for a list that can't have any null members."
+                      :query-path []
                       :variable-name :between}]}
            (execute schema "query ($between: [Date!]!) {
                               sundays(between: $between)
@@ -208,7 +223,12 @@
                     {:between [nil]}
                     nil))
         "should return an error")
-    (is (= {:errors [{:message "Variable `between' contains null members but supplies the value for a list that can't have any null members."
+    (is (= {:errors [{:argument :between
+                      :field :sundays
+                      :locations [{:column 27
+                                   :line 1}]
+                      :message "Variable `between' contains null members but supplies the value for a list that can't have any null members."
+                      :query-path []
                       :variable-name :between}]}
            (execute schema "query ($between: [Date!]!) {
                               sundays(between: $between)
@@ -216,7 +236,12 @@
                     {:between ["2017-03-01" nil]}
                     nil))
         "should return an error")
-    (is (= {:errors [{:message "No value was provided for variable `between', which is non-nullable."
+    (is (= {:errors [{:argument :between
+                      :field :sundays
+                      :locations [{:column 27
+                                   :line 1}]
+                      :message "No value was provided for variable `between', which is non-nullable."
+                      :query-path []
                       :variable-name :between}]}
            (execute schema "query ($between: [Date!]!) {
                               sundays(between: $between)
@@ -240,7 +265,12 @@
                       {:words [[["foo" "bar"]]]}
                       nil))
           "should return nested list")
-      (is (= {:errors [{:message "Variable `words' doesn't contain the correct number of (nested) lists.",
+      (is (= {:errors [{:argument :words
+                        :field :shout
+                        :locations [{:column 33
+                                     :line 1}]
+                        :message "Variable `words' doesn't contain the correct number of (nested) lists."
+                        :query-path []
                         :variable-name :words}]}
              (execute schema "query ($words: [[[CustomType]]]) {
                               shout(words: $words)
@@ -275,7 +305,12 @@
                       {:words [[[nil]]]}
                       nil))
           "should return an error")
-      (is (= {:errors [{:message"Variable `words' doesn't contain the correct number of (nested) lists.",
+      (is (= {:errors [{:argument :words
+                        :field :shout
+                        :locations [{:column 33
+                                     :line 1}]
+                        :message "Variable `words' doesn't contain the correct number of (nested) lists."
+                        :query-path []
                         :variable-name :words}]}
              (execute schema "query ($words: [[[CustomType]]]) {
                               shout(words: $words)
@@ -299,7 +334,12 @@
                                                     :args {:words {:type '(list (list (list (non-null :CustomType))))}}
                                                     :resolve (fn [ctx args v]
                                                                (:words args))}}})]
-      (is (= {:errors [{:message "Variable `words' contains null members but supplies the value for a list that can't have any null members.",
+      (is (= {:errors [{:argument :words
+                        :field :shout
+                        :locations [{:column 34
+                                     :line 1}]
+                        :message "Variable `words' contains null members but supplies the value for a list that can't have any null members."
+                        :query-path []
                         :variable-name :words}]}
              (execute schema "query ($words: [[[CustomType!]]]) {
                               shout(words: $words)
@@ -307,7 +347,12 @@
                       {:words [[[nil]]]}
                       nil))
           "should return an error")
-      (is (= {:errors [{:message"Variable `words' doesn't contain the correct number of (nested) lists.",
+      (is (= {:errors [{:argument :words
+                        :field :shout
+                        :locations [{:column 34
+                                     :line 1}]
+                        :message "Variable `words' doesn't contain the correct number of (nested) lists."
+                        :query-path []
                         :variable-name :words}]}
              (execute schema "query ($words: [[[CustomType!]]]) {
                               shout(words: $words)

--- a/test/com/walmartlabs/lacinia/variables_test.clj
+++ b/test/com/walmartlabs/lacinia/variables_test.clj
@@ -57,7 +57,12 @@
   (execute vars-schema q vars nil))
 
 (deftest int-rejects-non-integer-value
-  (is (= {:errors [{:message "Invalid Int value."
+  (is (= {:errors [{:argument :int
+                    :field :root
+                    :locations [{:column 21
+                                 :line 1}]
+                    :message "Invalid Int value."
+                    :query-path []
                     :type-name :Int
                     :value "42.0"}]}
          (query "query ($IntVar: Int) { root (int: $IntVar) { int }}"

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -220,7 +220,12 @@
            (execute default-schema q {:someId luke-id} nil)))
     (is (= {:data {:human {:name "Han Solo"}}}
            (execute default-schema q {:someId han-id} nil)))
-    (is (= {:errors [{:message "No value was provided for variable `someId', which is non-nullable."
+    (is (= {:errors [{:argument :id
+                      :field :human
+                      :locations [{:column 41
+                                   :line 1}]
+                      :message "No value was provided for variable `someId', which is non-nullable."
+                      :query-path []
                       :variable-name :someId}]}
            (execute default-schema q {} nil)))))
 


### PR DESCRIPTION
Capture exception context at parse time for use with dynamic arguments
(from query variables)

Fixes #133