### PR TITLE
Allow scalars to parse from any data, not just strings

### DIFF
--- a/dev-resources/object-scalars-schema.edn
+++ b/dev-resources/object-scalars-schema.edn
@@ -1,0 +1,10 @@
+{:scalars
+ {:Data
+  {:description "Arbitrary JSON/EDN data."
+   :parse :scalars/data.parse
+   :serialize :scalars/data.serialize}}
+
+ :queries
+ {:echo {:type :Data
+         :args {:input {:type :Data}}
+         :resolve :queries/echo}}}

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -106,7 +106,15 @@
   (let [{:keys [type value]} argument-value]
     (case type
 
-      (:string :integer :float :boolean) [:scalar value]
+      :string [:scalar value]
+
+      :integer [:scalar (Long/valueOf ^String value)]
+
+      :float [:scalar (Double/valueOf ^String value)]
+
+      :boolean [:scalar (Boolean/valueOf ^String value)]
+
+      ; (:string :integer :float :boolean) [:scalar value]
 
       :null [:null nil]
 
@@ -209,6 +217,18 @@
     [:array [[arg-type arg-value]]]
     arg-tuple))
 
+(defn ^:private arg-tuple->value
+  [[arg-type arg-value]]
+  (case arg-type
+    :scalar
+    arg-value
+
+    :array
+    (map arg-tuple->value arg-value)
+
+    :object
+    (map-vals arg-tuple->value arg-value)))
+
 (defmulti ^:private process-literal-argument
   "Validates a literal argument value to ensure it is compatible
   with the declared type of the field argument. Returns the underlying
@@ -217,7 +237,7 @@
   arg-value is a tuple of argument type (:scalar, :enum, :null, :array, or :object) and
   the parsed value."
 
-  (fn [schema argument-definition [arg-type _]]
+  (fn [_schema argument-definition [arg-type _]]
     (if (contains-modifier? :list argument-definition)
       ;; list types allow a single value on input
       :array
@@ -273,39 +293,48 @@
                             :enum-type enum-type-name})))))
 
 (defmethod process-literal-argument :object
-  [schema argument-definition [_ arg-value]]
-  (let [type-name (schema/root-type-name argument-definition)
-        schema-type (get schema type-name)]
-    (when-not (= :input-object (:category schema-type))
+  [schema argument-definition arg-tuple]
+  (let [[_ arg-value] arg-tuple
+        type-name (schema/root-type-name argument-definition)
+        schema-type (get schema type-name)
+        schema-category (:category schema-type)]
+    (cond
+
+      ;; An input object has fields, some of which are required, some of which
+      ;; have default values.
+      (= :input-object schema-category)
+      (let [object-fields (:fields schema-type)
+            default-values (collect-default-values object-fields)
+            required-keys (keys (filter-vals non-null-kind? object-fields))
+            process-object-field (fn [m k v]
+                                   (if-let [field (get object-fields k)]
+                                     (assoc m k
+                                            (process-literal-argument schema field v))
+                                     (throw-exception (format "Input object contained unexpected key %s."
+                                                              (q k))
+                                                      {:schema-type type-name})))
+            object-value (reduce-kv process-object-field
+                                    nil
+                                    arg-value)
+            with-defaults (merge default-values object-value)]
+        (doseq [k required-keys]
+          (when (nil? (get with-defaults k))
+            (throw-exception (format "No value provided for non-nullable key %s of input object %s."
+                                     (q k)
+                                     (q type-name))
+                             {:missing-key k
+                              :required-keys (sort required-keys)
+                              :schema-type type-name})))
+        with-defaults)
+
+      (= :scalar schema-category)
+      ;; A scalar usually accepts a string, but it can accept other types including even a map
+      (process-literal-argument schema argument-definition
+                                [:scalar (arg-tuple->value arg-tuple)])
+
+      :else
       (throw-exception "Input object supplied for argument whose type is not an input object."
-                       {:argument-type (:type-name schema-type)}))
-
-    ;; An input object has fields, some of which are required, some of which
-    ;; have default values.
-
-    (let [object-fields (:fields schema-type)
-          default-values (collect-default-values object-fields)
-          required-keys (keys (filter-vals non-null-kind? object-fields))
-          process-object-field (fn [m k v]
-                                 (if-let [field (get object-fields k)]
-                                   (assoc m k
-                                          (process-literal-argument schema field v))
-                                   (throw-exception (format "Input object contained unexpected key %s."
-                                                            (q k))
-                                                    {:schema-type type-name})))
-          object-value (reduce-kv process-object-field
-                                  nil
-                                  arg-value)
-          with-defaults (merge default-values object-value)]
-      (doseq [k required-keys]
-        (when (nil? (get with-defaults k))
-          (throw-exception (format "No value provided for non-nullable key %s of input object %s."
-                                   (q k)
-                                   (q type-name))
-                           {:missing-key k
-                            :required-keys (sort required-keys)
-                            :schema-type type-name})))
-      with-defaults)))
+                       {:argument-type (:type-name schema-type)}))))
 
 (defmethod process-literal-argument :array
   [schema argument-definition arg-tuple]
@@ -586,8 +615,16 @@
   [schema argument-definitions arguments]
   (when-not (empty? arguments)
     (let [process-arg (fn [arg-name arg-value]
-                        (let [arg-def (get argument-definitions arg-name)]
+                        (let [arg-def (get argument-definitions arg-name)
+                              arg-type-name (schema/root-type-name arg-def)
+                              arg-type (get schema arg-type-name)]
                           (with-exception-context {:argument arg-name}
+                            (when (and (= :scalar (:category arg-type))
+                                       (= :object (first arg-value)))
+                              (throw-exception (format "Argument %s contains a scalar argument with nested variables, which is not allowed."
+                                                       (q arg-name))
+                                               nil))
+
                             (when-not arg-def
                               (throw-exception (format "Unknown argument %s."
                                                        (q arg-name))

--- a/test/com/walmartlabs/lacinia/custom_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/custom_scalars_test.clj
@@ -427,9 +427,9 @@
                                              (:in args))})
                    (util/attach-scalar-transformers
                      {:parse (schema/as-conformer (fn [s]
-                                                    (if (= "5" s)
+                                                    (if (= 5 s)
                                                       (schema/coercion-failure "Just don't like 5.")
-                                                      (Integer/parseInt s))))
+                                                      s)))
                       :serialize (schema/as-conformer
                                    (fn [v]
                                      (if (< v 5)
@@ -449,7 +449,7 @@
                         :extensions {:argument :in
                                      :field :dupe
                                      :type-name :LimitedInt
-                                     :value "5"}}]}
+                                     :value 5}}]}
              (execute schema
                       "{ dupe (in: 5) }"
                       nil
@@ -468,7 +468,7 @@
                                      :line 1}]
                         :message "5 is too big."
                         :path [:test]
-                        :extensions {:arguments {:in "5"}}}]}
+                        :extensions {:arguments {:in 5}}}]}
              (execute schema
                       "{ test (in:5) }"
                       nil

--- a/test/com/walmartlabs/lacinia/object_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/object_scalars_test.clj
@@ -1,0 +1,102 @@
+; Copyright (c) 2018-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+(ns com.walmartlabs.lacinia.object-scalars-test
+  "Tests for scalars that consume and produce a map of un-typed data."
+  (:require
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.lacinia.util :refer [attach-resolvers attach-scalar-transformers]]
+    [com.walmartlabs.test-utils :refer [execute]]
+    [clojure.java.io :as io]
+    [clojure.edn :as edn]
+    [com.walmartlabs.lacinia.schema :as schema]))
+
+
+(def ^:private compiled-schema
+  (-> (io/resource "object-scalars-schema.edn")
+      slurp
+      edn/read-string
+      (attach-scalar-transformers {:scalars/data.parse (schema/as-conformer identity)
+                                   :scalars/data.serialize (schema/as-conformer identity)})
+      (attach-resolvers {:queries/echo (fn [_ {:keys [input]} _]
+                                         {:input_arg input})})
+      schema/compile))
+
+(defn ^:private execute-var
+  [v]
+  (execute compiled-schema "query ($v : Data) { echo (input: $v) }"
+           {:v v}
+           nil))
+
+(deftest numeric
+  (is (= {:data
+          {:echo
+           {:input_arg 2}}}
+         (execute compiled-schema "{ echo(input: 2) }"))))
+
+(deftest numeric-var
+  (is (= {:data {:echo {:input_arg 1138}}}
+         (execute-var 1138))))
+
+(deftest string
+  (is (= {:data {:echo {:input_arg "zardoz"}}}
+         (execute compiled-schema "{ echo (input: \"zardoz\" ) }"))))
+
+(deftest simple-map
+  (is (= {:data
+          {:echo
+           {:input_arg {:max 20
+                        :order "desc"
+                        :skip 10}}}}
+         (execute compiled-schema "{ echo(input: {skip: 10, max: 20, order: \"desc\"}) }"))))
+
+(deftest simple-map-var
+  (is (= {:data
+          {:echo
+           {:input_arg
+            {:max 20
+             :order "asc"
+             :skip 120}}}}
+         (execute-var {:skip 120
+                       :max 20
+                       :order "asc"}))))
+
+(deftest var-nested-in-map-not-allowed
+  (is (= {:errors [{:extensions {:argument :input
+                                 :field :echo}
+                    :locations [{:column 21
+                                 :line 1}]
+                    :message "Exception applying arguments to field `echo': Argument `input' contains a scalar argument with nested variables, which is not allowed."}]}
+         (execute compiled-schema
+                  "query ($p : Data) { echo (input: {p: $p}) }"
+                  {:p {:order 97
+                       :date "2018115"}}
+                  nil))))
+
+(deftest array-property
+  (is (= {:data
+          {:echo
+           {:input_arg {:vals [1
+                               3
+                               true
+                               3.14]}}}}
+         (execute compiled-schema "{ echo(input: {vals: [1 3 true 3.14]})}"))))
+
+(deftest nested-map-property
+  (is (= {:data
+          {:echo
+           {:input_arg
+            {:name "fred"
+             :address {:street "100 Bedrock Lane."}}}}}
+         (execute compiled-schema "{ echo(input: {name: \"fred\" address: {street: \"100 Bedrock Lane.\"}}) }"))))


### PR DESCRIPTION
This allows a scalar to be a complex structure (validated by the scalar's parse function).  This ends up modeling scalars in a way very, very similar to how Clojure reader macros operate.