### PR TITLE
Add limited support for directives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+Limited support for custom directives.
+
+
 ## 0.30.0 -- 1 Oct 2018
 
 A field resolver that returns a list of values may now wrap the individual

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
 Limited support for custom directives.
 
-*Breaking Change*: Previous releases of the Schema Definition Language parser
-wrapped the entire document with `{` and `}`.
-This release fixes that, but it means that existing SDL document will not
-parse correctly until the curly braces are removed.
+**Breaking Change**: Previous releases of the Schema Definition Language parser
+wrapped the entire document with `{` and `}.
+This is not correct, and such documents are not valid SDL.
+
+This release fixes that, but it means that any existing SDL documents will not
+parse correctly until the outermost curly braces are removed.
 
 ## 0.30.0 -- 1 Oct 2018
 

--- a/dev-resources/sample_schema.sdl
+++ b/dev-resources/sample_schema.sdl
@@ -6,6 +6,9 @@
     JEDI
   }
 
+  "Extra tracing of field operations"
+  directive @Trace (label : String!) on FIELD_DEFINITION
+
   "Date in standard ISO format"
   scalar Date
 
@@ -27,7 +30,7 @@
   }
 
   type Query {
-    in_episode(episode: episode = NEWHOPE) : [CharacterOutput]
+    in_episode(episode: episode = NEWHOPE) : [CharacterOutput] @Trace
   }
 
   type OtherQuery {
@@ -36,6 +39,8 @@
 
   type Mutation {
     add(character: Character = {name: "Unspecified", episodes: [NEWHOPE, EMPIRE, JEDI]}) : Boolean
+    @deprecated(reason: "just for testing")
+    @Trace(label: "add-character")
   }
 
   type Subscription {

--- a/docs/_examples/directive-defs.edn
+++ b/docs/_examples/directive-defs.edn
@@ -1,0 +1,10 @@
+{:directive-defs
+ {:access
+  {:locations #{:field-definition}
+   :args {:role {:type (not-null String)}}}}
+
+ :queries
+ {:ultimate_answer
+  {:type String
+   :directives [{:directive-type :access
+                 :directive-args {:role "deep-thought"}}]}}}

--- a/docs/deprecation.rst
+++ b/docs/deprecation.rst
@@ -18,4 +18,7 @@ Typically, the description indicates an alternative field to use instead.
 Deprecation does *not* affect execution of the field in any way; the deprecation flag and reason simply shows up
 in :doc:`introspection <introspection>`.
 
+When using the :doc:`Schema Definition Language <schema/parsing>`, elements may be marked with the
+``@deprecated`` :doc:`directive <directives>`.
+
 

--- a/docs/directives.rst
+++ b/docs/directives.rst
@@ -2,14 +2,48 @@ Directives
 ==========
 
 Directives provide a way to describe additional options to the GraphQL executor.
-Directives allow Lacinia to change the incoming query based on additional criteria.
-For example, we can use directives to include or skip a field if certain criteria are met.
 
 .. sidebar:: GraphQL Spec
 
    Read about directives :spec:`here <Language.Directives>`
    and :spec:`here <Type-System.Directives>`.
 
-Currently Lacinia supports just the two standard directives: ``@skip`` and ``@include``, but future versions
+Directives allow Lacinia to change the incoming query based on additional criteria.
+For example, we can use directives to include or skip a field if certain criteria are met.
+
+Currently Lacinia supports just the two standard query directives: ``@skip`` and ``@include``, but future versions
 may include more.
-Custom directives are not yet supported.
+
+.. warning::
+
+  Directive support is currently in transition towards partially supporting custom directives.
+
+When using :doc:`schema/parsing`, the `directive` keyword allows new directives to be defined.
+Directive definitions can be defined for executable elements (such as a field in a query document), or
+for type system elements (such as an object or field definition in the schema).
+
+Directives may also be defined in an EDN schema; the root ``:directive-defs`` element is a map of directives types
+to directive definition.  A directive defintion defines the types of any arguments, as well as a set of locations.
+
+.. literalinclude:: _examples/directive-defs.edn
+   :language: clojure
+
+This defines a field definition directive, ``@access``, and applies it to the  ``ultimate_answer``
+query field.
+
+Directives are validated:
+
+* Directives may have arguments, and the argument types must be rooted in known :doc:`scalar <fields>` types.
+
+* Directives may be placed on schema elements (objects and input objects, unions, enums and enum values, fields, etc.).
+  Directives placed on an element are verified to be applicable to the location.
+
+.. warning::
+
+   Directive support is evolving quickly; full support for directives, including argument type validation,
+   is forthcoming, as is an API to identify schema and executable directives.
+
+   The goal of the current stage is to support parsing of SDL schemas that include directive definitions
+   and directives on elements.
+
+

--- a/docs/directives.rst
+++ b/docs/directives.rst
@@ -3,6 +3,9 @@ Directives
 
 Directives provide a way to describe additional options to the GraphQL executor.
 
+Directives is a GraphQL term; in practice, directives are much like meta data in Clojure,
+or annotation in Java.
+
 .. sidebar:: GraphQL Spec
 
    Read about directives :spec:`here <Language.Directives>`
@@ -18,6 +21,9 @@ may include more.
 
   Directive support is currently in transition towards partially supporting custom directives.
 
+Directives in Schema IDL
+------------------------
+
 When using :doc:`schema/parsing`, the `directive` keyword allows new directives to be defined.
 Directive definitions can be defined for executable elements (such as a field in a query document), or
 for type system elements (such as an object or field definition in the schema).
@@ -30,6 +36,9 @@ to directive definition.  A directive defintion defines the types of any argumen
 
 This defines a field definition directive, ``@access``, and applies it to the  ``ultimate_answer``
 query field.
+
+Directive Validation
+--------------------
 
 Directives are validated:
 
@@ -45,5 +54,14 @@ Directives are validated:
 
    The goal of the current stage is to support parsing of SDL schemas that include directive definitions
    and directives on elements.
+
+   :doc:`introspection` hasn't caught up to to these changes; custom directives are not identified, nor
+   are directives on elements.
+
+@deprecated directive
+---------------------
+
+The ``@deprecated`` directive is supported.
+This enables :doc:`deprecation` of object fields and enum values.
 
 

--- a/docs/directives.rst
+++ b/docs/directives.rst
@@ -4,7 +4,7 @@ Directives
 Directives provide a way to describe additional options to the GraphQL executor.
 
 Directives is a GraphQL term; in practice, directives are much like meta data in Clojure,
-or annotation in Java.
+or annotations in Java.
 
 .. sidebar:: GraphQL Spec
 
@@ -19,13 +19,13 @@ may include more.
 
 .. warning::
 
-  Directive support is currently in transition towards partially supporting custom directives.
+  Directive support is currently in transition towards some support for custom directives.
 
 Directives in Schema IDL
 ------------------------
 
 When using :doc:`schema/parsing`, the `directive` keyword allows new directives to be defined.
-Directive definitions can be defined for executable elements (such as a field in a query document), or
+Directive definitions can be defined for executable elements (such as a field selection in a query document), or
 for type system elements (such as an object or field definition in the schema).
 
 Directives may also be defined in an EDN schema; the root ``:directive-defs`` element is a map of directives types

--- a/docs/schema/parsing.rst
+++ b/docs/schema/parsing.rst
@@ -67,7 +67,7 @@ Unions may be documented, but do not contain fields.
 
 Enums may be documented, as well as Enum values (e.g., ``:Episode/JEDI``).
 
-As is normal with SDL, the available queries, mutations, and subscriptions (not shown in this example)
+As is normal with Schema Definition Language, the available queries, mutations, and subscriptions (not shown in this example)
 are defined on ordinary schema objects, and the ``schema`` element identifies which objects are used for
 which purposes.
 

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                                   [org.clojure/data.csv "0.1.4"]
                                   [org.clojure/tools.cli "0.3.7"]]}}
   :aliases {"benchmarks" ["run" "-m" "perf"]}
-  :jvm-opts ["-Xmx1g"]
+  :jvm-opts ["-Xmx1g" "-XX:-OmitStackTraceInFastThrow"]
   :test2junit-output-dir ~(or (System/getenv "CIRCLE_TEST_REPORTS") "target/test2junit")
   :codox {:source-uri "https://github.com/walmartlabs/lacinia/blob/master/{filepath}#L{line}"
           :metadata   {:doc/format :markdown}})

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -124,7 +124,7 @@ argList
   ;
 
 argument
-  : description? Name ':' typeSpec directiveList? defaultValue?
+  : description? Name ':' typeSpec defaultValue? directiveList?
   ;
 
 typeSpec

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -10,7 +10,7 @@ description
   ;
 
 schemaDef
-  : 'schema' '{' operationTypeDef+ '}'
+  : 'schema' directiveList? '{' operationTypeDef+ '}'
   ;
 
 operationTypeDef
@@ -72,7 +72,7 @@ directiveArg
   ;
 
 typeDef
-  : description? 'type' Name implementationDef? fieldDefs directiveList?
+  : description? 'type' Name directiveList? implementationDef? fieldDefs
   ;
 
 fieldDefs

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -72,7 +72,7 @@ directiveArg
   ;
 
 typeDef
-  : description? 'type' Name directiveList? implementationDef? fieldDefs
+  : description? 'type' Name implementationDef? directiveList? fieldDefs
   ;
 
 fieldDefs

--- a/src/com/walmartlabs/lacinia/compiled_schema.clj
+++ b/src/com/walmartlabs/lacinia/compiled_schema.clj
@@ -1,0 +1,23 @@
+; Copyright (c) 2018-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+(ns ^:no-doc com.walmartlabs.lacinia.compiled-schema)
+
+;; Broken out into its own namespace to help with some live reloading issues.
+
+(defrecord CompiledSchema [])
+
+(defn compiled-schema?
+  [m]
+  (instance? CompiledSchema m))

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -16,6 +16,7 @@
   "Parsing of client querys using the ANTLR grammar."
   (:require
     [clojure.string :as str]
+    [com.walmartlabs.lacinia.compiled-schema :refer [compiled-schema?]]
     [com.walmartlabs.lacinia.internal-utils
      :refer [cond-let update? q map-vals filter-vals remove-vals
              with-exception-context throw-exception to-message
@@ -27,8 +28,7 @@
     [com.walmartlabs.lacinia.parser.query :as qp]
     [flatland.ordered.map :refer [ordered-map]])
   (:import
-    (clojure.lang ExceptionInfo)
-    (com.walmartlabs.lacinia.schema CompiledSchema)))
+    (clojure.lang ExceptionInfo)))
 
 (defn ^:private first-match
   [pred coll]
@@ -1143,7 +1143,7 @@
   ;; one is being selected. With an eye towards fast execution of parsed and cached queries, this may
   ;; not be the right approach.
   ([schema query-string operation-name]
-   (when-not (instance? CompiledSchema schema)
+   (when-not (compiled-schema? schema)
      (throw (IllegalStateException. "The provided schema has not been compiled.")))
    (xform-query schema (qp/parse-query query-string) operation-name)))
 

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -360,11 +360,12 @@
 
 (defmethod xform :scalarDef
   [prod]
-  (let [{:keys [name description]} (tag prod)]
+  (let [{:keys [name description directiveList]} (tag prod)]
     [[:scalars (xform name)]
      (-> {}
          (common/copy-meta name)
-         (apply-description description))]))
+         (apply-description description)
+         (apply-directives directiveList))]))
 
 (defmethod xform :objectValue
   [prod]

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -16,7 +16,7 @@
   "Parse a Schema Definition Language document into a Lacinia input schema."
   {:added "0.22.0"}
   (:require
-    [io.pedestal.log :as log]
+    #_ [io.pedestal.log :as log]
     [com.walmartlabs.lacinia.internal-utils :refer [remove-vals keepv q]]
     [com.walmartlabs.lacinia.parser.common :as common]
     [com.walmartlabs.lacinia.util :refer [inject-descriptions]]

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -132,7 +132,16 @@
                           (rest sub-prods)
                           sub-prods)]
     [[:roots] (-> (checked-map "schema entry" (map xform remaining-prods))
+                  ;; Temporary location until patch-schema-directives is invoked
                   (apply-directives directiveList))]))
+
+(defn ^:private patch-schema-directives
+  [schema]
+  (if-let [directives (get-in schema [:roots :directives])]
+    (-> schema
+        (assoc :directives directives)
+        (update :roots dissoc :directives))
+    schema))
 
 (defmethod xform :operationTypeDef
   [prod]
@@ -414,7 +423,8 @@
         (attach-field-fns :stream streamers)
         ;; TODO: This should inject stuff into the scalar, not replace it, right?
         (attach-scalars scalars)
-        (inject-descriptions documentation))))
+        (inject-descriptions documentation)
+        patch-schema-directives)))
 
 (defn parse-schema
   "Given a GraphQL schema string, parses it and returns a Lacinia EDN

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1081,7 +1081,7 @@
                        :directive-type directive-type})))
 
     (when-not (-> directive :locations (contains? location))
-      (throw (ex-info (format "Direction @%s on %s %s is not applicable."
+      (throw (ex-info (format "Directive @%s on %s %s is not applicable."
                               (name directive-type)
                               category
                               (q object-name))

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -398,7 +398,6 @@
                     :field-definition :argument-definition :interface
                     :union :enum :enum-value :input-object :input-field-definition})
 
-;; TODO: Figure out how to allow :directives here as well
 (s/def ::roots (s/map-of #{:query :mutation :subscription} ::schema-key))
 
 (s/def ::schema-object
@@ -412,6 +411,8 @@
                    ::queries
                    ::mutations
                    ::subscriptions
+                   ;; Schema-level directives
+                   ::directives
                    ::directive-defs]))
 
 ;; Again, this can be fleshed out once we have a handle on defining specs for

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1156,11 +1156,12 @@
                              :directive-type directive-type})))
 
           (when-not (-> directive :locations (contains? :argument-definition))
-            (throw (ex-info (format "Direction @%s on argument %s of field %s is not applicable."
+            (throw (ex-info (format "Directive @%s on argument %s of field %s is not applicable."
                                     (name directive-type)
                                     (q arg-name)
                                     (q qualified-name))
                             {:field-name qualified-name
+                              :arg-name arg-name
                              :directive-type directive-type
                              :allowed-locations (:locations directive)}))))))))
 

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -398,6 +398,7 @@
                     :field-definition :argument-definition :interface
                     :union :enum :enum-value :input-object :input-field-definition})
 
+;; TODO: Figure out how to allow :directives here as well
 (s/def ::roots (s/map-of #{:query :mutation :subscription} ::schema-key))
 
 (s/def ::schema-object

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1077,7 +1077,7 @@
                               category
                               (q object-name)
                               (name directive-type))
-                      {:object-name object-name
+                      {location object-name
                        :directive-type directive-type})))
 
     (when-not (-> directive :locations (contains? location))
@@ -1085,7 +1085,7 @@
                               (name directive-type)
                               category
                               (q object-name))
-                      {:object-name object-name
+                      {location object-name
                        :directive-type directive-type
                        :allowed-locations (:locations directive)})))))
 

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1108,7 +1108,7 @@
                         {:field-name qualified-name
                          :schema-types (type-map schema)})))
 
-      (doseq [directive-type (-> object-def :directives keys)
+      (doseq [directive-type (-> field-def :directives keys)
               :let [directive (get directives directive-type)]]
         (when-not directive
           (throw (ex-info (format "Field %s references unknown directive @%s."
@@ -1118,7 +1118,7 @@
                            :directive-type directive-type})))
 
         (when-not (-> directive :locations (contains? location))
-          (throw (ex-info (format "Direction @%s on field %s is not applicable."
+          (throw (ex-info (format "Directive @%s on field %s is not applicable."
                                   (name directive-type)
                                   (q qualified-name))
                           {:field-name qualified-name
@@ -1357,17 +1357,17 @@
           directive-type (-> u :directives keys)
           :let [directive (get-in schema [::directive-defs directive-type])]]
     (when-not directive
-      (throw (ex-info (format "Union %s references unknown directive %@."
+      (throw (ex-info (format "Union %s references unknown directive @%s."
                               (-> u :type-name q)
                               (name directive-type))
-                      {:union (:type-name q)
+                      {:union (:type-name u)
                        :directive-type directive-type})))
 
     (when-not (contains? (:locations directive) :union)
-      (throw (ex-info (format "Union %s references directive %@ which is not applicable."
+      (throw (ex-info (format "Union %s references directive @%s which is not applicable."
                               (-> u :type-name q)
                               (name directive-type))
-                      {:union (:type-name q)
+                      {:union (:type-name u)
                        :directive-type directive-type}))))
 
   schema)

--- a/test/com/walmartlabs/lacinia/directives_test.clj
+++ b/test/com/walmartlabs/lacinia/directives_test.clj
@@ -315,6 +315,37 @@
        {:id {:type :String
              :directives {:Ebb nil}}}}}}))
 
+(deftest argument-directive-unknown-type
+  (directive-test
+    "Argument `ebb' of field `User/id' references unknown directive @Unknown."
+    {:directive-type :Unknown
+     :arg-name :ebb
+     :field-name :User/id}
+    {:objects
+     {:User
+      {:fields
+       {:id {:type :String
+             :args {:ebb {:type :String
+                          :directives {:Unknown nil}}}}}}}}))
+
+(deftest argument-directive-inapplicable
+  (directive-test
+    "Directive @Ebb on argument `format' of field `Flow/id' is not applicable."
+    {:allowed-locations #{:enum}
+     :directive-type :Ebb
+     :arg-name :format
+     :field-name :Flow/id}
+    {:directive-defs
+     {:Ebb {:locations #{:enum}}}
+     :objects
+     {:Flow
+      {:fields
+       {:id {:type :String
+             :args
+             {:format {:type :String
+                       :directives {:Ebb nil}}}}}}}}))
+
+
 (comment
   (require '[clojure.test :refer [run-tests]])
   (run-tests)

--- a/test/com/walmartlabs/lacinia/directives_test.clj
+++ b/test/com/walmartlabs/lacinia/directives_test.clj
@@ -257,7 +257,7 @@
 
 (deftest object-directive-inapplicable
   (directive-test
-    "Directive @Ebb on Object `Flow' is not applicable."
+    "Directive @Ebb on object `Flow' is not applicable."
     {:allowed-locations #{:enum}
      :directive-type :Ebb
      :object :Flow}
@@ -280,8 +280,10 @@
 
 (deftest union-directive-inapplicable
   (directive-test
-    "Union `Ebb' references directive @deprecated which is not applicable."
-    {:directive-type :deprecated
+    "Directive @deprecated on union `Ebb' is not applicable."
+    {:allowed-locations #{:enum-value
+                          :field-definition}
+     :directive-type :deprecated
      :union :Ebb}
     {:objects
      {:Flow {:fields {}}}
@@ -344,6 +346,41 @@
              :args
              {:format {:type :String
                        :directives [{:directive-type :Ebb}]}}}}}}}))
+
+(deftest enum-directive-unknown-type
+  (directive-test
+    "Enum `Colors' references unknown directive @Unknown."
+    {:directive-type :Unknown
+     :enum :Colors}
+    {:enums
+     {:Colors
+      {:values [:red :green :blue]
+       :directives [{:directive-type :Unknown}]}}}))
+
+(deftest enum-directive-inapplicable
+  (directive-test
+    "Directive @nope on enum `Colors' is not applicable."
+    {:allowed-locations #{:object}
+     :directive-type :nope
+     :enum :Colors}
+    {:directive-defs {:nope {:locations #{:object}}}
+     :enums
+     {:Colors
+      {:values [:red :green :blue]
+       :directives [{:directive-type :nope}]}}}))
+
+(deftest enum-value-directive-unknown-type
+  (directive-test
+    "Enum value `Colors/red' referenced unknown directive @Unknown."
+    {:directive-type :Unknown
+     :enum-value :Colors/red}
+    {:enums
+     {:Colors
+      {:values [{:enum-value :red
+                 :directives [{:directive-type :Unknown}]}
+                :green :blue]}}}))
+
+
 
 
 (comment

--- a/test/com/walmartlabs/lacinia/directives_test.clj
+++ b/test/com/walmartlabs/lacinia/directives_test.clj
@@ -406,7 +406,43 @@
                  :directives [{:directive-type :Unknown}]}
                 :green :blue]}}}))
 
