### PR TITLE
Make it possible to define operations as fields of explicit root objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 0.26.0 -- UNRELEASED
+
+Lacinia now supports the `:roots` key in the input schema, which makes
+it possible to define query, mutation, or subscription operations
+in terms of the fields of an explicitly named object in the schema.
+This aligns Lacinia better with other implementations of GraphQL.
+
 ## 0.25.0 -- 2 Mar 2018
 
 Enum validation has changed: field resolvers may now return

--- a/dev-resources/root-object-schema.edn
+++ b/dev-resources/root-object-schema.edn
@@ -1,0 +1,10 @@
+{:queries
+ {:fred {:type String
+         :resolve :queries/fred}}
+ :objects
+ {:Barney
+  {:fields
+   {:last_name {:type String
+                :resolve :Barney/last-name}}}}
+
+ :roots {:query :Barney}}

--- a/dev-resources/root-object-with-conflicts-schema.edn
+++ b/dev-resources/root-object-with-conflicts-schema.edn
@@ -1,0 +1,10 @@
+{:queries
+ {:last_name {:type String
+              :resolve :queries/fred}}
+ :objects
+ {:Barney
+  {:fields
+   {:last_name {:type String
+                :resolve :Barney/last-name}}}}
+
+ :roots {:query :Barney}}

--- a/dev-resources/union-query-root-schema.edn
+++ b/dev-resources/union-query-root-schema.edn
@@ -1,0 +1,19 @@
+{:queries
+ {:version {:type String
+            :resolve :queries/version}}
+
+ :objects
+ {:Barney
+  {:fields
+   {:last_name {:type String
+                :resolve :Barney/last-name}}}
+
+  :Fred
+  {:fields
+   {:family_name {:type String
+                  :resolve :Fred/family-name}}}}
+
+ :unions
+ {:Queries {:members [:Fred :Barney]}}
+
+ :roots {:query :Queries}}

