### PR TITLE
Change the pr and pprint behavior for a compiled schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 It is now possible to mark fields (including operations) and enum values
 as deprecated.
 
+Compiled schemas now print and pretty-print as `#CompiledSchema<>`.
+
 ## 0.24.0 -- 30 Jan 2018
 
 Added the FieldResolver protocol that allows a Clojure record, such as a

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -19,9 +19,11 @@
     [clojure.string :as str]
     [clojure.set :refer [difference]]
     [clojure.spec.test.alpha :as stest]
-    [com.walmartlabs.lacinia.resolve :as resolve])
+    [com.walmartlabs.lacinia.resolve :as resolve]
+    [clojure.pprint :as pprint])
   (:import
-    (clojure.lang IObj)))
+    (clojure.lang IObj)
+    (java.io Writer)))
 
 ;; When using Clojure 1.9 alpha, the dependency on clojure-future-spec can be excluded,
 ;; and this code will not trigger; any? will come out of clojure.core as normal.
@@ -1137,6 +1139,8 @@
   (fn [_ _ value]
     (resolve-as value)))
 
+(defrecord CompiledSchema [])
+
 (defn ^:private construct-compiled-schema
   [schema options]
   ;; Note: using merge, not two calls to xfer-types, since want to allow
@@ -1150,10 +1154,10 @@
                                                   %)))]
     (-> {constants/query-root {:category :object
                                :type-name constants/query-root
-                                 :description "Root of all queries."}
+                               :description "Root of all queries."}
          constants/mutation-root {:category :object
                                   :type-name constants/mutation-root
-                                   :description "Root of all mutations."}
+                                  :description "Root of all mutations."}
          constants/subscription-root {:category :object
                                       :type-name constants/subscription-root
                                       :description "Root of all subscriptions."}}
@@ -1172,7 +1176,8 @@
               (map-vals #(compile-type % s) s))
         (prepare-and-validate-interfaces)
         (prepare-and-validate-objects :object options)
-        (prepare-and-validate-objects :input-object options))))
+        (prepare-and-validate-objects :input-object options)
+        map->CompiledSchema)))
 
 (defn default-field-resolver
   "The default for the :default-field-resolver option, this uses the field name as the key into
@@ -1234,3 +1239,28 @@
 ;; difficult to trace exceptions at runtime.
 
 (stest/instrument `compile)
+
+;; The compiled schema tends to be huge and unreadable. It clutters exception output.
+;; The following defmethods reduce its output to a stub.
+
+(def ^{:dynamic true
+       :added "0.25.0"} *verbose-schema-printing*
+  "If bound to true, then the compiled schema prints and pretty-prints like an ordinary map,
+  which is sometimes useful during development. When false (the default) the schema
+  output is just a placeholder."
+  false)
+
+(defmethod print-method CompiledSchema
+  [schema ^Writer w]
+  (if *verbose-schema-printing*
+    (print-method (into {} schema) w)
+    (.write w "#CompiledSchema<>")))
+
+(defmethod pprint/simple-dispatch CompiledSchema
+  [schema]
+  (if *verbose-schema-printing*
+    (pprint/simple-dispatch (into {} schema))
+    (pr schema)))
+
+
+

--- a/test/com/walmartlabs/lacinia/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/schema_test.clj
@@ -7,7 +7,8 @@
     [com.walmartlabs.lacinia.executor :as executor]
     [com.walmartlabs.lacinia.util :as util]
     [com.walmartlabs.test-utils :refer [is-thrown]]
-    [clojure.string :as str]))
+    [clojure.string :as str]
+    [clojure.pprint :as pprint]))
 
 (defmacro is-error?
   [form]
@@ -97,6 +98,22 @@
         (util/attach-resolvers
           schema-generated-lists
           {:schema-generated-resolver schema-generated-resolver}))))
+
+(deftest printing-support
+  (let [compiled-schema (schema/compile {})
+        as-map (into {} compiled-schema)]
+    (is (= "#CompiledSchema<>"
+           (pr-str compiled-schema)))
+
+    (is (= "#CompiledSchema<>"
+           (pprint/write compiled-schema :stream nil)))
+
+    (binding [schema/*verbose-schema-printing* true]
+      (is (= (pr-str as-map)
+             (pr-str compiled-schema)))
+
+      (is (= (pprint/write as-map :stream nil)
+             (pprint/write compiled-schema :stream nil))))))
 
 (deftest custom-scalars
   []


### PR DESCRIPTION
I've found that the incredibly verbose output when pr or pprint a compiled schema tends to overwhelm whatever debugging I'm doing.