### PR TITLE
20180720 merge scalars sdf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Removed a potential race condition related to asynchronous field resolvers.
 
 A change to how GraphQL schema documentation is attached.
 Previously, arguments were refered to as `:MyType.my_field/arg_name`
-but with this release, we've change it to `:MyType/my_field.arg_name`.
+but with this release, we've changed it to `:MyType/my_field.arg_name`.
 
 It is now possible, when parsing a schema from SDL, to document interfaces, enums, 
 scalars, and unions.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,12 @@ Changes have started to bring Lacinia into compliance with
 the [June 2018 version of the GraphQL specification](https://github.com/facebook/graphql/releases/tag/June2018).
 
 Lacinia now supports block strings (via `"""`) in query and schema documents.
-However, we have not yet implemented using block strings as documentation in schemas.
 
-The error maps inside the `:error` key are now structured according to the spec;
+In addition, descriptions are now supported inside schema documents;
+a string (or block string) before an element in the schema becomes the
+documentation for that element.
+
+The error maps inside the `:error` key are now structured according to the June 2018 spec;
 the top level keys are `:message`, `:locations`, and `:path`, and
 `:extensions` (which contains any other keys in the error map supplied
 by the field resolver).
@@ -25,9 +28,10 @@ A change to how GraphQL schema documentation is attached.
 Previously, arguments were refered to as `:MyType.my_field/arg_name`
 but with this release, we've changed it to `:MyType/my_field.arg_name`.
 
-It is now possible, when parsing a schema from SDL, to document interfaces, enums, 
-scalars, and unions.
-Previously, only objects and input objects could be documented.
+It is now possible, when parsing a schema from SDL via
+`com.walmartlabs.lacinia.parser.schema/parse-schema`, to
+attach descriptions to interfaces, enums, scalars, and unions.
+Previously, only objects and input objects could have descriptions attached.
 
 New function `com.walmartlabs.lacinia.util/inject-resolvers` is an alternate way
 to attach resolvers to a schema.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ the top level keys are `:message`, `:locations`, and `:path`, and
 `:extensions` (which contains any other keys in the error map supplied
 by the field resolver).
 
+[Closed Issues](https://github.com/walmartlabs/lacinia/milestone/17?closed=1)
+
 ## 0.28.0 -- 21 Jun 2018
 
 Removed a potential race condition related to asynchronous field resolvers.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@ the top level keys are `:message`, `:locations`, and `:path`, and
 `:extensions` (which contains any other keys in the error map supplied
 by the field resolver).
 
+The behavior of the `:scalars` option to `com.walmartlabs.lacina.parser.schema/parse-schema`
+has changed slightly; the values provided are now merged with any scalar
+data defined in the schema document.
+Previously, the supplied value *overwrote* what was parsed.
+
 [Closed Issues](https://github.com/walmartlabs/lacinia/milestone/17?closed=1)
 
 ## 0.28.0 -- 21 Jun 2018

--- a/dev-resources/documented-schema.sdl
+++ b/dev-resources/documented-schema.sdl
@@ -1,0 +1,60 @@
+{
+  """
+  Things that have a name.
+  """
+  interface Named {
+    "The unique name for the Named thing."
+    name: String
+  }
+
+  """
+  File node type.
+  """
+  enum FileNodeType {
+    "A standard file-system file."
+    FILE
+
+    "A directory that may contain other files and directories."
+    DIR
+
+    "A special file, such as a device."
+    SPECIAL
+  }
+
+  type DirectoryListing implements Named {
+    name: String
+    node_type: FileNodeType
+  }
+
+  """
+  String that identifies permissions on a file or directory.
+  """
+  scalar Permissions
+
+  """
+  Directory type.
+  """
+  type Directory implements Named {
+    name : String
+    permissions: Permissions
+    contents(
+      """
+      Wildcard used for matching.
+      """
+      match : String) : [DirectoryListing]
+  }
+
+  type File implements Named {
+    name : String
+  }
+
+  "Stuff that can appear on the file system"
+  union FileSystemEntry = File | Directory
+
+  type Query {
+    file(path : String) :  FileSystemEntry
+  }
+
+}
+
+

--- a/dev-resources/duplicate-type.sdl
+++ b/dev-resources/duplicate-type.sdl
@@ -1,0 +1,10 @@
+{
+  type Tree { height: Int }
+
+  type Leaf { id: ID }
+
+  type Tree { left: Node, right: Node }
+
+  union Node = Leaf | Tree
+
+}

--- a/dev-resources/sample_schema.sdl
+++ b/dev-resources/sample_schema.sdl
@@ -6,6 +6,7 @@
     JEDI
   }
 
+  "Date in standard ISO format"
   scalar Date
 
   interface Human {

--- a/docs/schema/parsing.rst
+++ b/docs/schema/parsing.rst
@@ -1,20 +1,13 @@
 GraphQL SDL Parsing
 ===================
 
-.. important::
-   The GraphQL Schema Definition Language is not yet a formal specification
-   and is still under development. As such, this part of Lacinia will continue
-   to evolve to keep up with new developments, and it's possible that breaking
-   changes will occur.
+.. sidebar:: GraphQL Spec
 
-.. sidebar:: GraphQL SDL
-
-  See the `RFC PR <https://github.com/facebook/graphql/pull/90>`_ for details
-  on the GraphQL Schema Definition Language.
+   Read about :spec:`the Schema Definition Language <Schema>`.
 
 As noted in the :doc:`overview <../overview>`, Lacinia schemas are represented as
 Clojure data. However, Lacinia also contains a facility to transform schemas
-written in the GraphQL Interface Definition Language into the form usable by Lacinia.
+written in the GraphQL Schema Definition Language into the form usable by Lacinia.
 This is exposed by the function ``com.walmartlabs.lacinia.parser.schema/parse-schema``.
 
 The Lacinia schema definition includes things which are not available in the SDL, such as
@@ -60,6 +53,14 @@ The ``:documentation`` key uses a naming convention on the keys which become pat
 ``:Query/find_all_in_episode.episode`` applies to the ``episode`` argument, inside the ``find_all_in_episode`` field
 of the ``Query`` object.
 
+.. tip::
+
+   Attaching documentation this way is less necessary since release 0.29.0, which added support for
+   embedded :spec:`schema documentation <Descriptions>`.
+
+   Alternately, the documentation map can be parsed from a Markdown file using
+   ``com.walmartlabs.lacinia.parser.docs/parse-docs``.
+
 The same key structure can be used to document input objects and interfaces.
 
 Unions may be documented, but do not contain fields.
@@ -71,3 +72,7 @@ are defined on ordinary schema objects, and the ``schema`` element identifies wh
 which purposes.
 
 The ``:roots`` map inside the Lacinia schema is equivalent to the ``schema`` element in the SDL.
+
+.. warning::
+
+   :spec:`Schema extensions <Schema-Extension>` are defined in the GraphQL specification, but not yet implemented.

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -27,19 +27,24 @@ subscriptionOperationDef
   ;
 
 typeDef
-  : 'type' typeName implementationDef? '{' fieldDef+ '}'
+  : 'type' typeName implementationDef? fieldDefs
   ;
+
+fieldDefs
+  : '{' fieldDef+ '}'
+  ;
+
 
 implementationDef
   : 'implements' typeName+
   ;
 
 inputTypeDef
-  : 'input' typeName '{' fieldDef+ '}'
+  : 'input' typeName fieldDefs
   ;
 
 interfaceDef
-  : 'interface' typeName '{' fieldDef+ '}'
+  : 'interface' typeName fieldDefs
   ;
 
 scalarDef
@@ -98,6 +103,11 @@ defaultValue
   : '=' value
   ;
 
+BooleanValue
+    : 'true'
+    | 'false'
+    ;
+
 Name
   : [_A-Za-z][_0-9A-Za-z]*
   ;
@@ -128,11 +138,6 @@ objectValue
 
 objectField
     : Name ':' value
-    ;
-
-BooleanValue
-    : 'true'
-    | 'false'
     ;
 
 NullValue

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -4,6 +4,11 @@ graphqlSchema
   : '{' (schemaDef|typeDef|inputTypeDef|unionDef|enumDef|interfaceDef|scalarDef)* '}'
   ;
 
+description
+  : StringValue
+  | BlockStringValue
+  ;
+
 schemaDef
   : 'schema' '{' operationTypeDef+ '}'
   ;
@@ -27,7 +32,7 @@ subscriptionOperationDef
   ;
 
 typeDef
-  : 'type' typeName implementationDef? fieldDefs
+  : description? 'type' typeName implementationDef? fieldDefs
   ;
 
 fieldDefs
@@ -40,19 +45,19 @@ implementationDef
   ;
 
 inputTypeDef
-  : 'input' typeName fieldDefs
+  : description? 'input' typeName fieldDefs
   ;
 
 interfaceDef
-  : 'interface' typeName fieldDefs
+  : description? 'interface' typeName fieldDefs
   ;
 
 scalarDef
-  : 'scalar' typeName
+  : description? 'scalar' typeName
   ;
 
 unionDef
-  : 'union' typeName '=' unionTypes
+  : description? 'union' typeName '=' unionTypes
   ;
 
 unionTypes
@@ -60,7 +65,15 @@ unionTypes
   ;
 
 enumDef
-  : 'enum' typeName '{' scalarName+ '}'
+  : description? 'enum' typeName enumValueDefs
+  ;
+
+enumValueDefs
+  : '{' enumValueDef+ '}'
+  ;
+
+enumValueDef
+  : description? scalarName
   ;
 
 scalarName
@@ -68,7 +81,7 @@ scalarName
   ;
 
 fieldDef
-  : fieldName fieldArgs? ':' typeSpec
+  : description? fieldName fieldArgs? ':' typeSpec
   ;
 
 fieldArgs
@@ -80,7 +93,7 @@ fieldName
   ;
 
 argument
-  : Name ':' typeSpec defaultValue?
+  : description? Name ':' typeSpec defaultValue?
   ;
 
 typeSpec

--- a/src/com/walmartlabs/lacinia/parser/common.clj
+++ b/src/com/walmartlabs/lacinia/parser/common.clj
@@ -16,8 +16,9 @@
   (:require [clj-antlr.proto :as antlr.proto]
             [clj-antlr.common :as antlr.common]
             [clojure.string :as str]
-            [com.walmartlabs.lacinia.internal-utils
-             :refer [keepv]])
+            [com.walmartlabs.lacinia.internal-utils :refer [keepv]]
+            [clojure.java.io :as io]
+            [clj-antlr.core :as antlr.core])
   (:import (org.antlr.v4.runtime.tree ParseTree TerminalNode)
            (org.antlr.v4.runtime Parser ParserRuleContext Token)
            (clj_antlr ParseError)))
@@ -136,8 +137,8 @@
               (.getText t))))))
 
 (defn antlr-parse
-  [grammar schema-string]
-  (let [{:keys [tree parser]} (antlr.proto/parse grammar nil schema-string)]
+  [grammar input-document]
+  (let [{:keys [tree parser]} (antlr.proto/parse grammar nil input-document)]
     (traverse tree parser)))
 
 (defn parse-failures
@@ -149,3 +150,9 @@
             :message message})
          errors)))
 