--- a/docs/_examples/parsed_sample_schema.edn
+++ b/docs/_examples/parsed_sample_schema.edn
@@ -1,6 +1,7 @@
 {:objects
  {:Character {:fields
-              {:name {:type (non-null String) :description "Character name"}
+              {:name {:type (non-null String)
+                      :description "Character name"}
                :episodes {:type (list :episode)}}
               :description "A Star Wars character"}
   :Query {:fields
@@ -25,16 +26,6 @@
  :enums
  {:episode {:values [:NEWHOPE :EMPIRE :JEDI]}}
 
- :queries
- {:find_all_in_episode {:type (list :Character)
-                        :args
-                        {:episode
-                         {:type (non-null :episode)
-                          :description "Episode for which to find characters."}}
-                        :resolve :find-all-in-episode
-                        :description "Find all characters in the given episode"}}
-
- :mutations
- {:add_character {:type Boolean
-                  :args {:character {:type (non-null :CharacterArg)}}
-                  :resolve :add-character}}}
+ :roots
+ {:query :Query
+  :mutation :Mutation}}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,9 +3,7 @@ Lacinia - GraphQL for Clojure
 
 Lacinia is a library for implementing
 Facebook's
-`GraphQL <https://facebook.github.io/react/blog/2015/05/01/graphql-introduction.html>`_
-specification in idiomatic
-`Clojure <http://clojure.org>`_.
+`GraphQL <https://graphql.org/>`_ specification in idiomatic `Clojure <http://clojure.org>`_.
 
 GraphQL is a way for clients to efficiently obtain data from servers.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ responding with JSON, it is also exceptionally useful for allowing backend syste
    resolve/index
    input-objects
    custom-scalars
+   roots
    introspection
    schema/parsing
    samples

--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -11,7 +11,8 @@ indicates the new state; this value will be recursively resolved and selected, j
 a query.
 
 Mutations are defined in the schema using the top-level ``:mutations`` key.
-Each mutation becomes a field of the special ``:MutationRoot`` object.
+
+Mutations may also be defined as fields of the :doc:`root mutation object <roots>`.
 
 When a single query includes more than one mutation, the mutations *must* execute in the client-specified
 order.

--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -16,7 +16,7 @@ Queries are defined using the ``:queries`` key of the schema.
 .. literalinclude:: _examples/query-def.edn
    :language: clojure
 
-Internally, each query becomes a field of a special object named ``:QueryRoot``.
+Queries may also be defined as fields of the :doc:`root query object <roots>`.
 
 The :doc:`field resolver <resolve/index>` for a query is passed nil
 as the the value (the third parameter).

--- a/docs/roots.rst
+++ b/docs/roots.rst
@@ -1,0 +1,46 @@
+Root Object Names
+=================
+
+Top-level query, mutation, and subscription operations are represented in Lacinia as fields on
+special objects.
+These objects are the "operation root objects".
+The default names of these objects are ``QueryRoot``, ``MutationRoot``, and ``SubscriptionRoot``.
+
+When compiling an input schema, these objects will be created if they do not already exist.
+
+The ``:roots`` key of the input schema is used to override the default names. Inside ``:roots``, you
+may specify keys ``:query``, ``:mutation``, or ``:subscription``, with the value being the name of the
+corresponding object.
+
+If the objects already exist, then
+any fields on the objects are automatically available operations.
+In the larger GraphQL world (beyond Lacinia), this is the typical way of defining operations.
+
+Beyond that, the operations from the ``:queries``, etc. map of the input schema will be
+merged into the fields of the corresponding root object.
+
+Name collisions are not allowed; a schema compile exception is thrown if an operation (via ``:queries``, etc.)
+conflicts with a field of the corresponding root object.
+
+Unions
+------
+
+It is allowed for the root type to be a union.
+This can be a handy way to organize many different operations.
+
+In this case, Lacinia creates a new object
+and merges the fields of the members of the union, along with any operations from the input schema.
+
+Again, the field names must not conflict.
+
+The new object becomes the root operation object.
+
+Internal Names
+--------------
+
+In some cases, you may see error messages that refer to fields in the
+``:__Queries``, ``:__Mutations``, or ``:__Subscriptions``
+objects.
+Internally, Lacinia constructs these objects, building ``:__Queries`` from the ``:queries`` map
+(and so forth).
+The fields may then be merged from these internal objects into the actual operation root objects.

--- a/docs/schema/parsing.rst
+++ b/docs/schema/parsing.rst
@@ -55,9 +55,13 @@ Example
    :name: return-value
    :language: clojure
 
-.. note::
-  The GraphQL SDL represents queries, mutations and subscriptions as types,
-  and Lacinia represents them as fields on ``:queries``, ``:mutations``, and
-  ``:subscriptions``. The Lacinia schema will retain the original types under
-  ``:objects``, which may be unused unless other parts of your schema definition
-  reference those types.
+The ``:documentation`` key uses a naming convention on the keys which become paths into the Lacinia input schema.
+``:Character/name`` applies to the ``name`` field of the ``Character`` object.
+``:Query.find_all_in_episode/episode`` applies to the ``episode`` argument, inside the ``find_all_in_episode`` field
+of the ``Query`` object.
+
+As is normal with SDL, the available queries, mutations, and subscriptions (not shown in this example)
+are defined on ordinary schema objects, and the ``schema`` element identifies which objects are used for
+which purposes.
+
+The ``:roots`` map inside the Lacinia schema is equivalent to the ``schema`` element in the SDL.

--- a/docs/subscriptions/overview.rst
+++ b/docs/subscriptions/overview.rst
@@ -26,5 +26,7 @@ the `web tier <https://github.com/walmartlabs/lacinia-pedestal>`_.
   This cleanup function typically stops whatever process was started earlier.
 
 Subscriptions are operations, like queries or mutations.
-They are defined using the top-level ``:subscriptions`` key in the schema.
+They are defined using the top-level ``:subscriptions`` key in the schema,
+or as fields of the :doc:`root subscription object <../roots>`.
+
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "0.25.0"
+(defproject com.walmartlabs/lacinia "0.26.0 "
   :description "A GraphQL server implementation in Clojure"
   :license {:name "Apache, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}

--- a/src/com/walmartlabs/lacinia/constants.clj
+++ b/src/com/walmartlabs/lacinia/constants.clj
@@ -1,14 +1,6 @@
 (ns ^:no-doc com.walmartlabs.lacinia.constants
   "A handy place to define namespaced constants")
 
-(def mutation-root
-  "Object in the compiled schema that contains, as fields, all mutations."
-  :MutationRoot)
-
-(def ^{:added "0.19.0"} subscription-root
-  "Object in the compiled schema that contains, as fields, all subscriptions."
-  :SubscriptionRoot)
-
 (def schema-key
   "Context key storing the compiled schema."
   ::schema)

--- a/src/com/walmartlabs/lacinia/constants.clj
+++ b/src/com/walmartlabs/lacinia/constants.clj
@@ -1,10 +1,6 @@
 (ns ^:no-doc com.walmartlabs.lacinia.constants
   "A handy place to define namespaced constants")
 
-(def query-root
-  "Object in the compiled schema that contains, as fields, all queries."
-  :QueryRoot)
-
 (def mutation-root
   "Object in the compiled schema that contains, as fields, all mutations."
   :MutationRoot)

--- a/src/com/walmartlabs/lacinia/internal_utils.clj
+++ b/src/com/walmartlabs/lacinia/internal_utils.clj
@@ -120,9 +120,10 @@
   (or (sequential? x) (set? x)))
 
 (defn is-internal-type-name?
-  "Identifies type names that are added by introspection."
+  "Identifies type names that are added by introspection, or a namespaced key used by Lacinia."
   [type-name]
-  (str/starts-with? (name type-name) "__"))
+  (or (namespace type-name)
+      (str/starts-with? (name type-name) "__")))
 
 (def ^:dynamic *exception-context*
   "Map of extra values to be added to the exception data when an exception is created."

--- a/src/com/walmartlabs/lacinia/introspection.clj
+++ b/src/com/walmartlabs/lacinia/introspection.clj
@@ -88,15 +88,16 @@
   [context _ _]
   (let [schema (get context constants/schema-key)
         type-names (remove is-internal-type-name? (keys schema))
-        queries-root (-> (get schema constants/query-root)
+        root (:com.walmartlabs.lacinia.schema/roots schema)
+        queries-root (-> (get schema (:query root))
                          (update :fields #(remove-keys is-internal-type-name? %)))
-        mutations-root (get schema constants/mutation-root)
+        mutations-root (get schema (:mutation root))
         omit-mutations (-> mutations-root :fields empty?)
-        subs-root (get schema constants/subscription-root)
+        subs-root (get schema (:subscription root))
         omit-subs (-> subs-root :fields empty?)
         type-names' (cond-> (set type-names)
-                      omit-mutations (disj constants/mutation-root)
-                      omit-subs (disj constants/subscription-root))
+                      omit-mutations (disj (:mutation root))
+                      omit-subs (disj (:subscription root)))
         not-null-boolean {:kind :non-null
                           :type {:kind :root
                                  :type :Boolean}}]

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -1130,30 +1130,10 @@
           (map #(compose-variable-definition schema %)
                (rest var-definitions)))))
 
-
-;; Ultimately, this needs to be done once and cached, perhaps by the schema compiler itself.
-
 (defn ^:private operation-type->root
   [schema operation-type]
-  (let [type-name (get-in schema [::schema/roots operation-type])
-        root-def (get schema type-name)]
-    (case (:category root-def)
-
-      :object
-      root-def
-
-      (:union :interface)
-      {:category :object
-       :type-name (keyword (str "__" (name operation-type)))
-       :fields (let [x (->> root-def
-                            :members
-                            (map #(get schema %))
-                            (map :fields)
-                            (reduce merge))]
-                 x)})))
-
-(defn ^:private root-selection
-  [schema x root])
+  (let [type-name (get-in schema [::schema/roots operation-type])]
+    (get schema type-name)))
 
 (defn ^:private xform-query
   "Given an output tree of sexps from clj-antlr, traverses and reforms into a

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -1129,10 +1129,10 @@
                (rest var-definitions)))))
 
 
