### PR TITLE
manually check compile args against spec

### DIFF
--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1216,11 +1216,10 @@
   ([schema options]
    ;; This is based on clojure.spec's assert, but is always on
    ;; the single branch alt adds :args to the explain path as expected in tests
-   (when-not (s/valid? ::compile-args [schema options])
-     (let [ed (s/explain-data ::compile-args [schema options])]
-       (throw (ex-info
-               (str "Spec assertion failed\n" (with-out-str (s/explain-out ed)))
-               ed))))
+   (when-let [ed (s/explain-data ::compile-args [schema options])]
+     (throw (ex-info
+             (str "Arguments to compile do not conform to spec:\n" (with-out-str (s/explain-out ed)))
+             ed)))
    (let [options' (merge default-compile-opts options)
          introspection-schema (introspection/introspection-schema)]
      (-> schema

--- a/test/com/walmartlabs/lacinia/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/schema_test.clj
@@ -135,8 +135,7 @@
                                 :Event
                                 1
                                 :parse]
-                           :path [:args
-                                  :schema
+                           :path [:schema
                                   :scalars
                                   1
                                   :parse]}
@@ -163,7 +162,7 @@
 (deftest enum-values-must-be-valid-ids
   (is-compile-exception
     {:enums {:episode {:values [:new-hope :empire :return-of-jedi]}}}
-    "[:keyword :new-hope] fails spec: :com.walmartlabs.lacinia.schema/enum-value at: [:args :schema :enums 1 :values :bare-value] predicate: graphql-identifier?"))
+    "[:keyword :new-hope] fails spec: :com.walmartlabs.lacinia.schema/enum-value at: [:schema :enums 1 :values :bare-value] predicate: graphql-identifier?"))
 
 (deftest requires-resolve-on-operation
   (is-compile-exception


### PR DESCRIPTION
This change stops lacinia from turnning on spec assert checking globally
and manully checks the compile-args spec when compile is called.