### PR TITLE
Allow keywords or symbols for modifiers, and * and ! as abbreviations

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -38,8 +38,8 @@ In the schema, a type can be:
 
 - A keyword corresponding to an object, interface, enum, or union
 - A scalar type (built in, or schema defined)
-- A non-nillable version of any of the above: ``(non-null X)``
-- A list of any of the above: ``(list X)``
+- A non-nillable version of any of the above: ``(non-null X)`` [#non-null]_
+- A list of any of the above: ``(list X)`` [#list]_
 
 The built-in scalar types:
 
@@ -125,3 +125,11 @@ Deprecation
 
 A field may include a ``:deprecation`` key; this identifies that the field
 is :doc:`deprecated <deprecation>`.
+
+
+.. [#non-null] You may use a symbol or keyword for ``non-null``, and may also use
+  ``!`` or ``:!`` as an abbreviation, e.g. ``(! String)``.
+  Keywords make it easier to use the modifier when a schema is expressed
+  inside Clojure code (rather than read from an EDN file), without needing to use quoting.
+
+.. [#list] Likewise, ``list`` may be abbreviated as ``*``.

--- a/src/com/walmartlabs/lacinia/expound.clj
+++ b/src/com/walmartlabs/lacinia/expound.clj
@@ -21,7 +21,7 @@
 
 (defmsg ::schema/resolver-type "implement the com.walmartlabs.lacinia.resolve/FieldResolver protocol")
 
-(defmsg ::schema/wrapped-type-modifier "type wrappers should be either (list type) or (non-null type)")
+(defmsg ::schema/wrapped-type-modifier "type wrappers should be (modifier type) where modifier is one of list/:list/*/:* or non-null/:non-null/!/:!")
 
 (defmsg ::schema/graphql-identifier "must be a valid GraphQL identifier: contain only letters, numbers, and underscores")
 

--- a/test/com/walmartlabs/lacinia/custom_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/custom_scalars_test.clj
@@ -264,8 +264,8 @@
         serialize-date #(.print date-formatter %)
         schema (schema/compile {:scalars {:Date {:parse parse-date
                                                  :serialize serialize-date}}
-                                :queries {:sundays {:type '(list (non-null :Date))
-                                                    :args {:between {:type '(non-null (list (non-null :Date)))}}
+                                :queries {:sundays {:type '(:* (:! :Date))
+                                                    :args {:between {:type '(! (* (! Date)))}}
                                                     :resolve (fn [ctx args v]
                                                                (let [[start end] (:between args)]
                                                                  (sundays start end)))}}})]

--- a/test/com/walmartlabs/lacinia/expound_tests.clj
+++ b/test/com/walmartlabs/lacinia/expound_tests.clj
@@ -38,7 +38,7 @@
 
 (deftest correctly-reports-incorrect-type-modifier
   (expect ::schema/field {:type '(something :String)}
-          "type wrappers should be either (list type) or (non-null type)"))
+          "type wrappers should be (modifier type)"))
 
 (deftest can-report-enum-value
   (expect ::schema/enum-value 123 "string?" "simple-symbol?" "simple-keyword?")


### PR DESCRIPTION
This allows `'(! String)` rather than `'(non-null String)` for example, or `(:non-null :String)` (using keywords to avoid quoting), or even `[:! :String]`.

I've been thinking about this for a long time, especially every time I've typed `not-null` or `non-nil` instead of `non-null`.

*Wait for 0.33.0 to be active before merge*