### PR TITLE
Specify a version for clojure-future-spec

### DIFF
--- a/docs/clojure.rst
+++ b/docs/clojure.rst
@@ -7,6 +7,6 @@ To use Lacinia with Clojure 1.8, modify your :file:`project.clj` to include ``cl
 
     :dependencies [[org.clojure/clojure "1.8.0"]
                    [com.walmartlabs/lacinia "x.y.z"]
-                   [clojure-future-spec ""]
+                   [clojure-future-spec "1.9.0-beta4"]
                    ...]
 


### PR DESCRIPTION
Otherwise one would get following error: `Bad artifact coordinates clojure-future-spec:clojure-future-spec:jar:, expected format is <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>`