### PR TITLE
Add support for reading external Markdown file for schema documentation, then attaching it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ See `com.walmartlabs.lacinia.parser.docs/parse-docs` and
 Lacinia now supports the `:roots` key in the input schema, which makes
 it possible to define query, mutation, or subscription operations
 in terms of the fields of an explicitly named object in the schema.
-This aligns Lacinia better withu other implementations of GraphQL.
+This aligns Lacinia better with other implementations of GraphQL.
 
 Lacinia is now based on Clojure 1.9, though it can also be used with
 Clojure 1.8.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ See `com.walmartlabs.lacinia.parser.docs/parse-docs` and
 Lacinia now supports the `:roots` key in the input schema, which makes
 it possible to define query, mutation, or subscription operations
 in terms of the fields of an explicitly named object in the schema.
-This aligns Lacinia better with other implementations of GraphQL.
+This aligns Lacinia better withu other implementations of GraphQL.
 
 Lacinia is now based on Clojure 1.9, though it can also be used with
 Clojure 1.8.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ but with this release, we've change it to `:MyType/my_field.arg_name`.
 It is now possible, when parsing a schema from SDL, to document interfaces, enums, and unions.
 Previously, only objects and input objects could be documented.
 
+It is now possible to combine external documentation, from a Markdown file,
+into an EDN schema.
+See `com.walmartlabs.lacinia.parser.docs/parse-docs` and
+`com.walmartlabs.lacinia.util/attach-descriptions`.
+
 ## 0.26.0 -- 20 Apr 2018
 
 Lacinia now supports the `:roots` key in the input schema, which makes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Previously, only objects and input objects could be documented.
 It is now possible to combine external documentation, from a Markdown file,
 into an EDN schema.
 See `com.walmartlabs.lacinia.parser.docs/parse-docs` and
-`com.walmartlabs.lacinia.util/attach-descriptions`.
+`com.walmartlabs.lacinia.util/inject-descriptions`.
 
 ## 0.26.0 -- 20 Apr 2018
 

--- a/dev-resources/basic-docs.md
+++ b/dev-resources/basic-docs.md
@@ -1,0 +1,12 @@
+# Character
+
+A person who appears in one of the movies.
+
+Persons are more than humans, and may include droids and computers.
+
+## Character/name
+
+The primary name of the character.
+
+For droids, this is the announced name, such as "AreToo".
+

--- a/dev-resources/preamble-docs.md
+++ b/dev-resources/preamble-docs.md
@@ -1,0 +1,8 @@
+This text is ignored.
+
+This text contains a # mark.
+
+# Customer
+
+Someone we sell to.
+

--- a/dev-resources/user.clj
+++ b/dev-resources/user.clj
@@ -3,4 +3,14 @@
     [criterium.core :as c]
     [clojure.java.io :as io]
     [com.walmartlabs.lacinia.schema :as schema]
