### PR TITLE
Fix SDL parsing to not improperly require wrapping curly braces

### DIFF
--- a/dev-resources/bad_schema.sdl
+++ b/dev-resources/bad_schema.sdl
@@ -1,51 +1,49 @@
-{
-  # Changing this will probably break tests.
-  enum episode {
-    NEWHOPE
-    EMPIRE
-    JEDI
-  }
+# Changing this will probably break tests.
+enum episode {
+  NEWHOPE
+  EMPIRE
+  JEDI
+}
 
-  scalar Date
+scalar Date
 
-  interface Character {
-    name: String
-    birthDate: Date
-  }
+interface Character {
+  name: String
+  birthDate: Date
+}
 
-  type CharacterOutput implements Character {
-    name: String
-    birthDate: Date
-    episodes: [episode]
-  }
+type CharacterOutput implements Character {
+  name: String
+  birthDate: Date
+  episodes: [episode]
+}
 
-  input Character {
-    name: String!
-    birthDate: Date
-    episodes: [episode]
-  }
+input Character {
+  name: String!
+  birthDate: Date
+  episodes: [episode]
+}
 
-  type Query {
-    in_episode(episode: episode = NEWHOPE, episode: String) : [CharacterOutput]
-  }
+type Query {
+  in_episode(episode: episode = NEWHOPE, episode: String) : [CharacterOutput]
+}
 
-  type Query {
-    find_by_names(names: [String!]!) : [CharacterOutput]
-    find_by_names(character_names: [String!]!) : [CharacterOutput]
-  }
+type Query {
+  find_by_names(names: [String!]!) : [CharacterOutput]
+  find_by_names(character_names: [String!]!) : [CharacterOutput]
+}
 
-  union Queries = Query
+union Queries = Query
 
-  type Queries {
-    find_by_names: Character
-  }
+type Queries {
+  find_by_names: Character
+}
 
-  type Mutation {
-    add(character: Character = {name: "Unspecified", episode: [NEWHOPE, EMPIRE, JEDI]}) : Boolean
-  }
+type Mutation {
+  add(character: Character = {name: "Unspecified", episode: [NEWHOPE, EMPIRE, JEDI]}) : Boolean
+}
 
-  schema {
-    query: Queries
-    mutation: Mutation
-  }
+schema {
+  query: Queries
+  mutation: Mutation
 }

--- a/dev-resources/blockquote.sdl
+++ b/dev-resources/blockquote.sdl
@@ -1,14 +1,9 @@
-{
-  type Query {
-   with_default(arg: String = """
-     line 1
+type Query {
+ with_default(arg: String = """
+   line 1
 
-     line 3
-       indented line 4
-     line 5
-     """) : String
-  }
+   line 3
+     indented line 4
+   line 5
+   """) : String
 }
-
-
-

--- a/dev-resources/documented-schema.sdl
+++ b/dev-resources/documented-schema.sdl
@@ -1,60 +1,55 @@
-{
-  """
-  Things that have a name.
-  """
-  interface Named {
-    "The unique name for the Named thing."
-    name: String
-  }
-
-  """
-  File node type.
-  """
-  enum FileNodeType {
-    "A standard file-system file."
-    FILE
-
-    "A directory that may contain other files and directories."
-    DIR
-
-    "A special file, such as a device."
-    SPECIAL
-  }
-
-  type DirectoryListing implements Named {
-    name: String
-    node_type: FileNodeType
-  }
-
-  """
-  String that identifies permissions on a file or directory.
-  """
-  scalar Permissions
-
-  """
-  Directory type.
-  """
-  type Directory implements Named {
-    name : String
-    permissions: Permissions
-    contents(
-      """
-      Wildcard used for matching.
-      """
-      match : String) : [DirectoryListing]
-  }
-
-  type File implements Named {
-    name : String
-  }
-
-  "Stuff that can appear on the file system"
-  union FileSystemEntry = File | Directory
-
-  type Query {
-    file(path : String) :  FileSystemEntry
-  }
-
+"""
+Things that have a name.
+"""
+interface Named {
+  "The unique name for the Named thing."
+  name: String
 }
 
+"""
+File node type.
+"""
+enum FileNodeType {
+  "A standard file-system file."
+  FILE
 
+  "A directory that may contain other files and directories."
+  DIR
+
+  "A special file, such as a device."
+  SPECIAL
+}
+
+type DirectoryListing implements Named {
+  name: String
+  node_type: FileNodeType
+}
+
+"""
+String that identifies permissions on a file or directory.
+"""
+scalar Permissions
+
+"""
+Directory type.
+"""
+type Directory implements Named {
+  name : String
+  permissions: Permissions
+  contents(
+    """
+    Wildcard used for matching.
+    """
+    match : String) : [DirectoryListing]
+}
+
+type File implements Named {
+  name : String
+}
+
+"Stuff that can appear on the file system"
+union FileSystemEntry = File | Directory
+
+type Query {
+  file(path : String) :  FileSystemEntry
+}

--- a/dev-resources/duplicate-type.sdl
+++ b/dev-resources/duplicate-type.sdl
@@ -1,10 +1,7 @@
-{
-  type Tree { height: Int }
+type Tree { height: Int }
 
-  type Leaf { id: ID }
+type Leaf { id: ID }
 
-  type Tree { left: Node, right: Node }
+type Tree { left: Node, right: Node }
 
-  union Node = Leaf | Tree
-
-}
+union Node = Leaf | Tree

--- a/dev-resources/enums.sdl
+++ b/dev-resources/enums.sdl
@@ -1,1 +1,1 @@
-{ enum Location { MATRIX ZION MACHINE_CITY}}
+enum Location { MATRIX ZION MACHINE_CITY}

--- a/dev-resources/interfaces.sdl
+++ b/dev-resources/interfaces.sdl
@@ -1,10 +1,8 @@
+interface Matrix
 {
-  interface Matrix
-  {
-    eject(the_one: Boolean!) : Human
-  }
+eject(the_one: Boolean!) : Human
+}
 
-  type Human {
-    name : String!
-  }
+type Human {
+name : String!
 }

--- a/dev-resources/mult-inheritance.sdl
+++ b/dev-resources/mult-inheritance.sdl
@@ -1,22 +1,20 @@
-{
-  interface Node {
-    id: ID!
-  }
+interface Node {
+  id: ID!
+}
 
-  interface Client {
-    ip: String
-  }
+interface Client {
+  ip: String
+}
 
-  type User implements Node, Client {
-    id: ID!
-    ip: String
-  }
+type User implements Node, Client {
+  id: ID!
+  ip: String
+}
 
-  type Query {
-    me: User
-  }
+type Query {
+  me: User
+}
 
-  schema {
-    query: Query
-  }
+schema {
+  query: Query
 }

--- a/dev-resources/sample_schema.sdl
+++ b/dev-resources/sample_schema.sdl
@@ -1,52 +1,50 @@
-{
-  # Changing this will probably break tests.
-  enum episode {
-    NEWHOPE
-    EMPIRE
-    JEDI
-  }
+# Changing this will probably break tests.
+enum episode {
+  NEWHOPE
+  EMPIRE
+  JEDI
+}
 
-  "Date in standard ISO format"
-  scalar Date
+"Date in standard ISO format"
+scalar Date
 
-  interface Human {
-    name: String
-    birthDate: Date
-  }
+interface Human {
+  name: String
+  birthDate: Date
+}
 
-  type CharacterOutput implements Human {
-    name: String
-    birthDate: Date
-    episodes: [episode]
-  }
+type CharacterOutput implements Human {
+  name: String
+  birthDate: Date
+  episodes: [episode]
+}
 
-  input Character {
-    name: String!
-    birthDate: Date
-    episodes: [episode]
-  }
+input Character {
+  name: String!
+  birthDate: Date
+  episodes: [episode]
+}
 
-  type Query {
-    in_episode(episode: episode = NEWHOPE) : [CharacterOutput]
-  }
+type Query {
+  in_episode(episode: episode = NEWHOPE) : [CharacterOutput]
+}
 
-  type OtherQuery {
-    find_by_names(names: [String!]!) : [CharacterOutput]
-  }
+type OtherQuery {
+  find_by_names(names: [String!]!) : [CharacterOutput]
+}
 
-  type Mutation {
-    add(character: Character = {name: "Unspecified", episodes: [NEWHOPE, EMPIRE, JEDI]}) : Boolean
-  }
+type Mutation {
+  add(character: Character = {name: "Unspecified", episodes: [NEWHOPE, EMPIRE, JEDI]}) : Boolean
+}
 
-  type Subscription {
-    new_character(episodes: [episode!]!) : CharacterOutput
-  }
+type Subscription {
+  new_character(episodes: [episode!]!) : CharacterOutput
+}
 
-  union Queries = Query | OtherQuery
+union Queries = Query | OtherQuery
 
-  schema {
-    query: Queries
-    mutation: Mutation
-    subscription: Subscription
-  }
+schema {
+  query: Queries
+  mutation: Mutation
+  subscription: Subscription
 }

--- a/dev-resources/unions.sdl
+++ b/dev-resources/unions.sdl
@@ -1,8 +1,6 @@
-{
-  type Human { name : String }
+type Human { name : String }
 
-  type Agent { id : Int
-               alias : String }
+type Agent { id : Int
+           alias : String }
 
-  union Combatant  = Human | Agent
-}
+union Combatant  = Human | Agent

--- a/docs/_examples/sample_schema.txt
+++ b/docs/_examples/sample_schema.txt
@@ -1,30 +1,28 @@
-{
-  enum episode {
-    NEWHOPE
-    EMPIRE
-    JEDI
-  }
+enum episode {
+  NEWHOPE
+  EMPIRE
+  JEDI
+}
 
-  type Character {
-    name: String!
-    episodes: [episode]
-  }
+type Character {
+  name: String!
+  episodes: [episode]
+}
 
-  input CharacterArg {
-    name: String!
-    episodes: [episode]!
-  }
+input CharacterArg {
+  name: String!
+  episodes: [episode]!
+}
 
-  type Query {
-    find_all_in_episode(episode: episode!) : [Character]
-  }
+type Query {
+  find_all_in_episode(episode: episode!) : [Character]
+}
 
-  type Mutation {
-    add_character(character: CharacterArg!) : Boolean
-  }
+type Mutation {
+  add_character(character: CharacterArg!) : Boolean
+}
 
-  schema {
-    query: Query
-    mutation: Mutation
-  }
+schema {
+  query: Query
+  mutation: Mutation
 }

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -1,7 +1,7 @@
 grammar GraphqlSchema;
 
 graphqlSchema
-  : '{' (schemaDef|typeDef|inputTypeDef|unionDef|enumDef|interfaceDef|scalarDef)* '}'
+  : (schemaDef|typeDef|inputTypeDef|unionDef|enumDef|interfaceDef|scalarDef)*
   ;
 
 description

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -207,10 +207,10 @@
     (is (= "Conflicting field argument: `episode'."
            (.getMessage e)))
     (is (= {:key :episode
-            :locations [{:column 16
-                         :line 29}
-                        {:column 44
-                         :line 29}]}
+            :locations [{:column 14
+                         :line 28}
+                        {:column 42
+                         :line 28}]}
            (ex-data e))))
 
   ;; This is a stand-in for any of the root things that can have a key conflict
@@ -218,10 +218,10 @@
                             (parse-schema "duplicate-type.sdl" {})))]
     (is (= "Conflicting objects: `Tree'." (.getMessage e)))
     (is (= {:key :Tree
-            :locations [{:column 3
-                         :line 2}
-                        {:column 3
-                         :line 6}]}
+            :locations [{:column 1
+                         :line 1}
+                        {:column 1
+                         :line 5}]}
            (ex-data e)))))
 
 (deftest supports-multiple-inheritance


### PR DESCRIPTION
The GraphQL spec does not seem to require this and the JS reference implementation of GraphQL fails to parse this syntax.