### PR TITLE
Tutorial: "Initial Schema"; console output shows a call to `(start)` that is not needed, will not work

### DIFF
--- a/docs/tutorial/init-schema.rst
+++ b/docs/tutorial/init-schema.rst
@@ -138,9 +138,7 @@ With all that in place, we can launch a REPL and try it out::
    Javadoc: (javadoc java-object-or-class-here)
       Exit: Control+D or (exit) or (quit)
    Results: Stored in vars *1, *2, *3, an exception in *e
-
-  user=> (start)
-  :started
+ 
   
   user=> (q "{ game_by_id(id: \"foo\") { id name summary }}")
   {:data #ordered/map ([:game_by_id nil])}


### PR DESCRIPTION
(start) is not working right here.

user=> (start)

CompilerException java.lang.RuntimeException: Unable to resolve symbol: start in this context, compiling:(/tmp/form-init7979298612564961133.clj:1:1)