### PR TITLE
fix typo in directives example

### DIFF
--- a/docs/_examples/directive-defs.edn
+++ b/docs/_examples/directive-defs.edn
@@ -1,7 +1,7 @@
 {:directive-defs
  {:access
   {:locations #{:field-definition}
-   :args {:role {:type (not-null String)}}}}
+   :args {:role {:type (non-null String)}}}}
 
  :queries
  {:ultimate_answer


### PR DESCRIPTION
`not-null` => `non-null`

I've signed the CLA