-(def ^:private operation-type->root
-  {:query constants/query-root
-   :mutation constants/mutation-root
-   :subscription constants/subscription-root})
+(defn ^:private operation-type->root
+  [schema operation-type]
+  (let [type-name (get-in schema [::schema/roots operation-type])]
+    (get schema type-name)))
 
 (defn ^:private xform-query
   "Given an output tree of sexps from clj-antlr, traverses and reforms into a
@@ -1149,9 +1149,7 @@
                                   (-> op-element second second keyword))
                              :query))
 
-        root (->> operation-type
-                  operation-type->root
-                  (get schema))
+        root (operation-type->root schema operation-type)
 
         variable-definitions (extract-variable-definitions schema operation)
 

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1147,7 +1147,7 @@
           :fields fields}))
 
 (defn ^:private merge-root
-  "Used after the compile-type stage, to merge together the root objects, once possibly provided
+  "Used after the compile-type stage, to merge together the root objects, one possibly provided
   via the input schema :roots map, and the other built from the :queries, :mutations, or :subscriptions
   maps (the 'extra object').
 

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1267,8 +1267,6 @@
   (s/cat :schema ::schema-object
          :options (s/? (s/nilable ::compile-options))))
 
-(s/fdef compile :args ::compile-args)
-
 (defn compile
   "Compiles an schema, verifies its correctness, and prepares it for query execution.
   The compiled schema is in an entirely different format than the input schema.

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1159,10 +1159,10 @@
         merge-into (fn [fields more-fields]
                      (reduce-kv (fn [m k v]
                                   (when (contains? m k)
-                                    (throw (ex-info (format "Name collision compiling schema. %s %s conflicts with one defined in type %s."
+                                    (throw (ex-info (format "Name collision compiling schema. %s %s conflicts with %s."
                                                             (-> root-name name str/capitalize)
-                                                            (q k)
-                                                            (q (get-in fields [k :containing-type-name])))
+                                                            (q (:qualified-field-name v))
+                                                            (q (get-in m [k :qualified-field-name])))
                                                     {:field-name k
                                                      :operation root-name})))
                                   (assoc m k v))

--- a/test/com/walmartlabs/lacinia/arguments_test.clj
+++ b/test/com/walmartlabs/lacinia/arguments_test.clj
@@ -9,10 +9,10 @@
   (when-let [e (is (thrown? ExceptionInfo
                             (compile-schema "unknown-argument-type-schema.edn"
                                             {:example identity})))]
-    (is (= "Argument `id' of field `QueryRoot/example' references unknown type `UUID'."
+    (is (= "Argument `id' of field `__Queries/example' references unknown type `UUID'."
            (.getMessage e)))
     (is (= {:arg-name :id
-            :field-name :QueryRoot/example
+            :field-name :__Queries/example
             :schema-types {:object [:MutationRoot
                                     :QueryRoot
                                     :SubscriptionRoot]

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -85,23 +85,9 @@
                         :Subscription {:fields {:new_character {:args {:episodes {:type '(non-null (list (non-null :episode)))}}
                                                                 :stream new-character
                                                                 :type :CharacterOutput}}}}
-              :queries {:in_episode {:args {:episode {:type :episode
-                                                      :defaultValue :NEWHOPE
-                                                      :description "Episode for which to find characters"}}
-                                     :description "Find all characters for a given episode"
-                                     :resolve in-episode
-                                     :type '(list :CharacterOutput)}
-                        :find_by_names {:args {:names {:type '(non-null (list (non-null String)))}}
-                                        :resolve find-by-names
-                                        :type '(list :CharacterOutput)}}
-              :mutations {:add {:args {:character {:type :Character
-                                                   :defaultValue {:name "Unspecified"
-                                                                  :episodes [:NEWHOPE :EMPIRE :JEDI]}}}
-                                :resolve add
-                                :type 'Boolean}}
-              :subscriptions {:new_character {:args {:episodes {:type '(non-null (list (non-null :episode)))}}
-                                              :stream new-character
-                                              :type :CharacterOutput}} }
+              :roots {:mutation :Mutation
+                      :query :Queries
+                      :subscription :Subscription}}
              parsed-schema)))
     (testing "using parsed schema"
       (let [compiled (schema/compile parsed-schema)]

--- a/test/com/walmartlabs/lacinia/roots_test.clj
+++ b/test/com/walmartlabs/lacinia/roots_test.clj
@@ -1,0 +1,69 @@
+(ns com.walmartlabs.lacinia.roots-test
+  "Tests related to specifying  operation root object names."
+  (:require
+    com.walmartlabs.lacinia.parser
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.lacinia.schema :as schema]
+    [com.walmartlabs.test-utils :refer [execute compile-schema]]))
+
+(deftest default-root-name
+  (let [schema (schema/compile {})]
+    (is (= {:data {:__schema {:queryType {:name "QueryRoot"}}}}
+           (execute schema "{__schema { queryType { name } } }")))))
+
+(deftest can-specify-root-name
+  (let [schema (schema/compile {:roots {:query :MyQueries}})]
+    (is (= {:data {:__schema {:queryType {:name "MyQueries"}}}}
+           (execute schema "{__schema { queryType { name } } }")))))
+
+(deftest root-object-may-contain-fields
+  (let [schema (compile-schema "root-object-schema.edn"
+                               {:queries/fred (constantly "Flintstone")
+                                :Barney/last-name (constantly "Rubble")})]
+    (is (= {:data {:barney "Rubble"
+                   :fred "Flintstone"}}
+           (execute schema "{
+             fred
+             barney: last_name
+           }")
+           ))))
+
+(deftest name-collisions-are-detected
+  (try
+    (compile-schema "root-object-with-conflicts-schema.edn"
+                    {:queries/fred (constantly "Flintstone")
+                     :Barney/last-name (constantly "Rubble")})
+    (is false "should be unreachable")
+    (catch Throwable e
+      (is (= "Name collision compiling schema. Query `__Queries/last_name' conflicts with `Barney/last_name'."
+             (.getMessage e)))
+      (is (= {:field-name :last_name
+              :operation :query}
+             (ex-data e))))))
+
+(deftest root-is-a-union
+  (let [schema (compile-schema "union-query-root-schema.edn"
+                               {:queries/version (constantly "1.0")
+                                :Fred/family-name (constantly "Flintstone")
+                                :Barney/last-name (constantly "Rubble")})]
+
+    ;; Member objects' fields are merged into __Queries along with extras.
+
+    (is (= {:data {:__schema {:queryType {:name "__Queries"}}}}
+           (execute schema "{__schema { queryType { name } } }")))
+
+    (is (= ["family_name"
+            "last_name"
+            "version"]
+           (->> (execute schema "{__type(name: \"__Queries\") { fields { name }}}")
+                :data :__type :fields
+                (mapv :name))))
+
+    (is (= {:data {:barney "Rubble"
+                   :fred "Flintstone"
+                   :version "1.0"}}
+           (execute schema
+                    "{ version
+                       fred: family_name
+                       barney: last_name
+                    }")))))

--- a/test/com/walmartlabs/lacinia/validator_test.clj
+++ b/test/com/walmartlabs/lacinia/validator_test.clj
@@ -378,8 +378,8 @@
                        (schema/compile {:queries {:unknown_type {:type :not_defined
                                                                  :resolve identity}}})))
         data (ex-data e)]
-    (is (= "Field `QueryRoot/unknown_type' references unknown type `not_defined'." (.getMessage e)))
-    (is (= {:field-name :QueryRoot/unknown_type
+    (is (= "Field `__Queries/unknown_type' references unknown type `not_defined'." (.getMessage e)))
+    (is (= {:field-name :__Queries/unknown_type
             :schema-types {:object [:MutationRoot
                                     :QueryRoot
                                     :SubscriptionRoot]


### PR DESCRIPTION
Other GraphQL implementations always define operations in terms of root objects; we're coming into this from an odd angle.

In any case, this also supports a root object actually being a union, in which case we merge together all the fields of all the members.

This simplifies the SDL parsing logic, as it can shift a lot of work to schema/compile, which includes new checks that the SDL code did not make (the check for conflicting names).

The merging of fields purposely leaves the `:qualified-field-name` unchanged, so you might end up with `:__Queries/foo` mixed in with `:QueryRoot/bar` & etc. I think this means that any errors reported (or exceptions thrown) involving such operations will be easier to interpret.  Check out the new and changed tests for examples.