### PR TITLE
Add summarize-query function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+
+New `com.walmartlabs.lacinia.parser/summarize-query` function,
+which is used to summarize a query without distractions such as
+aliases and field arguments. This is used to group similar
+queries together when doing performance analysis.
+
 ## 0.25.0 -- 2 Mar 2018
 
 Enum validation has changed: field resolvers may now return

--- a/dev-resources/summarize-schema.edn
+++ b/dev-resources/summarize-schema.edn
@@ -1,0 +1,36 @@
+{:objects
+ {:Toy
+  {:fields {:name {:type String}
+            :packaging {:type :Packaging}
+            :aisle {:type Int}}}
+  :Truck
+  {:fields {:model {:type String}
+            :dealership {:type Dealership}
+            :cost {:type Int}}}
+
+  :Dealership
+  {:fields {:name {:type String}
+            :address {:type String}
+            :city {:type String}
+            :state {:type String}
+            :postal_code {:type String}}}}
+
+ :enums
+ {:Packaging
+  {:values [plastic cardboard mixed]}}
+
+ :unions
+ {:Product {:members [:Toy :Truck]}}
+
+ :queries
+ {:toy_by_name {:type Toy
+                :resolve :placeholder
+                :args {:name {:type String}}}
+
+  :truck_by_model {:type Truck
+                   :resolve :placeholder
+                   :args {:model {:type String}}}
+
+  :product_by_string {:type Product
+                      :resolve :placeholder
+                      :args {:match {:type String}}}}}

--- a/test/com/walmartlabs/lacinia/summarize_query_tests.clj
+++ b/test/com/walmartlabs/lacinia/summarize_query_tests.clj
@@ -1,0 +1,53 @@
+(ns com.walmartlabs.lacinia.summarize-query-tests
+  (:require
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.test-utils :refer [compile-schema]]
+    [com.walmartlabs.lacinia.parser :as parser]))
+
+(def ^:private schema (compile-schema "summarize-schema.edn" {:placeholder (constantly nil)}))
+
+(defn ^:private s
+  [q]
+  (-> (parser/parse-query schema q)
+      parser/summarize-query))
+
+(deftest simple-field-names-are-alphabetical
+  (is (= "{toy_by_name {aisle name packaging}}"
+         (s "{ toy_by_name(name: \"Frisbee\") { name packaging aisle } }")
+         )))
+
+(deftest inline-fragments
+  (is (= "{product_by_string {__typename aisle cost dealership {city state} model name packaging}}"
+         (s "{ product_by_string {
+             type: __typename
+             ... on Toy { name packaging aisle }
+             ... on Truck { model dealership { city state } cost }
+           }
+         }"))))
+
+(deftest named-fragments
+  (is (= "{product_by_string {__typename aisle cost dealership {city postal_code state} model name packaging}}"
+         (s "query { product_by_string {
+             type: __typename
+             ... ToyData
+             ... TruckData
+           }
+         }
+
+         fragment ToyData on Toy { name packaging aisle }
+         fragment TruckData on Truck { model dealership { city state postal_code } cost }
+
+         "))))
+
+(deftest multiple-operations
+  (is (= "{toy_by_name {name} truck_by_model {model}}"
+         (s "{ toy: toy_by_name { name }
+               truck: truck_by_model { model }
+             }"))))
+
+(deftest multiple-of-same-operation
+  (is (= "{toy_by_name {aisle} toy_by_name {name} toy_by_name {packaging}}"
+         (s "{ car: toy_by_name { name }
+               lego: toy_by_name { packaging }
+               doll: toy_by_name { aisle }
+             }"))))


### PR DESCRIPTION
This code takes a parsed query and converts it to a uniform summary. The summary excludes directives, aliases, and field arguments and "inlines" fragments, and sorts everything alphabetically.
 
The resulting summary can act as a fingerprint for a range of similar queries that should have similar or identical processing.
At Walmart, we hash the summary and track summary-hash vs. execution time; this gives us insight into which queries are most expensive, and we work backwards from the hash to the actual summary and queries as well as the API key identifying the origin of the query.

Reviewers: This is the same as the summarize code used at Walmart, with improvements to handling of fragments.