-    [com.walmartlabs.lacinia :as l]))
+    [com.walmartlabs.lacinia :as l]
+    [clojure.spec.alpha :as s]
+    [expound.alpha :as expound]))
+
+(comment
+
+  ;; Currently, this breaks a couple of tests, so it should only be
+  ;; invoked for development.
+  (alter-var-root #'s/*explain-out* (constantly expound/printer))
+
+  )

--- a/src/com/walmartlabs/lacinia/internal_utils.clj
+++ b/src/com/walmartlabs/lacinia/internal_utils.clj
@@ -195,6 +195,21 @@
 
 (def ^:private operation-containers #{:queries :mutations :subscriptions})
 
+(defn resolver-path
+  "Given a key, such as :queries/user_by_id or :User/full_name, return the
+  path from the root of the schema to (and including) the :resolve key."
+  [schema k]
+  (let [container-name (-> k namespace keyword)
+        field-name (-> k name keyword)
+        path (if (operation-containers container-name)
+               [container-name field-name]
+               [:objects container-name :fields field-name])]
+    (when-not (get-in schema path)
+      (throw (ex-info "inject resolvers error: not found"
+                      {:key k})))
+
+    (conj path :resolve)))
+
 (defn ^:private type-root
   "Looks up the given type keyword in schema and returns the corresponding root key into
   the schema."

--- a/src/com/walmartlabs/lacinia/internal_utils.clj
+++ b/src/com/walmartlabs/lacinia/internal_utils.clj
@@ -192,3 +192,85 @@
   {:added "0.17.0"}
   [^TaggedValue v]
   (.tag v))
+
+(def ^:private operation-containers #{:queries :mutations :subscriptions})
+
+(defn ^:private type-root
+  "Looks up the given type keyword in schema and returns the corresponding root key into
+  the schema."
+  [schema type-name]
+  (if (operation-containers type-name)
+    type-name
+    (let [f (fn [k]
+              (when (-> schema (get k) (contains? type-name))
+                k))]
+      (or
+        (some f [:objects :input-objects :interfaces :enums :unions])
+        (throw (ex-info "Error attaching documentation: type not found" {:type-name type-name}))))))
+
+(defn ^:private index-of
+  "Index of a value in a vector, or nil if not found."
+  [v value]
+  (->> v
+       (keep-indexed #(when (= %2 value)
+                        %1))
+       first))
+
+(defn documentation-schema-path
+  "Returns a sequence of keys representing the path where the
+  documentation string should be attached in the nested associative schema
+  structure.
+
+  `location` should be one of:
+   - `:type`
+   - `:type/field`
+   - `:type/field.arg`
+
+   The type may identify an object, input object, interface, enum, or union.
+
+   union's do not have fields, an exception is thrown if a field of an enum is documented.
+
+   enum's have values, not fields.
+   It is allowed to document individual enum values, but enum values do not have arguments
+   (an exception will be thrown)."
+  [schema location]
+  (cond-let
+    :let [simple? (simple-keyword? location)
+          type-name (if simple?
+                      location
+                      (-> location namespace keyword))
+          [field-name arg-name] (when-not simple?
+                                  (-> location name (str/split #"\." 2)))
+          root (type-root schema type-name)]
+
+    simple?
+    [root type-name :description]
+
+    (= :unions root)
+    (throw (ex-info "Error attaching documentation: union members may not be documented"
+                    {:type-name type-name}))
+
+    :let [field-name' (keyword field-name)]
+
+    (= :enums root)
+    (if-not (str/blank? arg-name)
+      (throw (ex-info "Error attaching documentation: enum values do not have fields"
+                      {:type-name type-name}))
+      ;; The field-name is actually the enum value, in this context
+      (if-let [ix (index-of (get-in schema [root type-name :values])
+                            {:enum-value field-name'})]
+        [root type-name :values ix :description]
+        (throw (ex-info "Error attaching documentation: enum value not found"
+                        {:type-name type-name
+                         :enum-value field-name'}))))
+
+    :let [base (if (operation-containers root)
+                 [root field-name']
+                 [root type-name :fields field-name'])]
+
+    (str/blank? arg-name)
+    (conj base :description)
+
+    :else
+    (conj base :args (keyword arg-name) :description)))
+

--- a/src/com/walmartlabs/lacinia/parser/docs.clj
+++ b/src/com/walmartlabs/lacinia/parser/docs.clj
@@ -1,0 +1,63 @@
+; Copyright (c) 2017-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+(ns com.walmartlabs.lacinia.parser.docs
+  "Parsing of a Markdown file for purposes of attaching documentation to a schema."
+  {:added "0.27.0"}
+  (:require
+    [clojure.string :as str]
+    [com.walmartlabs.lacinia.internal-utils :refer [cond-let]]))
+
+(def ^:private header-re
+  ;; Don't really care how deep the heading is
+  #"\#+\s+(.*?)\s*$")
+
+(defn ^:private combine-block
+  [lines]
+  (->> lines
+       (str/join "\n")
+       str/trim))
+
+(defn parse-docs
+  "Parses an input document.  Returns a map who keys are the keyword versions of headers, and whose values
+  are the (trimmed) content immediately beneath that header."
+  [input]
+  (loop [lines (str/split-lines input)
+         result {}
+         header nil
+         block []]
+    (cond-let
+      (nil? lines)
+      (if header
+        (assoc result header (combine-block block))
+        result)
+
+      :let [line (first lines)
+            more-lines (next lines)
+            [_ new-header] (re-matches header-re line)]
+
+      (some? new-header)
+      (recur more-lines
+             (if header
+               (assoc result header (combine-block block))
+               result)
+             (keyword new-header)
+             [])
+
+      (some? header)
+      (recur more-lines result header (conj block line))
+
+      :else
+      ;; In the preamble, if any, before first header.
+      (recur more-lines result header block))))

--- a/src/com/walmartlabs/lacinia/parser/docs.clj
+++ b/src/com/walmartlabs/lacinia/parser/docs.clj
@@ -33,7 +33,7 @@
   "Parses an input document.  Returns a map who keys are the keyword versions of headers, and whose values
   are the (trimmed) content immediately beneath that header.
 
-  The result is a documentation map that can be provided to [[attach-descriptions]]."
+  The result is a documentation map that can be provided to [[inject-descriptions]]."
   [input]
   (loop [lines (str/split-lines input)
          result {}

--- a/src/com/walmartlabs/lacinia/parser/docs.clj
+++ b/src/com/walmartlabs/lacinia/parser/docs.clj
@@ -31,7 +31,9 @@
 
 (defn parse-docs
   "Parses an input document.  Returns a map who keys are the keyword versions of headers, and whose values
-  are the (trimmed) content immediately beneath that header."
+  are the (trimmed) content immediately beneath that header.
+
+  The result is a documentation map that can be provided to [[attach-descriptions]]."
   [input]
   (loop [lines (str/split-lines input)
          result {}

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -17,7 +17,7 @@
   {:added "0.22.0"}
   (:require [com.walmartlabs.lacinia.internal-utils :refer [remove-vals]]
             [com.walmartlabs.lacinia.parser.common :refer [antlr-parse parse-failures stringvalue->String]]
-            [com.walmartlabs.lacinia.util :refer [attach-descriptions]]
+            [com.walmartlabs.lacinia.util :refer [inject-descriptions]]
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
             [clj-antlr.core :as antlr.core])
@@ -344,7 +344,7 @@
         (attach-field-fns :resolve resolvers)
         (attach-field-fns :stream streamers)
         (attach-scalars scalars)
-        (attach-descriptions documentation)
+        (inject-descriptions documentation)
         (attach-operations root))))
 
 (defn parse-schema

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -15,11 +15,11 @@
 (ns com.walmartlabs.lacinia.parser.schema
   "Parse a Schema Definition Language document into a Lacinia input schema."
   {:added "0.22.0"}
-  (:require [com.walmartlabs.lacinia.internal-utils :refer [remove-vals cond-let]]
+  (:require [com.walmartlabs.lacinia.internal-utils :refer [remove-vals]]
             [com.walmartlabs.lacinia.parser.common :refer [antlr-parse parse-failures stringvalue->String]]
+            [com.walmartlabs.lacinia.util :refer [attach-descriptions]]
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
-            [clojure.string :as str]
             [clj-antlr.core :as antlr.core])
   (:import (clj_antlr ParseError)))
 
@@ -278,88 +278,6 @@
   (cond-> schema
     scalars (assoc :scalars scalars)))
 
-(defn ^:private type-root
-  "Looks up the given type keyword in schema to determine if it is an
-  input or output object, and returns the corresponding root key into
-  the schema."
-  [schema type-name]
-  (let [f (fn [k]
-            (when (-> schema (get k) (contains? type-name))
-              k))]
-    (or
-      (some f [:objects :input-objects :interfaces :enums :unions])
-      (throw (ex-info "Error attaching documentation: type not found" {:type-name type-name})))))
-
-(defn ^:private index-of
-  "Index of a value in a vector, or nil if not found."
-  [v value]
-  (->> v
-       (keep-indexed #(when (= %2 value)
-                        %1))
-       first))
-
-(defn ^:private documentation-schema-path
-  "Returns a sequence of keys representing the path where the
-  documentation string should be attached in the nested associative schema
-  structure.
-
-  `location` should be one of:
-   - `:type`
-   - `:type/field`
-   - `:type/field.arg`
-
-   The type may identify an object, input object, interface, enum, or union.
-
-   union's do not have fields, an exception is thrown if a field of an enum is documented.
-
-   enum's have values, not fields.
-   It is allowed to document individual enum values, but enum values do not have arguments
-   (an exception will be thrown)."
-  [schema location]
-  (cond-let
-    :let [simple? (simple-keyword? location)
-          type-name (if simple?
-                      location
-                      (-> location namespace keyword))
-          [field-name arg-name] (when-not simple?
-                                  (-> location name (str/split #"\." 2)))
-          root (type-root schema type-name)]
-
-    simple?
-    [root type-name :description]
-
-    (= :unions root)
-    (throw (ex-info "Error attaching documentation: union members may not be documented"
-                    {:type-name type-name}))
-
-    :let [field-name' (keyword field-name)]
-
-    (= :enums root)
-    (if-not (str/blank? arg-name)
-      (throw (ex-info "Error attaching documentation: enum values do not have fields"
-                      {:type-name type-name}))
-      ;; The field-name is actually the enum value, in this context
-      (if-let [ix (index-of (get-in schema [root type-name :values])
-                            {:enum-value field-name'})]
-        [root type-name :values ix :description]
-        (throw (ex-info "Error attaching documentation: enum value not found"
-                        {:type-name type-name
-                         :enum-value field-name'}))))
-
-    (str/blank? arg-name)
-    [root type-name :fields field-name' :description]
-
-    :else
-    [root type-name :fields field-name' :args (keyword arg-name) :description]))
-
-(defn ^:private attach-documentation
-  [schema documentation]
-  (reduce-kv (fn [schema' location documentation]
-               (let [ks (documentation-schema-path schema location)]
-                 (assoc-in schema' ks documentation)))
-             schema
-             documentation))
-
 (defn ^:private duplicates
   "Returns duplicates in coll, retaining original element meta"
   [coll]
@@ -426,7 +344,7 @@
         (attach-field-fns :resolve resolvers)
         (attach-field-fns :stream streamers)
         (attach-scalars scalars)
-        (attach-documentation documentation)
+        (attach-descriptions documentation)
         (attach-operations root))))
 
 (defn parse-schema
@@ -477,7 +395,6 @@
 (s/def ::scalar-def (s/keys :req-un [::parse ::serialize]))
 (s/def ::description string?)
 (s/def ::fields (s/map-of simple-keyword? ::description))
-(s/def ::documentation-def (s/keys :opt-un [::description ::fields]))
 
 (s/def ::documentation (s/map-of keyword? string?))
 (s/def ::scalars (s/map-of simple-keyword? ::scalar-def))

--- a/src/com/walmartlabs/lacinia/util.clj
+++ b/src/com/walmartlabs/lacinia/util.clj
@@ -16,7 +16,7 @@
   "Useful utility functions."
   (:require
     [com.walmartlabs.lacinia.internal-utils
-     :refer [to-message map-vals cond-let update?]]))
+     :refer [to-message map-vals cond-let update? documentation-schema-path]]))
 
 (defn ^:private attach-callbacks
   [field-container callbacks-map callback-kw error-name]
@@ -107,3 +107,34 @@
    (merge {:message (to-message t)}
           (ex-data t)
           more-data)))
+
+(defn attach-descriptions
+  "Attaches documentation to a schema, a `:description` keys on various elements
+  within the schema.
+
+  The documentation map keys are keywords with a particular structure,
+  and the values are formatted Markdown strings.
+
+  The keys are one of the following forms:
+
+  - `:Type`
+  - `:Type/name`
+  - `:Type/name.argument`
+
+  A simple `Type` will document an object, input object, interface, union, or enum.
+
+  The second form is used to document a field of an object, input object, or interface, or
+  to document a specific value of an enum (e.g., `:Episode/NEW_HOPE`).
+
+  The final form is used to document an argument to a field (it does not make sense for enums).
+
+  Additionally, the `Type` can be `queries`, `mutations`, or `subscriptions`, in which case
+  the `name` will be the name of the operation (e.g., `:queries/episode`).
+
+  See [[parse-docs]]."
+  {:added "0.27.0"}
+  [schema documentation]
+  (reduce-kv (fn [schema' location description]
+               (assoc-in schema' (documentation-schema-path schema location) description))
+             schema
+             documentation))

--- a/src/com/walmartlabs/lacinia/util.clj
+++ b/src/com/walmartlabs/lacinia/util.clj
@@ -108,8 +108,8 @@
           (ex-data t)
           more-data)))
 
-(defn attach-descriptions
-  "Attaches documentation to a schema, a `:description` keys on various elements
+(defn inject-descriptions
+  "Injects documentation into a schema, as `:description` keys on various elements
   within the schema.
 
   The documentation map keys are keywords with a particular structure,

--- a/src/com/walmartlabs/lacinia/util.clj
+++ b/src/com/walmartlabs/lacinia/util.clj
@@ -16,7 +16,8 @@
   "Useful utility functions."
   (:require
     [com.walmartlabs.lacinia.internal-utils
-     :refer [to-message map-vals cond-let update? documentation-schema-path]]))
+     :refer [to-message map-vals cond-let update? documentation-schema-path
+             resolver-path]]))
 
 (defn ^:private attach-callbacks
   [field-container callbacks-map callback-kw error-name]
@@ -138,22 +139,6 @@
                (assoc-in schema' (documentation-schema-path schema location) description))
              schema
              documentation))
-
-
-(def ^:private operation-names #{:queries :mutation :subscriptions})
-
-(defn ^:private resolver-path
-  [schema k]
-  (let [container-name (-> k namespace keyword)
-        field-name (-> k name keyword)
-        path (if (operation-names container-name)
-               [container-name field-name]
-               [:objects container-name :fields field-name])]
-    (when-not (get-in schema path)
-      (throw (ex-info "inject resolvers error: not found"
-                      {:key k})))
-
-    (conj path :resolve)))
 
 (defn inject-resolvers
   "Adds resolvers to the schema.  The resolvers map is a map of keywords to

--- a/test/com/walmartlabs/lacinia/parser/docs_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/docs_test.clj
@@ -1,0 +1,43 @@
+; Copyright (c) 2017-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+(ns com.walmartlabs.lacinia.parser.docs-test
+  (:require
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.lacinia.parser.docs :refer [parse-docs]]
+    [clojure.java.io :as io]))
+
+(defn ^:private parse
+  [path]
+  (-> path
+      io/resource
+      slurp
+      parse-docs))
+
+(deftest basic-parse
+  (is (= {:Character "A person who appears in one of the movies.
+
+Persons are more than humans, and may include droids and computers."
+          :Character/name "The primary name of the character.
+
+For droids, this is the announced name, such as \"AreToo\"."}
+         (parse "basic-docs.md"))))
+
+(deftest empty-parse
+  (is (= {}
+         (parse-docs ""))))
+
+(deftest ignores-before-first-header
+  (is (= {:Customer "Someone we sell to."}
+         (parse "preamble-docs.md"))))

--- a/test/com/walmartlabs/lacinia/util_test.clj
+++ b/test/com/walmartlabs/lacinia/util_test.clj
@@ -77,3 +77,24 @@
              {:parse int
               :serialize double}}}
            (util/attach-scalar-transformers schema transformers)))))
+
+(deftest attach-descriptions
+  ;; This tests a couple of cases that aren't covered by the
+  ;; parser.schema-test namespace.
+
+  (let [schema {:queries
+                {:hello
+                 {:type :String
+                  :args
+                  {:name {:type :String}}}}}
+        documentation {:queries/hello "HELLO"
+                       :queries/hello.name "HELLO.NAME"}]
+
+    (is (= {:queries
+            {:hello
+             {:type :String
+              :description "HELLO"
+              :args
+              {:name {:type :String
+                      :description "HELLO.NAME"}}}}}
+           (util/attach-descriptions schema documentation)))))

--- a/test/com/walmartlabs/lacinia/util_test.clj
+++ b/test/com/walmartlabs/lacinia/util_test.clj
@@ -78,7 +78,7 @@
               :serialize double}}}
            (util/attach-scalar-transformers schema transformers)))))
 
-(deftest attach-descriptions
+(deftest inject-descriptions
   ;; This tests a couple of cases that aren't covered by the
   ;; parser.schema-test namespace.
 
@@ -97,4 +97,4 @@
               :args
               {:name {:type :String
                       :description "HELLO.NAME"}}}}}
-           (util/attach-descriptions schema documentation)))))
+           (util/inject-descriptions schema documentation)))))


### PR DESCRIPTION
Feedback on the naming of the various functions ... I'm vacillating between `attach-documentation` and `attach-descriptions`.