### PR TITLE
Convert the flatland.ordered dependency to vendored code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,16 @@
 Limited support for custom directives.
 
 **Breaking Change**: Previous releases of the Schema Definition Language parser
-wrapped the entire document with `{` and `}.
+wrapped the entire document with `{` and `}`.
 This is not correct, and such documents are not valid SDL.
 
 This release fixes that, but it means that any existing SDL documents will not
 parse correctly until the outermost curly braces are removed.
+
+This release replaces the dependency on
+[org.flatland/ordered](https://github.com/amalloy/ordered)
+with vendored copies of the code in an internal namespace.
+This is to enable compatibility with JDK 11.
 
 ## 0.30.0 -- 1 Oct 2018
 

--- a/LICENCE.ordered.txt
+++ b/LICENCE.ordered.txt
@@ -1,0 +1,227 @@
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF
+THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and
+documentation distributed under this Agreement, and
+
+b) in the case of each subsequent Contributor:
+
+i) changes to the Program, and
+
+ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and
+are distributed by that particular Contributor. A Contribution
+'originates' from a Contributor if it was added to the Program by such
+Contributor itself or anyone acting on such Contributor's
+behalf. Contributions do not include additions to the Program which:
+(i) are separate modules of software distributed in conjunction with
+the Program under their own license agreement, and (ii) are not
+derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor
+which are necessarily infringed by the use or sale of its Contribution
+alone or when combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this
+Agreement, including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby
+grants Recipient a non-exclusive, worldwide, royalty-free copyright
+license to reproduce, prepare derivative works of, publicly display,
+publicly perform, distribute and sublicense the Contribution of such
+Contributor, if any, and such derivative works, in source code and
+object code form.
+
+b) Subject to the terms of this Agreement, each Contributor hereby
+grants Recipient a non-exclusive, worldwide, royalty-free patent
+license under Licensed Patents to make, use, sell, offer to sell,
+import and otherwise transfer the Contribution of such Contributor, if
+any, in source code and object code form.  This patent license shall
+apply to the combination of the Contribution and the Program if, at
+the time the Contribution is added by the Contributor, such addition
+of the Contribution causes such combination to be covered by the
+Licensed Patents. The patent license shall not apply to any other
+combinations which include the Contribution. No hardware per se is
+licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the
+licenses to its Contributions set forth herein, no assurances are
+provided by any Contributor that the Program does not infringe the
+patent or other intellectual property rights of any other entity. Each
+Contributor disclaims any liability to Recipient for claims brought by
+any other entity based on infringement of intellectual property rights
+or otherwise. As a condition to exercising the rights and licenses
+granted hereunder, each Recipient hereby assumes sole responsibility
+to secure any other intellectual property rights needed, if any. For
+example, if a third party patent license is required to allow
+Recipient to distribute the Program, it is Recipient's responsibility
+to acquire that license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient
+copyright rights in its Contribution, if any, to grant the copyright
+license set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form
+under its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+
+b) its license agreement:
+
+i) effectively disclaims on behalf of all Contributors all warranties
+and conditions, express and implied, including warranties or
+conditions of title and non-infringement, and implied warranties or
+conditions of merchantability and fitness for a particular purpose;
+
+ii) effectively excludes on behalf of all Contributors all liability
+for damages, including direct, indirect, special, incidental and
+consequential damages, such as lost profits;
+
+iii) states that any provisions which differ from this Agreement are
+offered by that Contributor alone and not by any other party; and
+
+iv) states that source code for the Program is available from such
+Contributor, and informs licensees how to obtain it in a reasonable
+manner on or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+
+b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained
+within the Program.
+
+Each Contributor must identify itself as the originator of its
+Contribution, if any, in a manner that reasonably allows subsequent
+Recipients to identify the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain
+responsibilities with respect to end users, business partners and the
+like. While this license is intended to facilitate the commercial use
+of the Program, the Contributor who includes the Program in a
+commercial product offering should do so in a manner which does not
+create potential liability for other Contributors. Therefore, if a
+Contributor includes the Program in a commercial product offering,
+such Contributor ("Commercial Contributor") hereby agrees to defend
+and indemnify every other Contributor ("Indemnified Contributor")
+against any losses, damages and costs (collectively "Losses") arising
+from claims, lawsuits and other legal actions brought by a third party
+against the Indemnified Contributor to the extent caused by the acts
+or omissions of such Commercial Contributor in connection with its
+distribution of the Program in a commercial product offering.  The
+obligations in this section do not apply to any claims or Losses
+relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim,
+and b) allow the Commercial Contributor tocontrol, and cooperate with
+the Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such
+claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those
+performance claims and warranties, and if a court requires any other
+Contributor to pay any damages as a result, the Commercial Contributor
+must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS
+PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY
+WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY
+OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely
+responsible for determining the appropriateness of using and
+distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to
+the risks and costs of program errors, compliance with applicable
+laws, damage to or loss of data, programs or equipment, and
+unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR
+ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING
+WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR
+DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED
+HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+the Program itself (excluding combinations of the Program with other
+software or hardware) infringes such Recipient's patent(s), then such
+Recipient's rights granted under Section 2(b) shall terminate as of
+the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably
+practicable. However, Recipient's obligations under this Agreement and
+any licenses granted by Recipient relating to the Program shall
+continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign
+the responsibility to serve as the Agreement Steward to a suitable
+separate entity. Each new version of the Agreement will be given a
+distinguishing version number. The Program (including Contributions)
+may always be distributed subject to the version of the Agreement
+under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the
+Program (including its Contributions) under the new version. Except as
+expressly stated in Sections 2(a) and 2(b) above, Recipient receives
+no rights or licenses to the intellectual property of any Contributor
+under this Agreement, whether expressly, by implication, estoppel or
+otherwise. All rights in the Program not expressly granted under this
+Agreement are reserved.
+
+This Agreement is governed by the laws of the State of Washington and
+the intellectual property laws of the United States of America. No
+party to this Agreement will bring a legal action under this Agreement
+more than one year after the cause of action arose. Each party waives
+its rights to a jury trial in any resulting litigation.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ More details are [in the manual](http://lacinia.readthedocs.io/en/latest/clojure
 
 ## License
 
-Copyright © 2017 WalmartLabs
+Copyright © 2017-2018 WalmartLabs
 
 Distributed under the Apache License, Version 2.0.
+
+Portions of the code are derived from
+the [ordered](https://github.com/amalloy/ordered)
+and [useful](https://github.com/amalloy/useful) libraries, which are released under the terms
+of the [Eclipse Public License - v 1.0](LICENSE.ordered.txt).

--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,9 @@
             [test2junit "1.2.5"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [clj-antlr "0.2.4"]
-                 [org.clojure/data.json "0.2.6"]
-                 [org.flatland/ordered "1.5.6"
-                  :exclusions [org.clojure/tools.macro]]]
+                 [org.clojure/data.json "0.2.6"]]
+  :source-paths ["src"
+                 "vendor-src"]
   :profiles {:dev {:dependencies [[criterium "0.4.4"]
                                   [expound "0.7.1"]
                                   [joda-time "2.10"]
@@ -22,4 +22,5 @@
   :jvm-opts ["-Xmx1g" "-XX:-OmitStackTraceInFastThrow"]
   :test2junit-output-dir ~(or (System/getenv "CIRCLE_TEST_REPORTS") "target/test2junit")
   :codox {:source-uri "https://github.com/walmartlabs/lacinia/blob/master/{filepath}#L{line}"
+          :source-paths ["src"]                             ; and not vendor-src
           :metadata   {:doc/format :markdown}})

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -17,7 +17,7 @@
   (:require
     [com.walmartlabs.lacinia.internal-utils
      :refer [cond-let map-vals remove-vals q]]
-    [flatland.ordered.map :refer [ordered-map]]
+    [com.walmartlabs.lacinia.vendor.ordered.map :refer [ordered-map]]
     [com.walmartlabs.lacinia.schema :as schema]
     [com.walmartlabs.lacinia.resolve :as resolve
      :refer [resolve-as combine-results]]

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -28,7 +28,7 @@
     [clojure.spec.alpha :as s]
     [com.walmartlabs.lacinia.resolve :as resolve]
     [com.walmartlabs.lacinia.parser.query :as qp]
-    [flatland.ordered.map :refer [ordered-map]])
+    [com.walmartlabs.lacinia.vendor.ordered.map :refer [ordered-map]])
   (:import
     (clojure.lang ExceptionInfo)))
 

--- a/vendor-src/com/walmartlabs/lacinia/vendor/ordered/common.clj
+++ b/vendor-src/com/walmartlabs/lacinia/vendor/ordered/common.clj
@@ -1,0 +1,7 @@
+(ns com.walmartlabs.lacinia.vendor.ordered.common)
+
+(defmacro change! [field f & args]
+  `(set! ~field (~f ~field ~@args)))
+
+(defprotocol Compactable
+  (compact [this]))

