### PR TITLE
Changes and improvements to how SDL schema documentation is attached

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 0.27.0 -- UNRELEASED
+
+A change to how GraphQL schema documentation is attached.
+Previously, arguments were refered to as `:MyType.my_field/arg_name`
+but with this release, we've change it to `:MyType/my_field.arg_name`.
+
 ## 0.26.0 -- 20 Apr 2018
 
 Lacinia now supports the `:roots` key in the input schema, which makes
@@ -45,7 +51,7 @@ Added the FieldResolver protocol that allows a Clojure record, such as a
 
 Field resolvers for enum types are now required to return a keyword, and that
 keyword must match one of the values defined for the enum.
-Previously, Lacinia failed to peform any checks in this case, which could result
+Previously, Lacinia failed to perform any checks in this case, which could result
 in invalid data present in the result map.
 
 [Closed Issues](https://github.com/walmartlabs/lacinia/milestone/12?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ A change to how GraphQL schema documentation is attached.
 Previously, arguments were refered to as `:MyType.my_field/arg_name`
 but with this release, we've change it to `:MyType/my_field.arg_name`.
 
+It is now possible, when parsing a schema from SDL, to document interfaces, enums, and unions.
+Previously, only objects and input objects could be documented.
+
 ## 0.26.0 -- 20 Apr 2018
 
 Lacinia now supports the `:roots` key in the input schema, which makes

--- a/dev-resources/enums.sdl
+++ b/dev-resources/enums.sdl
@@ -1,0 +1,1 @@
+{ enum Location { MATRIX ZION MACHINE_CITY}}

--- a/dev-resources/interfaces.sdl
+++ b/dev-resources/interfaces.sdl
@@ -1,0 +1,10 @@
+{
+  interface Matrix
+  {
+    eject(the_one: Boolean!) : Human
+  }
+
+  type Human {
+    name : String!
+  }
+}

--- a/dev-resources/unions.sdl
+++ b/dev-resources/unions.sdl
@@ -1,0 +1,8 @@
+{
+  type Human { name : String }
+
+  type Agent { id : Int
+               alias : String }
+
+  union Combatant  = Human | Agent
+}

--- a/docs/_examples/parsed_sample_schema.edn
+++ b/docs/_examples/parsed_sample_schema.edn
@@ -24,7 +24,9 @@
                   :episodes {:type (non-null (list :episode))}}}}
 
  :enums
- {:episode {:values [:NEWHOPE :EMPIRE :JEDI]}}
+ {:episode {:values [{:enum-value :NEWHOPE}
+                     {:enum-value :EMPIRE}
+                     {:enum-value :JEDI}]}}
 
  :roots
  {:query :Query

--- a/docs/schema/parsing.rst
+++ b/docs/schema/parsing.rst
@@ -31,7 +31,7 @@ to attach to the schema:
                            :serialize serialize-spec}}
    :documentation {:type-name doc-str
                    :type-name/field-name doc-str
-                   :type-name.field-name/arg-name doc-str}}
+                   :type-name/field-name.arg-name doc-str}}
 
 Example
 -------
@@ -48,7 +48,7 @@ Example
                  :documentation {:Character "A Star Wars character"
                                  :Character/name "Character name"
                                  :Query/find_all_in_episode "Find all characters in the given episode"
-                                 :Query.find_all_in_episode/episode "Episode for which to find characters."}})
+                                 :Query/find_all_in_episode.episode "Episode for which to find characters."}})
 
 .. literalinclude:: /_examples/parsed_sample_schema.edn
    :caption: *Return value of parse-schema*
@@ -57,7 +57,7 @@ Example
 
 The ``:documentation`` key uses a naming convention on the keys which become paths into the Lacinia input schema.
 ``:Character/name`` applies to the ``name`` field of the ``Character`` object.
-``:Query.find_all_in_episode/episode`` applies to the ``episode`` argument, inside the ``find_all_in_episode`` field
+``:Query/find_all_in_episode.episode`` applies to the ``episode`` argument, inside the ``find_all_in_episode`` field
 of the ``Query`` object.
 
 As is normal with SDL, the available queries, mutations, and subscriptions (not shown in this example)