+(deftest can-deprecate-object-fields
+  (let [schema (schema/compile
+                 {:objects
+                  {:User
+                   {:fields {:id {:type :ID
+                                  :directives [{:directive-type :deprecated}]}
+                             :name {:type :String
+                                    :directives [{:directive-type :deprecated
+                                                  :directive-args
+                                                  {:reason "Use full_name instead."}}]}}}}})]
+    (is (= true
+           (get-in schema [:User :fields :id :deprecated])))
+    (is (= "Use full_name instead."
+           (get-in schema [:User :fields :name :deprecated])))))
 
+(deftest can-deprecate-interface-fields
+  (let [schema (schema/compile
+                 {:interfaces
+                  {:Account
+                   {:fields {:id {:type :ID
+                                  :directives [{:directive-type :deprecated}]}}}}})]
+    (is (= true
+           (get-in schema [:Account :fields :id :deprecated])))))
+
+
+(deftest can-deprecate-enum-values
+  (let [schema (schema/compile
+                 {:enums
+                  {:Color
+                   {:values [:red
+                             {:enum-value :green
+                              :directives [{:directive-type :deprecated}]}]}}})]
+    (is (= {:green {:directives [{:directive-type :deprecated}]
+                    :deprecated true
+                    :enum-value :green}
+            :red {:enum-value :red}}
+           (get-in schema [:Color :values-detail])))))
 
 
 (comment

--- a/test/com/walmartlabs/lacinia/directives_test.clj
+++ b/test/com/walmartlabs/lacinia/directives_test.clj
@@ -13,7 +13,7 @@
 ; limitations under the License.
 
 (ns com.walmartlabs.lacinia.directives-test
-  (:require [clojure.test :as t :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing]]
             [com.walmartlabs.lacinia.schema :as schema]
             [com.walmartlabs.test-schema :refer [test-schema]]
             [com.walmartlabs.lacinia :refer [execute]]))
