### PR TITLE
Tutorial: call to non-existing start function removed

### DIFF
--- a/docs/tutorial/init-schema.rst
+++ b/docs/tutorial/init-schema.rst
@@ -138,9 +138,6 @@ With all that in place, we can launch a REPL and try it out::
    Javadoc: (javadoc java-object-or-class-here)
       Exit: Control+D or (exit) or (quit)
    Results: Stored in vars *1, *2, *3, an exception in *e
-
-  user=> (start)
-  :started
   
   user=> (q "{ game_by_id(id: \"foo\") { id name summary }}")
   {:data #ordered/map ([:game_by_id nil])}


### PR DESCRIPTION
When following the tutorial, the start function does not exist yet, nor is it necessary to run the query.