--- a/vendor-src/com/walmartlabs/lacinia/vendor/ordered/map.clj
+++ b/vendor-src/com/walmartlabs/lacinia/vendor/ordered/map.clj
@@ -1,0 +1,214 @@
+(ns com.walmartlabs.lacinia.vendor.ordered.map
+  (:use [com.walmartlabs.lacinia.vendor.ordered.common :only [change! Compactable compact]]
+        [com.walmartlabs.lacinia.vendor.ordered.set :only [ordered-set]]
+        [com.walmartlabs.lacinia.vendor.useful.experimental.delegate :only [delegating-deftype]])
+  (:require [clojure.string :as s])
+  (:import (clojure.lang APersistentMap
+                         IPersistentMap
+                         IPersistentCollection
+                         IPersistentVector
+                         IEditableCollection
+                         ITransientMap
+                         ITransientVector
+                         IHashEq
+                         IObj
+                         IFn
+                         Seqable
+                         MapEquivalence
+                         Reversible
+                         MapEntry
+                         ;; Indexed, maybe add later?
+                         ;; Sorted almost certainly not accurate
+                         )
+           (java.util Map Map$Entry)))
+
+;; We could use compile-if technique here, but hoping to avoid
+;; an AOT issue using this way instead.
+(def hasheq-ordered-map
+  (or (resolve 'clojure.core/hash-unordered-coll)
+      (fn old-hasheq-ordered-map [^Seqable m]
+        (reduce (fn [acc ^MapEntry e]
+                  (let [k (.key e), v (.val e)]
+                    (unchecked-add ^Integer acc ^Integer (bit-xor (hash k) (hash v)))))
+                0 (.seq m)))))
+
+(defn entry [k v i]
+  (MapEntry. k (MapEntry. i v)))
+
+(declare transient-ordered-map)
+
+(delegating-deftype OrderedMap [^IPersistentMap backing-map
+                                ^IPersistentVector order]
+  {backing-map {IPersistentMap [(count [])]
+                Map [(size [])
+                     (containsKey [k])
+                     (isEmpty [])
+                     (keySet [])]}}
+  ;; tagging interfaces
+  MapEquivalence
+
+  IPersistentMap
+  (equiv [this other]
+    (and (instance? Map other)
+         (= (.count this) (.size ^Map other))
+         (every? (fn [^MapEntry e]
+                   (let [k (.key e)]
+                     (and (.containsKey ^Map other k)
+                          (= (.val e) (.get ^Map other k)))))
+                 (.seq this))))
+  (entryAt [this k]
+    (let [v (get this k ::not-found)]
+      (when (not= v ::not-found)
+        (MapEntry. k v))))
+  (valAt [this k]
+    (.valAt this k nil))
+  (valAt [this k not-found]
+    (if-let [^MapEntry e (.get ^Map backing-map k)]
+      (.val e)
+      not-found))
+
+  IFn
+  (invoke [this k]
+    (.valAt this k))
+  (invoke [this k not-found]
+    (.valAt this k not-found))
+
+  Map
+  (get [this k]
+    (.valAt this k))
+  (containsValue [this v]
+    (boolean (seq (filter #(= % v) (.values this)))))
+  (values [this]
+    (map (comp val val) (.seq this)))
+
+  Object
+  (toString [this]
+    (str "{" (s/join ", " (for [[k v] this] (str k " " v))) "}"))
+  (equals [this other]
+    (.equiv this other))
+  (hashCode [this]
+    (APersistentMap/mapHash this))
+  IHashEq
+  (hasheq [this]
+    (hasheq-ordered-map this))
+
+  IPersistentMap
+  (empty [this]
+    (OrderedMap. (-> {} (with-meta (meta backing-map))) []))
+  (cons [this obj]
+    (condp instance? obj
+      Map$Entry (let [^Map$Entry e obj]
+                  (.assoc this (.getKey e) (.getValue e)))
+      IPersistentVector (if (= 2 (count obj))
+                          (.assoc this (nth obj 0) (nth obj 1))
+                          (throw (IllegalArgumentException.
+                                  "Vector arg to map conj must be a pair")))
+      (persistent! (reduce (fn [^ITransientMap m ^Map$Entry e]
+                             (.assoc m (.getKey e) (.getValue e)))
+                           (transient this)
+                           obj))))
+
+  (assoc [this k v]
+    (if-let [^MapEntry e (.get ^Map backing-map k)]
+      (let [old-v (.val e)]
+        (if (identical? old-v v)
+          this
+          (let [i (.key e)]
+            (OrderedMap. (.cons backing-map (entry k v i))
+                         (.assoc order i (MapEntry. k v))))))
+      (OrderedMap. (.cons backing-map (entry k v (.count order)))
+                   (.cons order (MapEntry. k v)))))
+  (without [this k]
+    (if-let [^MapEntry e (.get ^Map backing-map k)]
+      (OrderedMap. (.without backing-map k)
+                   (.assoc order (.key e) nil))
+      this))
+  (seq [this]
+    (seq (keep identity order)))
+  (iterator [this]
+    (clojure.lang.SeqIterator. (.seq this)))
+  (entrySet [this]
+    ;; not performant, but i'm not going to implement another whole java interface from scratch just
+    ;; because rich won't let us inherit from AbstractSet
+    (apply ordered-set this))
+
+  IObj
+  (meta [this]
+    (.meta ^IObj backing-map))
+  (withMeta [this m]
+    (OrderedMap. (.withMeta ^IObj backing-map m) order))
+
+  IEditableCollection
+  (asTransient [this]
+    (transient-ordered-map this))
+
+  Reversible
+  (rseq [this]
+    (seq (keep identity (rseq order))))
+
+  Compactable
+  (compact [this]
+    (into (empty this) this)))
+
+(def ^{:private true,
+       :tag OrderedMap} empty-ordered-map (empty (OrderedMap. nil nil)))
+
+(defn ordered-map
+  "Return a map with the given keys and values, whose entries are
+sorted in the order that keys are added. assoc'ing a key that is
+already in an ordered map leaves its order unchanged. dissoc'ing a
+key and then later assoc'ing it puts it at the end, as if it were
+assoc'ed for the first time. Supports transient."
+  ([] empty-ordered-map)
+  ([coll]
+     (into empty-ordered-map coll))
+  ([k v & more]
+     (apply assoc empty-ordered-map k v more)))
+
+;; contains? is broken for transients. we could define a closure around a gensym
+;; to use as the not-found argument to a get, but deftype can't be a closure.
+;; instead, we pass `this` as the not-found argument and hope nobody makes a
+;; transient contain itself.
+
+(delegating-deftype TransientOrderedMap [^{:unsynchronized-mutable true, :tag ITransientMap} backing-map,
+                                         ^{:unsynchronized-mutable true, :tag ITransientVector} order]
+  {backing-map {ITransientMap [(count [])]}}
+  ITransientMap
+  (valAt [this k]
+    (.valAt this k nil))
+  (valAt [this k not-found]
+    (if-let [^MapEntry e (.valAt backing-map k)]
+      (.val e)
+      not-found))
+  (assoc [this k v]
+    (let [^MapEntry e (.valAt backing-map k this)
+          vector-entry (MapEntry. k v)
+          i (if (identical? e this)
+              (do (change! order .conj vector-entry)
+                  (dec (.count order)))
+              (let [idx (.key e)]
+                (change! order .assoc idx vector-entry)
+                idx))]
+      (change! backing-map .conj (entry k v i))
+      this))
+  (conj [this e]
+    (let [[k v] e]
+      (.assoc this k v)))
+  (without [this k]
+    (let [^MapEntry e (.valAt backing-map k this)]
+      (when-not (identical? e this)
+        (let [i (.key e)]
+          (change! backing-map dissoc! k)
+          (change! order assoc! i nil)))
+      this))
+  (persistent [this]
+    (OrderedMap. (.persistent backing-map)
+                 (.persistent order))))
+
+(defn transient-ordered-map [^OrderedMap om]
+  (TransientOrderedMap. (.asTransient ^IEditableCollection (.backing-map om))
+                        (.asTransient ^IEditableCollection (.order om))))
+
+(defmethod print-method OrderedMap [o ^java.io.Writer w]
+  (.write w "#ordered/map ")
+  (print-method (seq o) w))

--- a/vendor-src/com/walmartlabs/lacinia/vendor/ordered/set.clj
+++ b/vendor-src/com/walmartlabs/lacinia/vendor/ordered/set.clj
@@ -1,0 +1,155 @@
+(ns com.walmartlabs.lacinia.vendor.ordered.set
+  (:use [com.walmartlabs.lacinia.vendor.ordered.common :only [Compactable compact change!]])
+  (:require [clojure.string :as s])
+  (:import (clojure.lang IPersistentSet ITransientSet IEditableCollection
+                         IPersistentMap ITransientMap ITransientAssociative
+                         IPersistentVector ITransientVector IHashEq
+                         Associative Seqable SeqIterator Reversible IFn IObj)
+           (java.util Set Collection)))
+
+(declare transient-ordered-set)
+
+;; We could use compile-if technique here, but hoping to avoid
+;; an AOT issue using this way instead.
+(def hasheq-ordered-set
+  (or (resolve 'clojure.core/hash-unordered-coll)
+      (fn old-hasheq-ordered-set [^Seqable s]
+        (reduce + (map hash (.seq s))))))
+
+(deftype OrderedSet [^IPersistentMap k->i
+                     ^IPersistentVector i->k]
+  IPersistentSet
+  (disjoin [this k]
+    (if-let [i (.valAt k->i k)]
+      (OrderedSet. (dissoc k->i k)
+                   (assoc i->k i ::empty))
+      this))
+  (cons [this k]
+    (if-let [i (.valAt k->i k)]
+      this
+      (OrderedSet. (.assoc ^Associative k->i k (.count i->k))
+                   (.cons i->k k))))
+  (seq [this]
+    (seq (remove #(identical? ::empty %) i->k)))
+  (empty [this]
+    (OrderedSet. (-> {} (with-meta (meta k->i)))
+                 []))
+  (equiv [this other]
+    (.equals this other))
+  (get [this k]
+    (when (.valAt k->i k) k))
+  (count [this]
+    (.count k->i))
+
+  IObj
+  (meta [this]
+    (.meta ^IObj k->i))
+  (withMeta [this m]
+    (OrderedSet. (.withMeta ^IObj k->i m)
+                 i->k))
+
+  Compactable
+  (compact [this]
+    (into (empty this) this))
+
+  Object
+  (toString [this]
+    (str "#{" (clojure.string/join " " (map str this)) "}"))
+  (hashCode [this]
+    (reduce + (map #(.hashCode ^Object %) (.seq this))))
+  (equals [this other]
+    (or (identical? this other)
+        (and (instance? Set other)
+             (let [^Set s other]
+               (and (= (.size this) (.size s))
+                    (every? #(.contains s %) (.seq this)))))))
+
+  IHashEq
+  (hasheq [this]
+    (hasheq-ordered-set this))
+  
+  Set
+  (iterator [this]
+    (SeqIterator. (.seq this)))
+  (contains [this k]
+    (.containsKey k->i k))
+  (containsAll [this ks]
+    (every? #(.contains this %) ks))
+  (size [this]
+    (.count this))
+  (isEmpty [this]
+    (zero? (.count this)))
+  (^objects toArray [this ^objects dest]
+    (reduce (fn [idx item]
+              (aset dest idx item)
+              (inc idx))
+            0, (.seq this))
+    dest)
+  (toArray [this]
+    (.toArray this (object-array (.count this))))
+
+  Reversible
+  (rseq [this]
+    (seq (remove #(identical? ::empty %) (rseq i->k))))
+
+  IEditableCollection
+  (asTransient [this]
+    (transient-ordered-set this))
+  IFn
+  (invoke [this k] (when (.contains this k) k)))
+
+(def ^{:private true,
+       :tag OrderedSet} empty-ordered-set (empty (OrderedSet. nil nil)))
+
+(defn ordered-set
+  "Return a set with the given items, whose items are sorted in the
+order that they are added. conj'ing an item that was already in the
+set leaves its order unchanged. disj'ing an item and then later
+conj'ing it puts it at the end, as if it were being added for the 
+first time. Supports transient.
+
+Note that clojure.set functions like union, intersection, and
+difference can change the order of their input sets for efficiency
+purposes, so may not return the order you expect given ordered sets
+as input."
+  ([] empty-ordered-set)
+  ([& xs] (into empty-ordered-set xs)))
+
+(deftype TransientOrderedSet [^{:unsynchronized-mutable true
+                                :tag ITransientMap} k->i,
+                              ^{:unsynchronized-mutable true
+                                :tag ITransientVector} i->k]
+  ITransientSet
+  (count [this]
+    (.count k->i))
+  (get [this k]
+    (when (.valAt k->i k) k))
+  (disjoin [this k]
+    (let [i (.valAt k->i k)]
+      (when i
+        (change! k->i .without k)
+        (change! i->k .assocN i ::empty)))
+    this)
+  (conj [this k]
+    (let [i (.valAt k->i k)]
+      (when-not i
+        (change! ^ITransientAssociative k->i .assoc k (.count i->k))
+        (change! i->k conj! k)))
+    this)
+  (contains [this k]
+    (boolean (.valAt k->i k)))
+  (persistent [this]
+    (OrderedSet. (.persistent k->i)
+                 (.persistent i->k))))
+
+(defn transient-ordered-set [^OrderedSet os]
+  (TransientOrderedSet. (transient (.k->i os))
+                        (transient (.i->k os))))
+
+(defn into-ordered-set
+  [items]
+  (into empty-ordered-set items))
+
+(defmethod print-method OrderedSet [o ^java.io.Writer w]
+  (.write w "#ordered/set ")
+  (print-method (seq o) w))

--- a/vendor-src/com/walmartlabs/lacinia/vendor/useful/debug.clj
+++ b/vendor-src/com/walmartlabs/lacinia/vendor/useful/debug.clj
@@ -1,0 +1,37 @@
+(ns com.walmartlabs.lacinia.vendor.useful.debug)
+
+;; leave out of ns decl so we can load with classlojure.io/resource-forms
+(require '[clojure.pprint :as p])
+(require '[clojure.stacktrace :as s])
+
+(letfn [(interrogate-form [list-head form]
+          `(let [display# (fn [val#]
+                            (let [form# (with-out-str
+                                          (clojure.pprint/with-pprint-dispatch
+                                            clojure.pprint/code-dispatch
+                                            (clojure.pprint/pprint '~form)))
+                                  val# (with-out-str (clojure.pprint/pprint val#))]
+                              (~@list-head
+                               (if (every? (partial > clojure.pprint/*print-miser-width*)
+                                           [(count form#) (count val#)])
+                                 (str (subs form# 0 (dec (count form#))) " is " val#)
+                                 (str form# "--------- is ---------\n" val#)))))]
+             (try (doto ~form display#)
+                  (catch Throwable t#
+                    (display# {:thrown t#
+                               :trace (with-out-str
+                                        (clojure.stacktrace/print-cause-trace t#))})
+                    (throw t#)))))]
+
+  (defmacro ?
+    "A useful debugging tool when you can't figure out what's going on:
+  wrap a form with ?, and the form will be printed alongside
+  its result. The result will still be passed along."
+    [val]
+    (interrogate-form `(#(do (print %) (flush))) val))
+
+  (defmacro ^{:dont-test "Complicated to test, and should work if ? does"}
+    ?!
+    ([val] `(?! "/tmp/spit" ~val))
+    ([file val]
+       (interrogate-form `(#(spit ~file % :append true)) val))))

--- a/vendor-src/com/walmartlabs/lacinia/vendor/useful/experimental/delegate.clj
+++ b/vendor-src/com/walmartlabs/lacinia/vendor/useful/experimental/delegate.clj
@@ -1,0 +1,111 @@
+; Copyright (c) 2018-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+(ns com.walmartlabs.lacinia.vendor.useful.experimental.delegate
+  (:use com.walmartlabs.lacinia.vendor.useful.debug)
+  (:require [com.walmartlabs.lacinia.vendor.useful.ns :as ns]))
+
+(defn canonical-name
+  "Resolve a symbol in the current namespace; but intead of returning its value,
+   return a canonical name that can be used to name the same thing in any
+   namespace."
+  [sym]
+  (if-let [val (resolve sym)]
+    (condp instance? val
+      java.lang.Class (symbol (pr-str val))
+      clojure.lang.Var (ns/var-name val)
+      (throw (IllegalArgumentException.
+              (format "%s names %s, an instance of %s, which has no canonical name."
+                      sym val (class val)))))
+    sym))
+
+(defn parse-deftype-specs
+  "Given a mess of deftype specs, possibly with classes/interfaces specified multiple times,
+  collapse it into a map like {interface => (method1 method2...)}.
+  Needed because core.deftype only allows specifying a class ONCE, so our delegating versions would
+  clash with client's custom methods."
+  [decls]
+  (loop [ret {}, curr-key nil, decls decls]
+    (if-let [[x & xs] (seq decls)]
+      (if (seq? x)
+        (let [mname (symbol (name (first x)))
+              nargs (count (second x))]
+          (recur (assoc-in ret [curr-key [mname nargs]] x),
+                 curr-key, xs))
+        (let [interface-name (canonical-name x)]
+          (recur (update-in ret [interface-name] #(or % {})),
+                 interface-name, xs)))
+      ret)))
+
+(defn emit-deftype-specs
+  "Given a map returned by aggregate, spit out a flattened deftype body."
+  [specs]
+  (apply concat
+         (for [[interface methods] specs]
+           (cons interface
+                 (for [[[method-name num-args] method] methods]
+                   method)))))
+
+(letfn [;; Output the method body for a delegating implementation
+        (delegating-method [method-name args delegate]
+          `(~method-name [~'_ ~@args]
+             (. ~delegate (~method-name ~@args))))
+
+        ;; Create a series of Interface (method...) (method...) expressions,
+        ;; suitable for creating the entire body of a deftype or reify.
+        (type-body [delegate-map other-args]
+          (let [our-stuff (for [[send-to interfaces] delegate-map
+                                [interface which] interfaces
+                                :let [send-to (vary-meta send-to
+                                                         assoc :tag interface)]
+                                [name args] which]
+                            [interface (delegating-method name args send-to)])]
+            (emit-deftype-specs
+             (parse-deftype-specs
+              (apply concat other-args our-stuff)))))]
+
+  (defmacro delegating-deftype
+    "Shorthand for defining a new type with deftype, which delegates the methods you name to some
+    other object or objects. Delegates are usually a member field, but can be any expression: the
+    expression will be evaluated every time a method is delegated. The delegate object (or
+    expression) will be type-hinted with the type of the interface being delegated.
+
+    The delegate-map argument should be structured like:
+      {object-to-delegate-to {Interface1 [(method1 [])
+                                          (method2 [foo bar baz])]
+                              Interface2 [(otherMethod [other])]},
+       another-object {Interface1 [(method3 [whatever])]}}.
+
+    This will cause your deftype to include an implementation of Interface1.method1 which does its
+    work by forwarding to (.method1 object-to-delegate-to), and likewise for the other
+    methods. Arguments will be forwarded on untouched, and you should not include a `this`
+    parameter. Note especially that you can have methods from Interface1 implemented by delegating
+    to multiple objects if you choose, and can also include custom implementations for the remaining
+    methods of Interface1 if you have no suitable delegate.
+
+    Arguments after `delegate-map` are as with deftype, although if deftype ever has options defined
+    for it, delegating-deftype may break with them."
+    [cname [& fields] delegate-map & deftype-args]
+    `(deftype ~cname [~@fields]
+       ~@(type-body delegate-map deftype-args)))
+
+  (defmacro delegating-defrecord
+    "Like delegating-deftype, but creates a defrecod body instead of a deftype."
+    [cname [& fields] delegate-map & deftype-args]
+    `(defrecord ~cname [~@fields]
+       ~@(type-body delegate-map deftype-args)))
+
+  (defmacro delegating-reify
+    "Like delegating-deftype, but creates a reify body instead of a deftype."
+    [delegate-map & reify-args]
+    `(reify ~@(type-body delegate-map reify-args))))

--- a/vendor-src/com/walmartlabs/lacinia/vendor/useful/ns.clj
+++ b/vendor-src/com/walmartlabs/lacinia/vendor/useful/ns.clj
@@ -1,0 +1,32 @@
+(ns com.walmartlabs.lacinia.vendor.useful.ns)
+
+(defn var-name
+  "Get the namespace-qualified name of a var."
+  [v]
+  (apply symbol (map str ((juxt (comp ns-name :ns)
+                                :name)
+                          (meta v)))))
+
+(defn alias-var
+  "Create a var with the supplied name in the current namespace, having the same
+  metadata and root-binding as the supplied var."
+  [name ^clojure.lang.Var var]
+  (apply intern *ns* (with-meta name (merge {:dont-test (str "Alias of " (var-name var))}
+                                            (meta var)
+                                            (meta name)))
+         (when (.hasRoot var) [@var])))
+
+(defmacro defalias
+  "Defines an alias for a var: a new var with the same root binding (if
+  any) and similar metadata. The metadata of the alias is its initial
+  metadata (as provided by def) merged into the metadata of the original."
+  [dst src]
+  `(alias-var (quote ~dst) (var ~src)))
+
+(defn alias-ns
+  "Create vars in the current namespace to alias each of the public vars in
+  the supplied namespace."
+  [ns-name]
+  (require ns-name)
+  (doseq [[name var] (ns-publics (the-ns ns-name))]
+    (alias-var name var)))


### PR DESCRIPTION
This also applies a trivial patch to the ordered set implementation,
to provide JDK 11 compatibility.

To keep any future maintenance of this code easy, I did nothing to the vendored code beyond changing the namespace.

Fixes #237 