--- a/docs/schema/parsing.rst
+++ b/docs/schema/parsing.rst
@@ -60,6 +60,12 @@ The ``:documentation`` key uses a naming convention on the keys which become pat
 ``:Query/find_all_in_episode.episode`` applies to the ``episode`` argument, inside the ``find_all_in_episode`` field
 of the ``Query`` object.
 
+The same key structure can be used to document input objects and interfaces.
+
+Unions may be documented, but do not contain fields.
+
+Enums may be documented, as well as Enum values (e.g., ``:Episode/JEDI``).
+
 As is normal with SDL, the available queries, mutations, and subscriptions (not shown in this example)
 are defined on ordinary schema objects, and the ``schema`` element identifies which objects are used for
 which purposes.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "0.26.0"
+(defproject com.walmartlabs/lacinia "0.27.0"
   :description "A GraphQL server implementation in Clojure"
   :license {:name "Apache, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -193,7 +193,8 @@
    (:scalarName (:name \"JEDI\")))"
   [enum]
   {(keyword (select1 [:typeName :name] enum))
-   {:values (vec (map (comp keyword first) (select [:scalarName :name] enum)))}})
+   {:values (vec (map #(hash-map :enum-value (-> % first keyword))
+                      (select [:scalarName :name] enum)))}})
 
 (defn ^:private xform-operation
   "Transforms an operation parse tree node by inlining the operation types."
@@ -281,10 +282,21 @@
   "Looks up the given type keyword in schema to determine if it is an
   input or output object, and returns the corresponding root key into
   the schema."
-  [schema type]
-  (cond
-    (get-in schema [:objects type]) :objects
-    (get-in schema [:input-objects type]) :input-objects))
+  [schema type-name]
+  (let [f (fn [k]
+            (when (-> schema (get k) (contains? type-name))
+              k))]
+    (or
+      (some f [:objects :input-objects :interfaces :enums :unions])
+      (throw (ex-info "Error attaching documentation: type not found" {:type-name type-name})))))
+
+(defn ^:private index-of
+  "Index of a value in a vector, or nil if not found."
+  [v value]
+  (->> v
+       (keep-indexed #(when (= %2 value)
+                        %1))
+       first))
 
 (defn ^:private documentation-schema-path
   "Returns a sequence of keys representing the path where the
@@ -294,29 +306,57 @@
   `location` should be one of:
    - `:type`
    - `:type/field`
-   - `:type/field.arg`"
-  [location]
-  (cond-let
-    (simple-keyword? location)
-    ;; type description
-    [location :description]
+   - `:type/field.arg`
 
-    :let [type-name (-> location namespace keyword)
-          [field-name arg-name] (-> location name (str/split #"\." 2))]
+   The type may identify an object, input object, interface, enum, or union.
+
+   union's do not have fields, an exception is thrown if a field of an enum is documented.
+
+   enum's have values, not fields.
+   It is allowed to document individual enum values, but enum values do not have arguments
+   (an exception will be thrown)."
+  [schema location]
+  (cond-let
+    :let [simple? (simple-keyword? location)
+          type-name (if simple?
+                      location
+                      (-> location namespace keyword))
+          [field-name arg-name] (when-not simple?
+                                  (-> location name (str/split #"\." 2)))
+          root (type-root schema type-name)]
+
+    simple?
+    [root type-name :description]
+
+    (= :unions root)
+    (throw (ex-info "Error attaching documentation: union members may not be documented"
+                    {:type-name type-name}))
+
+    :let [field-name' (keyword field-name)]
+
+    (= :enums root)
+    (if-not (str/blank? arg-name)
+      (throw (ex-info "Error attaching documentation: enum values do not have fields"
+                      {:type-name type-name}))
+      ;; The field-name is actually the enum value, in this context
+      (if-let [ix (index-of (get-in schema [root type-name :values])
+                            {:enum-value field-name'})]
+        [root type-name :values ix :description]
+        (throw (ex-info "Error attaching documentation: enum value not found"
+                        {:type-name type-name
+                         :enum-value field-name'}))))
 
     (str/blank? arg-name)
-    [type-name :fields (keyword field-name) :description]
+    [root type-name :fields field-name' :description]
 
     :else
-    [type-name :fields (keyword field-name) :args (keyword arg-name) :description]))
+    [root type-name :fields field-name' :args (keyword arg-name) :description]))
 
 (defn ^:private attach-documentation
   [schema documentation]
   (reduce-kv (fn [schema' location documentation]
-               (let [ks (documentation-schema-path location)
-                     root (type-root schema (first ks))]
-                 (when-not root (throw (ex-info "Error attaching documentation: type not found" {:type type})))
-                 (assoc-in schema' (concat [root] ks) documentation)))
+               (let [ks (documentation-schema-path schema location)]
+                 (assoc-in schema' ks documentation)))
              schema
              documentation))
 

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -65,7 +65,7 @@
                                                             :Character/name "Character name"
                                                             :Character/birthDate "Date of Birth"
                                                             :Query/in_episode "Find all characters for a given episode"
-                                                            :Query.in_episode/episode "Episode for which to find characters"}})]
+                                                            :Query/in_episode.episode "Episode for which to find characters"}})]
     (testing "parsing"
       (is (= {:enums {:episode {:values [:NEWHOPE :EMPIRE :JEDI]}}
               :scalars {:Date {:parse date-parse :serialize date-parse}}

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -56,18 +56,26 @@
 
 (def ^:private streamer-map {:Subscription {:new_character new-character}})
 
+(defn ^:private parse-schema [path options]
+  (-> path
+      resource
+      slurp
+      (parser/parse-schema options)))
+
 (deftest schema-parsing
-  (let [parsed-schema (parser/parse-schema (slurp (resource "sample_schema.sdl"))
-                                           {:resolvers resolver-map
-                                            :scalars scalar-map
-                                            :streamers streamer-map
-                                            :documentation {:Character "A character"
-                                                            :Character/name "Character name"
-                                                            :Character/birthDate "Date of Birth"
-                                                            :Query/in_episode "Find all characters for a given episode"
-                                                            :Query/in_episode.episode "Episode for which to find characters"}})]
+  (let [parsed-schema (parse-schema "sample_schema.sdl"
+                                    {:resolvers resolver-map
+                                     :scalars scalar-map
+                                     :streamers streamer-map
+                                     :documentation {:Character "A character"
+                                                     :Character/name "Character name"
+                                                     :Character/birthDate "Date of Birth"
+                                                     :Query/in_episode "Find all characters for a given episode"
+                                                     :Query/in_episode.episode "Episode for which to find characters"}})]
     (testing "parsing"
-      (is (= {:enums {:episode {:values [:NEWHOPE :EMPIRE :JEDI]}}
+      (is (= {:enums {:episode {:values [{:enum-value :NEWHOPE}
+                                         {:enum-value :EMPIRE}
+                                         {:enum-value :JEDI}]}}
               :scalars {:Date {:parse date-parse :serialize date-parse}}
               :interfaces {:Human {:fields {:name {:type 'String}
                                             :birthDate {:type :Date}}}}
@@ -113,20 +121,97 @@
         (is (= {:data {:add false}}
                (execute compiled "mutation { add(character: {name: \"Darth Vader\"}) }" nil {})))))))
 
+(deftest can-identify-unknown-doc
+  (when-let [e (is (thrown-with-msg? ExceptionInfo
+                                     #"Error attaching documentation: type not found"
+                                     (parse-schema "interfaces.sdl" {:documentation {:Agent "Virtual killers."}})))]
+    (is (= {:type-name :Agent}
+           (ex-data e)))))
+
+(deftest can-attach-doc-to-interfaces
+  (is (= '{:interfaces
+           {:Matrix
+            {:description "A virtual construct."
+             :fields
+             {:eject {:args {:the_one {:description "If true, then Neo is ejected."
+                                       :type (non-null Boolean)}}
+                      :description "Eject a Human into Zen."
+                      :type :Human}}}}
+           :objects
+           {:Human
+            {:description "Power source."
+             :fields
+             {:name {:description "Unimportant."
+                     :type (non-null String)}}}}}
+         (parse-schema "interfaces.sdl"
+                       {:documentation
+                        {:Matrix "A virtual construct."
+                         :Matrix/eject "Eject a Human into Zen."
+                         :Matrix/eject.the_one "If true, then Neo is ejected."
+                         :Human "Power source."
+                         :Human/name "Unimportant."}}))))
+
+(deftest can-attach-doc-to-unions
+  (is (= '{:objects {:Agent {:fields {:alias {:type String}
+                                      :id {:type Int}}}
+                     :Human {:fields {:name {:type String}}}}
+           :unions {:Combatant {:description "Being in the Matrix."
+                                :members [:Human
+                                          :Agent]}}}
+         (parse-schema "unions.sdl"
+                       {:documentation
+                        {:Combatant "Being in the Matrix."}}))))
+
+(deftest can-not-attach-doc-to-union-member
+  (when-let [e (is (thrown-with-msg? ExceptionInfo
+                                     #"Error attaching documentation: union members may not be documented"
+                                     (parse-schema "unions.sdl" {:documentation {:Combatant/Human "Energy Source."}})))]
+    (is (= {:type-name :Combatant}
+           (ex-data e)))))
+
+(deftest can-attach-doc-to-enums
+  (is (= {:enums {:Location {:description "Where a scene takes place."
+                             :values [{:description "The virtual world."
+                                       :enum-value :MATRIX}
+                                      {:description "The apparently real world outside the Matrix."
+                                       :enum-value :ZION}
+                                      {:description "Where the 'bots hang out."
+                                       :enum-value :MACHINE_CITY}]}}}
+         (parse-schema "enums.sdl" {:documentation
+                                    {:Location "Where a scene takes place."
+                                     :Location/MATRIX "The virtual world."
+                                     :Location/ZION "The apparently real world outside the Matrix."
+                                     :Location/MACHINE_CITY "Where the 'bots hang out."}}))))
+
+(deftest can-not-attach-doc-to-enum-value-args
+  (when-let [e (is (thrown-with-msg? ExceptionInfo
+                                     #"Error attaching documentation: enum values do not have fields"
+                                     (parse-schema "enums.sdl" {:documentation {:Location/MATRIX.highway "Dangerous."}})))]
+    (is (= {:type-name :Location}
+           (ex-data e)))))
+
+(deftest enum-value-must-exist
+  (when-let [e (is (thrown-with-msg? ExceptionInfo
+                                     #"Error attaching documentation: enum value not found"
+                                     (parse-schema "enums.sdl" {:documentation {:Location/FLOOR_13 "Similar."}})))]
+    (is (= {:type-name :Location
+            :enum-value :FLOOR_13}
+           (ex-data e)))))
+
 (deftest schema-validation
   (let [exception (is (thrown-with-msg? ExceptionInfo
                                         #"Error parsing schema"
-                                        (parser/parse-schema (slurp (resource "bad_schema.sdl")) {})))]
+                                        (parse-schema "bad_schema.sdl" {})))]
     (is (= '#{{:error "Duplicate type names"
                :duplicate-types ({:name "Character" :location {:line 11 :column 13}}
-                                 {:name "Character" :location {:line 22 :column 9}}
-                                 {:name "Query" :location {:line 28 :column 8}}
-                                 {:name "Query" :location {:line 32 :column 8}}
-                                 {:name "Queries" :location {:line 37 :column 9}}
-                                 {:name "Queries" :location {:line 39 :column 8}})}
+                                  {:name "Character" :location {:line 22 :column 9}}
+                                  {:name "Query" :location {:line 28 :column 8}}
+                                  {:name "Query" :location {:line 32 :column 8}}
+                                  {:name "Queries" :location {:line 37 :column 9}}
+                                  {:name "Queries" :location {:line 39 :column 8}})}
               {:error "Duplicate fields defined on type"
                :duplicate-fields ({:name "find_by_names" :location {:line 33 :column 5}}
-                                  {:name "find_by_names" :location {:line 34 :column 5}})
+                                   {:name "find_by_names" :location {:line 34 :column 5}})
                :type "Query"}
               {:error "Duplicate arguments defined on field"
                :duplicate-arguments ("episode")


### PR DESCRIPTION
This includes an incompatible change to how we "path" a keyword to a location in the schema. It also adds support for documenting interfaces, enums, enum values,  and unions.