### PR TITLE
Change schema parser to accept &-separated interfaces

### DIFF
--- a/dev-resources/mult-inheritance.sdl
+++ b/dev-resources/mult-inheritance.sdl
@@ -6,7 +6,7 @@ interface Client {
   ip: String
 }
 
-type User implements Node, Client {
+type User implements Node & Client {
   id: ID!
   ip: String
 }

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -78,7 +78,7 @@ fieldDefs
   ;
 
 implementationDef
-  : K_IMPLEMENTS anyName+
+  : K_IMPLEMENTS '&'? Name ('&' Name)*
   ;
 
 inputTypeDef

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -306,8 +306,10 @@
 
 (defmethod xform :implementationDef
   [prod]
-  (let [types (drop 2 prod)]
-    (mapv xform types)))
+  (->> prod
+       rest
+       (filter #(-> % first (= :name)))
+       (mapv xform)))
 
 (defmethod xform :typeSpec
   [prod]


### PR DESCRIPTION
A small change to consolidate the format required for implementing multiple interfaces when parsing a schema file to EDN.

The parser for a schema file to Lacinia's EDN appears to accept inheritance of multiple `space-separated` interfaces.
The [example from FB](https://facebook.github.io/graphql/draft/#sec-Interfaces) for implementing multiple interfaces is `ampersand-separated`.
It would be good if this was an option as in my scenario I am sharing one schema file between Lacinia  and a different JS library.

This isn't backwards compatible which may be an issue? I could change the regex to something like `'implements' (Name '&'?)* Name`.