@@ -220,7 +220,6 @@
 (defmacro directive-test
   [expected-msg expected-ex-data schema]
   `(when-let [e# (is (~'thrown? Throwable (schema/compile ~schema)))]
-     #_(prn e#)
      (is (= ~expected-msg (.getMessage e#)))
      (is (= ~expected-ex-data
             (merge-exception-data e#)))))
@@ -251,7 +250,7 @@
   (directive-test
     "Object `User' references unknown directive @Unknown."
     {:directive-type :Unknown
-     :object-name :User}
+     :object :User}
     {:objects
      {:User {:directives {:Unknown nil}
              :fields {}}}}))
@@ -261,7 +260,7 @@
     "Directive @Ebb on Object `Flow' is not applicable."
     {:allowed-locations #{:enum}
      :directive-type :Ebb
-     :object-name :Flow}
+     :object :Flow}
     {:directive-defs
      {:Ebb {:locations #{:enum}}}
      :objects

--- a/test/com/walmartlabs/lacinia/directives_test.clj
+++ b/test/com/walmartlabs/lacinia/directives_test.clj
@@ -268,6 +268,55 @@
      {:Flow {:fields {}
              :directives {:Ebb nil}}}}))
 
+(deftest union-directive-unknown-type
+  (directive-test
+    "Union `Ebb' references unknown directive @Unknown."
+    {:directive-type :Unknown
+     :union :Ebb}
+    {:objects
+     {:Flow {:fields {}}}
+     :unions
+     {:Ebb {:members [:Flow]
+            :directives {:Unknown nil}}}}))
+
+(deftest union-directive-inapplicable
+  (directive-test
+    "Union `Ebb' references directive @deprecated which is not applicable."
+    {:directive-type :deprecated
+     :union :Ebb}
+    {:objects
+     {:Flow {:fields {}}}
+     :unions
+     {:Ebb {:members [:Flow]
+            ;; Can only deprecated fields and enum values
+            :directives {:deprecated nil}}}}))
+
+
+(deftest field-directive-unknown-type
+  (directive-test
+    "Field `User/id' references unknown directive @Unknown."
+    {:directive-type :Unknown
+     :field-name :User/id}
+    {:objects
+     {:User
+      {:fields {:id {:type :String
+                     :directives {:Unknown nil}}}}}}))
+
+(deftest field-directive-inapplicable
+  (directive-test
+    "Directive @Ebb on field `Flow/id' is not applicable."
+    {:allowed-locations #{:enum}
+     :directive-type :Ebb
+     :field-name :Flow/id}
+    {:directive-defs
+     {:Ebb {:locations #{:enum}}}
+     :objects
+     {:Flow
+      {:fields
+       {:id {:type :String
+             :directives {:Ebb nil}}}}}}))
+
 (comment
+  (require '[clojure.test :refer [run-tests]])
   (run-tests)
   )

--- a/test/com/walmartlabs/lacinia/directives_test.clj
+++ b/test/com/walmartlabs/lacinia/directives_test.clj
@@ -252,7 +252,7 @@
     {:directive-type :Unknown
      :object :User}
     {:objects
-     {:User {:directives {:Unknown nil}
+     {:User {:directives [{:directive-type :Unknown}]
              :fields {}}}}))
 
 (deftest object-directive-inapplicable
@@ -265,7 +265,7 @@
      {:Ebb {:locations #{:enum}}}
      :objects
      {:Flow {:fields {}
-             :directives {:Ebb nil}}}}))
+             :directives [{:directive-type :Ebb}]}}}))
 
 (deftest union-directive-unknown-type
   (directive-test
@@ -276,7 +276,7 @@
      {:Flow {:fields {}}}
      :unions
      {:Ebb {:members [:Flow]
-            :directives {:Unknown nil}}}}))
+            :directives [{:directive-type :Unknown}]}}}))
 
 (deftest union-directive-inapplicable
   (directive-test
@@ -288,7 +288,7 @@
      :unions
      {:Ebb {:members [:Flow]
             ;; Can only deprecated fields and enum values
-            :directives {:deprecated nil}}}}))
+            :directives [{:directive-type :deprecated}]}}}))
 
 
 (deftest field-directive-unknown-type
@@ -299,7 +299,7 @@
     {:objects
      {:User
       {:fields {:id {:type :String
-                     :directives {:Unknown nil}}}}}}))
+                     :directives [{:directive-type :Unknown}]}}}}}))
 
 (deftest field-directive-inapplicable
   (directive-test
@@ -313,7 +313,7 @@
      {:Flow
       {:fields
        {:id {:type :String
-             :directives {:Ebb nil}}}}}}))
+             :directives [{:directive-type :Ebb}]}}}}}))
 
 (deftest argument-directive-unknown-type
   (directive-test
@@ -326,7 +326,7 @@
       {:fields
        {:id {:type :String
              :args {:ebb {:type :String
-                          :directives {:Unknown nil}}}}}}}}))
+                          :directives [{:directive-type :Unknown}]}}}}}}}))
 
 (deftest argument-directive-inapplicable
   (directive-test
@@ -343,7 +343,7 @@
        {:id {:type :String
              :args
              {:format {:type :String
-                       :directives {:Ebb nil}}}}}}}}))
+                       :directives [{:directive-type :Ebb}]}}}}}}}))
 
 
 (comment

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -160,9 +160,73 @@
   (is (= {:enums {:Matter {:values [{:enum-value :Solid}
                                     {:enum-value :Liquid}
                                     {:enum-value :Gas}
+                                    {:enum-value :Plasma}]
+                           :directives [{:directive-type :Trace}]}}}
+         (parse-string "{ enum Matter @Trace { Solid Liquid Gas Plasma} }"))))
+
+(deftest enum-value-directive
+  (is (= {:enums {:Matter {:values [{:enum-value :Solid}
+                                    {:enum-value :Liquid}
+                                    {:enum-value :Gas}
                                     {:enum-value :Plasma
                                      :directives [{:directive-type :Rare}]}]}}}
          (parse-string "{ enum Matter { Solid Liquid Gas Plasma @Rare }}"))))
