### PR TITLE
When using attach-resolvers, if a field already has a function attached, it incorrectly treats it as a factory function reference

### DIFF
--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -80,7 +80,7 @@
                            (cond-> node
                              (-> arguments :if false?) (assoc :disabled? true)))}}))
 
-(declare ^:private xform-argument-map build-map-from-parsed-arguments)
+(declare ^:private build-map-from-parsed-arguments)
 
 (defn ^:private xform-argument-value
   "Returns a tuple of type and string value.  True scalar values will be passed,
@@ -1015,21 +1015,6 @@
                   :fragment-name fragment-name})
           (cond-> directives (assoc :directives (convert-parsed-directives schema directives)))
           mark-node-for-prepare))))
-
-(defn ^:private find-element
-  [container element-type]
-  (->> container
-       next
-       (filter #(= (first %) element-type))
-       first))
-
-(defn ^:private element->map
-  "Maps a parsed element to a map."
-  [element]
-  (reduce (fn [m sub-element]
-            (assoc m (first sub-element) (rest sub-element)))
-          nil
-          (rest element)))
 
 (defn ^:private construct-var-type-map
   "Converts a var-type (in the parsed format) into a similar stucture that

--- a/src/com/walmartlabs/lacinia/util.clj
+++ b/src/com/walmartlabs/lacinia/util.clj
@@ -31,6 +31,9 @@
                 (fn? reference)
                 field
 
+                (var? reference)
+                field
+
                 :let [factory? (not (keyword? reference))
                       callback-source (get callbacks-map
                                            (if factory?

--- a/src/com/walmartlabs/lacinia/util.clj
+++ b/src/com/walmartlabs/lacinia/util.clj
@@ -28,6 +28,9 @@
                 (nil? reference)
                 field
 
+                (fn? reference)
+                field
+
                 :let [factory? (not (keyword? reference))
                       callback-source (get callbacks-map
                                            (if factory?

--- a/test/com/walmartlabs/lacinia/expound_tests.clj
+++ b/test/com/walmartlabs/lacinia/expound_tests.clj
@@ -17,6 +17,7 @@
   (:require
     [clojure.test :refer [deftest is use-fixtures]]
     [com.walmartlabs.test-reporting :refer [reporting]]
+    com.walmartlabs.lacinia.expound
     [com.walmartlabs.lacinia.schema :as schema]
     [com.walmartlabs.lacinia.parser.schema :as ps]
     [clojure.spec.alpha :as s]

--- a/test/com/walmartlabs/lacinia/expound_tests.clj
+++ b/test/com/walmartlabs/lacinia/expound_tests.clj
@@ -17,7 +17,6 @@
   (:require
     [clojure.test :refer [deftest is use-fixtures]]
     [com.walmartlabs.test-reporting :refer [reporting]]
-    com.walmartlabs.lacinia.expound
     [com.walmartlabs.lacinia.schema :as schema]
     [com.walmartlabs.lacinia.parser.schema :as ps]
     [clojure.spec.alpha :as s]

--- a/test/com/walmartlabs/lacinia/roots_test.clj
+++ b/test/com/walmartlabs/lacinia/roots_test.clj
@@ -15,7 +15,6 @@
 (ns com.walmartlabs.lacinia.roots-test
   "Tests related to specifying  operation root object names."
   (:require
-    com.walmartlabs.lacinia.parser
     [clojure.test :refer [deftest is]]
     [com.walmartlabs.lacinia.schema :as schema]
     [com.walmartlabs.test-utils :refer [execute compile-schema]]))

--- a/test/com/walmartlabs/lacinia/util_test.clj
+++ b/test/com/walmartlabs/lacinia/util_test.clj
@@ -18,11 +18,15 @@
             [com.walmartlabs.lacinia.util :as util])
   (:import (clojure.lang ExceptionInfo)))
 
+(defn resolve-id
+  [_ _ _])
+
 (deftest attach-resolvers
   (let [schema {:objects
                 {:person
                  {:fields
-                  {:id {:type 'Int}
+                  {:id {:type 'Int
+                        :resolve resolve-id}
                    :name {:type 'String
                           :resolve :person-name}
                    :total-credit {:type 'Int
@@ -39,7 +43,8 @@
         resolved-schema {:objects
                          {:person
                           {:fields
-                           {:id {:type 'Int}
+                           {:id {:type 'Int
+                                 :resolve resolve-id}
                             :name {:type 'String
                                    :resolve str}
                             :total-credit {:type 'Int


### PR DESCRIPTION
If `:resolve` value is an fn, `attach-callbacks` should skip it instead of trying to treat is as "factory" (which results in an exception). This behavior is useful when merging multiple schemas with already attached resolvers.

Ping @bcarrell, @hlship 