+(defn compile-grammar
+  [path]
+  (-> path
+      io/resource
+      slurp
+      antlr.core/parser))

--- a/src/com/walmartlabs/lacinia/parser/common.clj
+++ b/src/com/walmartlabs/lacinia/parser/common.clj
@@ -23,6 +23,17 @@
            (org.antlr.v4.runtime Parser ParserRuleContext Token)
            (clj_antlr ParseError)))
 
+(defn as-map
+  "Converts a normal Antlr production into a map."
+  [prod]
+  (->> prod
+       rest
+       (reduce (fn [m sub-prod]
+                 (assoc! m (first sub-prod) (rest sub-prod)))
+               (transient {}))
+       persistent!))
+
+
 (defn ^:private unescape-ascii
   [^String escaped-sequence]
   (case escaped-sequence
@@ -79,6 +90,12 @@
                                          l))
                                      (rest lines)))]
         (str/join "\n" trimmed-lines)))))
+
+(defn copy-meta
+  "Copys meta data from an object to a new object; with Antlr, meta data
+  is location data."
+  [to from]
+  (with-meta to (meta from)))
 
 (defn blockstringvalue->String
   "Transform an ANTLR multi-line block string value into a Clojure string."

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -84,7 +84,7 @@
   (cond-> schema
     scalars (assoc :scalars scalars)))
 
