### PR TITLE
Add (failing) test for duplicate Fragment names

### DIFF
--- a/test/com/walmartlabs/lacinia/validator_test.clj
+++ b/test/com/walmartlabs/lacinia/validator_test.clj
@@ -191,6 +191,36 @@
                                    :line 9}]
                       :message "Fragment `HumanFragment' is never used."}]}
            (execute compiled-schema q {} nil))))
+  (let [q "query UseFragment {
+             luke: human(id: \"1000\") {
+               ...HumanFragment
+             }
+           }
+           fragment HumanFragment on human {
+             name
+           }
+           fragment HumanFragment on human {
+             homePlanet
+           }"]
+    (is (= {:errors [{:locations [{:column 21 :line 6}, {:column 21 :line 9}]
+                      :message "There can be only one fragment named \"HumanFragment\"."}
+                      ]}
+           (execute compiled-schema q {} nil))))
+  (let [q "query UseFragment {
+             luke: human(id: \"1000\") {
+               name
+             }
+           }
+           fragment UnusedDuplicateFragment on human {
+             name
+           }
+           fragment UnusedDuplicateFragment on human {
+             homePlanet
+           }"]
+    (is (= {:errors [{:locations [{:column 21 :line 6}, {:column 21 :line 9}]
+                      :message "There can be only one fragment named \"UnusedDuplicateFragment\"."}
+                      ]}
+           (execute compiled-schema q {} nil))))
   (let [q "query withNestedFragments {
              luke: human(id: \"1000\") {
                friends {


### PR DESCRIPTION
Currently lacinia does not validate uniqueness of Fragment names, so this test should be failing. 
I am sending it as a PR to gather feedback. I don't know if marking the test as "pending" and merging is an option (I know this from other testing tools). 

--- 

spec: <http://facebook.github.io/graphql/June2018/#sec-Fragment-Name-Uniqueness>
test in reference implementation: <https://github.com/graphql/graphql-js/blob/bce300f9db68a738dd30d2b8be81efb30b78690c/src/validation/__tests__/UniqueFragmentNames-test.js#L101-L132>