+
+(deftest input-object-directives
+  (is (= '{:input-objects
+           {:Ebb
+            {:directives [{:directive-type :InputObject}]
+             :fields {:flow {:type String
+                             :args {:direction {:directives [{:directive-type :Arg}]
+                                                :type String}}
+                             :directives [{:directive-type :Field}]}}}}}
+         (parse-string "{ input Ebb @InputObject { flow(direction : String @Arg) : String @Field }}"))))
+
+(deftest object-directives
+  (is (= '{:objects
+           {:Ebb
+            {:directives [{:directive-type :Object}]
+             :fields {:flow {:type String
+                             :args {:direction {:directives [{:directive-type :Arg}]
+                                                :type String}}
+                             :directives [{:directive-type :Field}]}}}}}
+         (parse-string "{ type Ebb @Object { flow(direction : String @Arg) : String @Field }}"))))
+
+(deftest interface-directives
+  (is (= '{:interfaces
+           {:Ebb
+            {:directives [{:directive-type :Interface}]
+             :fields {:flow {:type String
+                             :args {:direction {:directives [{:directive-type :Arg}]
+                                                :type String}}
+                             :directives [{:directive-type :Field}]}}}}}
+         (parse-string "{ interface Ebb @Interface { flow(direction : String @Arg) : String @Field }}"))))
+
+(deftest union-directives
+  (is (= '{:objects
+           {:Beauty
+            {:fields {:level {:type String}}}}
+           :unions
+           {:Truth
+            {:members [:Beauty]
+             :directives [{:directive-type :Union}]}}}
+         (parse-string "{ union Truth @Union = Beauty
+                          type Beauty { level : String}
+                        }"))))
+
+(deftest field-argument-directive
+  (is (= '{:objects
+           {:Ebb
+            {:fields
+             {:flow {:type String
+                     :args {:direction {:type String
+                                        :directives [{:directive-type :Trace}]}}}}}}}
+         (parse-string "{ type Ebb { flow(direction: String @Trace) : String }}"))))
+
+(deftest schema-directives
+  (is (= {:roots {:query :Query
+                  :directives [{:directive-type :Schema}]}}
+         (parse-string "{ schema @Schema { query : Query } }"))))
 
 (deftest schema-parsing
   (let [parsed-schema (parse-schema "sample_schema.sdl"

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -224,8 +224,11 @@
             {:fields
              {:flow {:type String
                      :args {:direction {:type String
-                                        :directives [{:directive-type :Trace}]}}}}}}}
-         (parse-string "type Ebb { flow(direction: String @Trace) : String }"))))
+                                        :directives [{:directive-type :Trace}]}
+                            :level {:type Int
+                                    :default-value 10
+                                    :directives [{:directive-type :Flow}]}}}}}}}
+         (parse-string "type Ebb { flow(direction: String @Trace, level : Int = 10 @Flow) : String }"))))
 
 (deftest schema-directives
   (is (= {:roots {:query :Query}

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -156,6 +156,7 @@
                           type Ebb { flow : String @Trace
                                      ready : Boolean @Trace(label: \"flow-ready\") } }"))))
 
+
 (deftest enum-directive
   (is (= {:enums {:Matter {:values [{:enum-value :Solid}
                                     {:enum-value :Liquid}
@@ -201,6 +202,10 @@
                                                 :type String}}
                              :directives [{:directive-type :Field}]}}}}}
          (parse-string "{ interface Ebb @Interface { flow(direction : String @Arg) : String @Field }}"))))
+
+(deftest scalar-directives
+  (is (= {:scalars {:Date {:directives [{:directive-type :deprecated}]}}}
+         (parse-string "{ scalar Date @deprecated}"))))
 
 (deftest union-directives
   (is (= '{:objects

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -228,8 +228,8 @@
          (parse-string "type Ebb { flow(direction: String @Trace) : String }"))))
 
 (deftest schema-directives
-  (is (= {:roots {:query :Query
-                  :directives [{:directive-type :Schema}]}}
+  (is (= {:roots {:query :Query}
+          :directives [{:directive-type :Schema}]}
          (parse-string "schema @Schema { query : Query }"))))
 
 (deftest schema-parsing


### PR DESCRIPTION
What's here:

- parsing of directive definitions and directives in Schema Definition Language documents
- directive definitions may have documentation
- directives in schema elements are validated w.r.t. location
- @deprecated directive for field definitions and schema values

What's not here:

- type checking and coercion of directive arguments
- in fact, any validation of directive arguments
- an API to expose directives (type system or executable) to field resolvers 
- Introspection about directive definitions or element directives