-;; This is very similar to the code for parsing a query, and included a bit of duplication.
+;; This is very similar to the code for parsing a query, and includes a bit of duplication.
 ;; Perhaps at some point we can merge it all into a single, unified grammar.
 
 (defmulti ^:private xform

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -16,7 +16,8 @@
   "Parse a Schema Definition Language document into a Lacinia input schema."
   {:added "0.22.0"}
   (:require
-    [com.walmartlabs.lacinia.internal-utils :refer [remove-vals]]
+    #_[io.pedestal.log :as log]
+    [com.walmartlabs.lacinia.internal-utils :refer [remove-vals keepv q]]
     [com.walmartlabs.lacinia.parser.common :as common]
     [com.walmartlabs.lacinia.util :refer [inject-descriptions]]
     [clojure.spec.alpha :as s])
@@ -31,236 +32,40 @@
 (def ^:private grammar
   (common/compile-grammar "com/walmartlabs/lacinia/schema.g4"))
 
-(defn ^:private rest-or-true
-  "Return (rest coll), or true if coll only contains a single element."
-  [coll]
-  (or (seq (rest coll))
-      [true]))
+(defn ^:private tag
+  "Returns a map of the nested productions in a production.
+  Nested productions are elements after the first; the key is the
+  first element in each nested production.
 
-(defn ^:private select
-  "Selects nodes from the ANTLR parse tree given a path, which is a
-  vector of alternatively node keyword labels, sets of node keyword
-  labels or predicate functions that accept a node as a
-  parameter. Always accepts and returns a sequence of nodes."
-  [path nodes]
-  (let [[p & rst] path]
-    (cond->> (seq (mapcat
-                   (fn [node]
-                     (map rest-or-true
-                          (filter (cond
-                                    (keyword? p) #(= (first %) p)
-                                    (set? p) #(p (first %))
-                                    (fn? p) p)
-                                  node)))
-                   nodes))
-      (seq rst) (recur rst))))
+  Note that this should only be used in cases where none of the productions repeat."
+  [prod]
+  (reduce (fn [m p]
+            (assoc m (first p) p))
+          {}
+          (rest prod)))
 
-(defn ^:private select-map
-  "Maps over selected nodes, providing a sequence of nodes as a
-  shortcut to facilitate using selectors within f."
-  [f path nodes]
-  (map (comp f vector) (select path nodes)))
+(defn ^:private assoc-check
+  [m content k v]
+  (when (contains? m k)
+    (let [locations (keepv meta [(get m k)
+                                 v])]
+      (throw (ex-info (format "Conflicting %s: %s."
+                              content
+                              (q k))
+                      (cond-> {:key k}
+                        (seq locations) (assoc :locations locations))))))
+  (assoc m k v))
 
-(defn ^:private select1
-  "Selects a terminal scalar value. Should only be used when path
-  resolves to a single scalar."
-  [path nodes]
-  (ffirst (select path nodes)))
+(defn ^:private checked-map
+  "Given a seq of key/value tuples, assembles a map, checking that keys do not conflict
+  (throwing an exception if they do).
 
-(defn ^:private xform-type-name
-  [typename]
-  (if (#{"Boolean" "String" "Int" "Float" "ID"} typename)
-    (symbol typename)
-    (keyword typename)))
-
-(defn ^:private xform-typespec
-  "Transforms a type specification parse tree node.
-
-  Example node:
-  ((:typeName (:name \"Character\")))
-  or
-  ((:listType (:typeSpec (:typeName (:name \"episode\")))))"
-  [typespec]
-  (cond
-    ;; list
-    (select1 [:listType] typespec) (cond->> (list 'list (xform-typespec (select [:listType :typeSpec] typespec)))
-                                     (select1 [:required] typespec) (list 'non-null))
-    ;; scalar
-    :else (cond->> (xform-type-name (select1 [:typeName :name] typespec))
-            (select1 [:required] typespec) (list 'non-null))))
-
-(declare ^:private xform-map-value)
-
-(defn ^:private xform-default-value
-  "Transforms a default argument value parse tree node.
-
-  Example node:
-  ((:value
-   (:objectValue
-    (:objectField
-     (:name \"name\")
-     (:value (:stringvalue \"Unspecified\")))
-    (:objectField
-     (:name \"episodes\")
-     (:value
-      (:arrayValue
-       (:value (:enumValue (:name \"NEWHOPE\")))
-       (:value (:enumValue (:name \"EMPIRE\")))
-       (:value (:enumValue (:name \"JEDI\")))))))))"
-  [arg-value]
-  (let [[type value & _] arg-value]
-    (case type
-      :nullvalue nil
-      :enumValue (keyword (second value))
-      :arrayValue (mapv (comp xform-default-value second) (rest arg-value))
-      :objectValue (apply merge (select-map xform-map-value [:objectField] [(rest arg-value)]))
-      :stringvalue (common/stringvalue->String value)
-      :blockstringvalue (common/blockstringvalue->String value)
-      value)))
-
-(defn ^:private xform-map-value
-  "Transforms a map value parse tree node.
-
-  Example node:
-  ((:name \"name\")
-   (:value (:stringvalue \"Unspecified\")))"
-  [object-field]
-  {(keyword (select1 [:name] object-field))
-   (some-> (select1 [:value] object-field)
-           (xform-default-value))})
-
-(defn ^:private xform-field-arg
-  "Transforms an argument parse tree node.
-
-  Example node:
-  ((:name \"episode\")
-   (:typeSpec (:typeName (:name \"episode\")))
-   (:defaultValue (:value (:enumValue (:name \"NEWHOPE\")))))"
-  [arg]
-  {(keyword (select1 [:name] arg))
-   (let [field-arg {:type (xform-typespec (select [:typeSpec] arg))}]
-     (if-let [default-value (some-> (select1 [:defaultValue :value] arg)
-                                    (xform-default-value))]
-       (assoc field-arg :defaultValue default-value)
-       field-arg))})
-
-(defn ^:private xform-field
-  "Transforms a field parse tree node.
-
-  Example node:
-  ((:fieldName (:name \"name\"))
-   (:typeSpec (:typeName (:name \"String\"))))"
-  [field]
-  {(keyword (select1 [:fieldName :name] field))
-   (cond-> {:type (xform-typespec (select [:typeSpec] field))}
-     (select [:fieldArgs] field) (assoc :args
-                                        (apply merge
-                                               (select-map xform-field-arg [:fieldArgs :argument] field))))})
-
-(defn ^:private xform-type
-  "Transforms a type definition parse tree node.
-
-  Example node:
-  ((:'type' \"type\")
-   (:typeName (:name \"CharacterOutput\"))
-   (:implementationDef
-    (:'implements' \"implements\")
-    (:typeName (:name \"Human\"))
-    (:typeName (:name \"Jedi\"))
-   (:fieldDef
-    (:fieldName (:name \"name\"))
-    (:typeSpec (:typeName (:name \"String\"))))
-   (:fieldDef
-    (:fieldName (:name \"birthDate\"))
-    (:typeSpec (:typeName (:name \"Date\")))))"
-  [type]
-  {(keyword (select1 [:typeName :name] type))
-   (let [[_ _ maybe-impl-def] (first type)
-         implemented-types (when (= :implementationDef (first maybe-impl-def))
-                             (->> maybe-impl-def
-                                  (drop 2)                  ; :implementationDef and :implements pair
-                                  (map (comp keyword second second))))]
-     (cond-> {:fields (apply merge (select-map xform-field [:fieldDef] type))}
-       implemented-types (assoc :implements implemented-types)))})
-
-(defn ^:private xform-enum
-  "Transforms an enum parse tree node.
-
-  Example node:
-  ((:'enum' \"enum\")
-   (:typeName (:name \"episode\"))
-   (:scalarName (:name \"NEWHOPE\"))
-   (:scalarName (:name \"EMPIRE\"))
-   (:scalarName (:name \"JEDI\")))"
-  [enum]
-  {(keyword (select1 [:typeName :name] enum))
-   {:values (vec (map #(hash-map :enum-value (-> % first keyword))
-                      (select [:scalarName :name] enum)))}})
-
-#_ (defn ^:private xform-operation
-  "Transforms an operation parse tree node by inlining the operation types."
-  [schema operation]
-  (let [operation-type (keyword (select1 [:typeName :name] operation))]
-    (or (:fields (get-in schema [:objects operation-type]))
-        ;; Since Lacinia schemas do not support specifying a
-        ;; union type as an operation directly but the
-        ;; GraphQL schema language does, then we need to
-        ;; resolve the union here.
-        (some->> (get-in schema [:unions operation-type :members])
-                 (map #(get-in schema [:objects % :fields]))
-                 (apply merge))
-        (throw (ex-info "Operation type not found" {:operation operation-type})))))
-
-(defn ^:private xform-scalar
-  "Transforms a scalar parse tree node.
-
-  Example node:
-  ((:'scalar' \"scalar\") (:typeName (:name \"Date\")))"
-  [scalar]
-  {(keyword (select1 [:typeName :name] scalar))
-   {:parse nil
-    :serialize nil}})
-
-(defn ^:private xform-union
-  "Transforms a union parse tree node.
-
-  Example node:
-  ((:'union' \"union\")
-   (:typeName (:name \"Queries\"))
-   (:unionTypes
-    (:typeName (:name \"Query\"))
-    (:'|' \"|\")
-    (:typeName (:name \"OtherQuery\"))))"
-  [union]
-  {(keyword (select1 [:typeName :name] union))
-   {:members (mapv (comp keyword first)
-                   (select [:unionTypes :typeName :name] union))}})
-
-(defn ^:private attach-operations
-  "Builds the :schema key of the Lacinia schema.
-
-  Example schema definition parse tree node:
-
-  ((:schemaDef
-    (:'schema' \"schema\")
-    (:operationTypeDef
-     (:queryOperationDef
-      (:'query' \"query\")
-      (:typeName (:name \"Queries\"))))
-    (:operationTypeDef
-     (:mutationOperationDef
-      (:'mutation' \"mutation\")
-      (:typeName (:name \"Mutation\"))))
-    (:operationTypeDef
-     (:subscriptionOperationDef
-      (:'subscription' \"subscription\")
-      (:typeName (:name \"Subscription\"))))))"
-  [schema root]
-  (->> (select [:schemaDef :operationTypeDef] root)
-       (map #(vector (-> % first second second keyword)
-                     (-> % first (nth 2) second second keyword)))
-       (into {})
-       (assoc schema :roots)))
+  content describes what is being built, and is used for exception messages."
+  [content kvs]
+  (reduce (fn [m [k v]]
+            (assoc-check m content k v))
+          {}
+          kvs))
 
 (defn ^:private attach-field-fns
   "Attaches a map of either resolvers or subscription streamers"
@@ -279,74 +84,225 @@
   (cond-> schema
     scalars (assoc :scalars scalars)))
 
-(defn ^:private duplicates
-  "Returns duplicates in coll, retaining original element meta"
-  [coll]
-  (let [coll-freq (frequencies coll)]
-    (->> (remove (fn [el] (= (get coll-freq el) 1)) coll)
-         (seq))))
+;; This is very similar to the code for parsing a query, and included a bit of duplication.
+;; Perhaps at some point we can merge it all into a single, unified grammar.
 
-(defn ^:private validate!
-  "Validates the schema parse tree against errors that will be hidden
-  by the transformation to the Lacinia schema."
-  [root]
-  (when-let [errors (->> (concat
-                          ;; Find duplicate types
-                          (when-let [duplicate-types (->> root
-                                                          (select [#{:typeDef :enumDef :scalarDef :unionDef :interfaceDef :inputTypeDef} :typeName])
-                                                          (map first)
-                                                          (duplicates))]
-                            [{:error "Duplicate type names" :duplicate-types (map (fn [type-name-node]
-                                                                                    {:name (second type-name-node)
-                                                                                     :location (meta type-name-node)})
-                                                                                  duplicate-types)}])
-                          ;; find duplicate fields within each type
-                          (select-map (fn [nodes]
-                                        (when-let [duplicate-fields (->> nodes
-                                                                         (select [:fieldDef :fieldName])
-                                                                         (map first)
-                                                                         (duplicates))]
-                                          {:error "Duplicate fields defined on type"
-                                           :duplicate-fields (map (fn [field-name-node]
-                                                                    {:name (second field-name-node)
-                                                                     :location (meta field-name-node)})
-                                                                  duplicate-fields)
-                                           :type (select1 [:typeName :name] nodes)}))
-                                      [#{:typeDef :inputTypeDef :interfaceDef}]
-                                      root)
-                          ;; find duplicate arguments within each field
-                          (select-map (fn [nodes]
-                                        (when-let [duplicate-args (->> nodes
-                                                                       (select [:fieldArgs :argument :name])
-                                                                       (map first)
-                                                                       (duplicates))]
-                                          {:error "Duplicate arguments defined on field"
-                                           :duplicate-arguments (distinct duplicate-args)
-                                           :field (let [field-name-node (select1 [:fieldName] nodes)]
-                                                    {:name (second field-name-node)
-                                                     :location (meta field-name-node)})}))
-                                      [#{:typeDef :interfaceDef} :fieldDef]
-                                      root))
-                         (remove nil?)
-                         (seq))]
-    (throw (ex-info "Error parsing schema" {:errors errors}))))
+(defmulti ^:private xform
+  "Transform an Antlr production into a result.
+
+  Antlr productions are recursive lists; the first element is a type
+  (from the grammar), and the rest of the list are nested productions.
+
+  Meta data on the production is the location (line, column) of the production."
+  first
+  ;; When debugging/developing, this is incredibly useful:
+  #_(fn [prod]
+      (log/trace :dispatch prod)
+      (first prod))
+  :default ::default)
+
+(defn ^:private xform-second
+  [prod]
+  (-> prod second xform))
+
+
+(defmethod xform :schemaDef
+  [prod]
+  [[:roots] (checked-map "schema entry" (map xform (drop 2 prod)))])
+
+(defmethod xform :operationTypeDef
+  [prod]
+  (xform (second prod)))
+
+(defmethod xform :queryOperationDef
+  [prod]
+  (let [[_ _ type-prod] prod]
+    [:query (xform type-prod)]))
+
+(defmethod xform :mutationOperationDef
+  [prod]
+  (let [[_ _ type-prod] prod]
+    [:mutation (xform type-prod)]))
+
+(defmethod xform :subscriptionOperationDef
+  [prod]
+  (let [[_ _ type-prod] prod]
+    [:subscription (xform type-prod)]))
+
+(defmethod xform :typeName
+  [prod]
+  (let [name-k (xform-second prod)]
+    ;; By convention, these type names for built-in types are represented as
+    ;; symbols, not keywords.
+    (if (#{:Boolean :String :Int :Float :ID} name-k)
+      (-> name-k name symbol)
+      name-k)))
+
+(defmethod xform :name
+  [prod]
+  (-> prod second keyword))
+
+(defmethod xform :typeDef
+  [prod]
+  (let [{:keys [typeName implementationDef fieldDefs]} (tag prod)]
+    [[:objects (xform typeName)]
+     (cond-> (common/copy-meta {:fields (xform fieldDefs)} typeName)
+       implementationDef (assoc :implements (xform implementationDef)))]))
+
+(defmethod xform :fieldDefs
+  [prod]
+  (checked-map "field" (map xform (rest prod))))
+
+(defmethod xform :fieldDef
+  [prod]
+  (let [{:keys [fieldName typeSpec fieldArgs]} (tag prod)]
+    [(xform fieldName)
+     (cond-> (common/copy-meta {:type (xform typeSpec)} fieldName)
+       fieldArgs (assoc :args (xform fieldArgs)))]))
+
+(defmethod xform :fieldArgs
+  [prod]
+  (checked-map "field argument" (map xform (rest prod))))
+
+(defmethod xform :argument
+  [prod]
+  (let [{:keys [name typeSpec defaultValue]} (tag prod)]
+    [(xform name)
+     (cond-> (common/copy-meta {:type (xform typeSpec)} name)
+       defaultValue (assoc :default-value (xform-second defaultValue)))]))
+
+(defmethod xform :value
+  [prod]
+  (xform-second prod))
+
+(defmethod xform :enumValue
+  [prod]
+  (xform-second prod))
+
+(defmethod xform :booleanvalue
+  [prod]
+  (Boolean/valueOf ^String (second prod)))
+
+(defmethod xform :intvalue
+  [prod]
+  (Integer/parseInt ^String (second prod)))
+
+(defmethod xform :floatvalue
+  [prod]
+  (Float/parseFloat ^String (second prod)))
+
+(defmethod xform :fieldName
+  [prod]
+  (xform-second prod))
+
+(defmethod xform :implementationDef
+  [prod]
+  (let [types (drop 2 prod)]
+    (mapv xform types)))
+
+(defmethod xform :typeSpec
+  [prod]
+  (let [[_ type required] prod
+        base-type (-> type xform)]
+    (if (some? required)
+      (list 'non-null base-type)
+      base-type)))
+
+(defmethod xform :listType
+  [prod]
+  (list 'list (xform-second prod)))
+
+(defmethod xform :interfaceDef
+  [prod]
+  (let [[_ _ type fieldDefs] prod]
+    [[:interfaces (xform type)]
+     (common/copy-meta {:fields (xform fieldDefs)} type)]))
+
+(defmethod xform :unionDef
+  [prod]
+  (let [[_ _ type unionTypes] prod]
+    [[:unions (xform type)]
+     (common/copy-meta {:members (xform unionTypes)} type)]))
+
+(defmethod xform :unionTypes
+  [prod]
+  (->> prod
+       rest
+       (filter #(-> % first (= :typeName)))
+       (mapv xform)))
+
+(defmethod xform :enumDef
+  [prod]
+  (let [[_ _ type & enumValues] prod]
+    [[:enums (xform type)]
+     {:values (mapv (fn [prod]
+                      (common/copy-meta {:enum-value (xform prod)} prod))
+                    enumValues)}]))
+
+(defmethod xform :scalarName
+  [prod]
+  (xform-second prod))
+
+(defmethod xform :inputTypeDef
+  [prod]
+  (let [{:keys [typeName fieldDefs]} (tag prod)]
+    [[:input-objects (xform typeName)]
+     (common/copy-meta {:fields (xform fieldDefs)} typeName)]))
+
+(defmethod xform :scalarDef
+  [prod]
+  (let [[_ _ typeName] prod]
+    [[:scalars (xform typeName)]
+     (common/copy-meta {} typeName)]))
+
+(defmethod xform :objectValue
+  [prod]
+  (-> (map xform (rest prod))
+      (as-> % (checked-map "object key" %))
+      (common/copy-meta prod)))
+
+(defmethod xform :objectField
+  [prod]
+  (let [[_ name value] prod]
+    [(xform name)
+     (xform value)]))
+
+(defmethod xform :stringvalue
+  [prod]
+  (-> prod second common/stringvalue->String))
+
+(defmethod xform :blockstringvalue
+  [prod]
+  (-> prod second common/blockstringvalue->String))
+
+(defmethod xform :arrayValue
+  [prod]
+  (common/copy-meta (mapv xform (rest prod)) prod))
 
 (defn ^:private xform-schema
   "Given an ANTLR parse tree, returns a Lacinia schema."
   [antlr-tree resolvers scalars streamers documentation]
-  (let [root (select [:graphqlSchema] [[antlr-tree]])]
-    (validate! root)
-    (-> {:objects (apply merge (select-map xform-type [:typeDef] root))
-         :input-objects (apply merge (select-map xform-type [:inputTypeDef] root))
-         :enums (apply merge (select-map xform-enum [:enumDef] root))
-         :scalars (apply merge (select-map xform-scalar [:scalarDef] root))
-         :unions (apply merge (select-map xform-union [:unionDef] root))
-         :interfaces (apply merge (select-map xform-type [:interfaceDef] root))}
+  (let [schema (->> antlr-tree
+                    rest
+                    (map xform)
+                    (reduce (fn [schema [path value]]
+                              (let [path' (butlast path)
+                                    k (last path)]
+                                ;; Generally, the path is two values (a category such
+                                ;; as :objects, and a key within), but there's also
+                                ;; [:root] (for the schema production).
+                                (if-not (seq path')
+                                  (assoc schema k value)
+                                  (update-in schema path'
+                                             assoc-check
+                                             (-> path' last name) k value))))
+                            {}))]
+    (-> schema
         (attach-field-fns :resolve resolvers)
         (attach-field-fns :stream streamers)
+        ;; TODO: This should inject stuff into the scalar, not replace it, right?
         (attach-scalars scalars)
-        (inject-descriptions documentation)
-        (attach-operations root))))
+        (inject-descriptions documentation))))
 
 (defn parse-schema
   "Given a GraphQL schema string, parses it and returns a Lacinia EDN
@@ -375,19 +331,19 @@
                     ed)))
 
   (let [{:keys [resolvers scalars streamers documentation]} attach]
-    (remove-vals ;; Remove any empty schema components to avoid clutter
-     ;; and optimize for human readability
-     #(or (nil? %) (= {} %))
-     (xform-schema (try
-                     (common/antlr-parse grammar schema-string)
-                     (catch ParseError e
-                       (let [failures (common/parse-failures e)]
-                         (throw (ex-info "Failed to parse GraphQL schema."
-                                         {:errors failures})))))
-                   resolvers
-                   scalars
-                   streamers
-                   documentation))))
+    (remove-vals                                            ;; Remove any empty schema components to avoid clutter
+      ;; and optimize for human readability
+      #(or (nil? %) (= {} %))
+      (xform-schema (try
+                      (common/antlr-parse grammar schema-string)
+                      (catch ParseError e
+                        (let [failures (common/parse-failures e)]
+                          (throw (ex-info "Failed to parse GraphQL schema."
+                                          {:errors failures})))))
+                    resolvers
+                    scalars
+                    streamers
+                    documentation))))
 
 (s/def ::field-fn (s/map-of simple-keyword? (s/or :function fn? :keyword simple-keyword?)))
 (s/def ::fn-map (s/map-of simple-keyword? ::field-fn))

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -279,7 +279,9 @@
 ;; Use of a function here, rather than just the set, is due to https://github.com/bhb/expound/issues/101
 (s/def ::wrapped-type-modifier #(contains? #{'list 'non-null} %))
 (s/def ::arg (s/keys :req-un [::type]
-                     :opt-un [::description]))
+                     :opt-un [::description
+                              ::default-value]))
+(s/def ::default-value any?)
 (s/def ::args (s/map-of ::schema-key ::arg))
 ;; Defining these callbacks in spec has been a challenge. At some point,
 ;; we can expand this to capture a bit more about what a field resolver

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -76,7 +76,10 @@
       (is (= {:enums {:episode {:values [{:enum-value :NEWHOPE}
                                          {:enum-value :EMPIRE}
                                          {:enum-value :JEDI}]}}
-              :scalars {:Date {:parse date-parse :serialize date-parse}}
+              ;; Demonstrate that the scalar in the SDL (with a description) has the :parse and :serialize merged onto it:
+              :scalars {:Date {:parse date-parse
+                               :serialize date-parse
+                               :description "Date in standard ISO format"}}
               :interfaces {:Human {:fields {:name {:type 'String}
                                             :birthDate {:type :Date}}}}
               :unions {:Queries {:members [:Query :OtherQuery]}}

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -242,3 +242,38 @@
     (is (some? input-arg))
     (is (= "line 1\n\nline 3\n  indented line 4\nline 5"
            (:default-value input-arg)))))
+
+(deftest embedded-docs
+  (let [schema (-> "documented-schema.sdl"
+                   resource
+                   slurp
+                   (parser/parse-schema {}))]
+    (is (= {:enums {:FileNodeType {:description "File node type."
+                                   :values [{:description "A standard file-system file."
+                                             :enum-value :FILE}
+                                            {:description "A directory that may contain other files and directories."
+                                             :enum-value :DIR}
+                                            {:description "A special file, such as a device."
+                                             :enum-value :SPECIAL}]}}
+            :interfaces {:Named {:description "Things that have a name."
+                                 :fields {:name {:description "The unique name for the Named thing."
+                                                 :type 'String}}}}
+            :objects {:Directory {:description "Directory type."
+                                  :fields {:contents {:args {:match {:description "Wildcard used for matching."
+                                                                     :type 'String}}
+                                                      :type '(list :DirectoryListing)}
+                                           :name {:type 'String}
+                                           :permissions {:type :Permissions}}
+                                  :implements [:Named]}
+                      :DirectoryListing {:fields {:name {:type 'String}
+                                                  :node_type {:type :FileNodeType}}
+                                         :implements [:Named]}
+                      :File {:fields {:name {:type 'String}}
+                             :implements [:Named]}
+                      :Query {:fields {:file {:args {:path {:type 'String}}
+                                              :type :FileSystemEntry}}}}
+            :scalars {:Permissions {:description "String that identifies permissions on a file or directory."}}
+            :unions {:FileSystemEntry {:description "Stuff that can appear on the file system"
+                                       :members [:File
+                                                 :Directory]}}}
+           schema))))


### PR DESCRIPTION
Follow on to #217 

- Previously :scalars option just overwrote any scalars from the document
- Now, we merge - because documentation for scalars may be in the SDL document
- I also noticed some out-of-date comments, and some dead code to delete