### PR TITLE
GraphQL schema parsing support for extend type and empty type

### DIFF
--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -90,7 +90,7 @@ inputTypeDef
   ;
 
 interfaceDef
-  : description? K_INTERFACE anyName directiveList? fieldDefs
+  : description? K_INTERFACE anyName directiveList? fieldDefs?
   ;
 
 scalarDef

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -70,7 +70,7 @@ directiveArg
   ;
 
 typeDef
-  : description? K_TYPE anyName implementationDef? directiveList? fieldDefs
+  : description? K_TYPE anyName implementationDef? directiveList? fieldDefs?
   ;
 
 typeExtDef

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -1,7 +1,7 @@
 grammar GraphqlSchema;
 
 graphqlSchema
-  : (schemaDef|typeDef|inputTypeDef|unionDef|enumDef|interfaceDef|scalarDef|directiveDef)*
+  : (schemaDef|typeDef|typeExtDef|inputTypeDef|unionDef|enumDef|interfaceDef|scalarDef|directiveDef)*
   ;
 
 description
@@ -71,6 +71,10 @@ directiveArg
 
 typeDef
   : description? K_TYPE anyName implementationDef? directiveList? fieldDefs
+  ;
+
+typeExtDef
+  : description? K_EXTEND K_TYPE anyName implementationDef? directiveList? fieldDefs
   ;
 
 fieldDefs

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -86,7 +86,7 @@ implementationDef
   ;
 
 inputTypeDef
-  : description? K_INPUT anyName directiveList? fieldDefs
+  : description? K_INPUT anyName directiveList? fieldDefs?
   ;
 
 interfaceDef

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -74,7 +74,7 @@ typeDef
   ;
 
 typeExtDef
-  : description? K_EXTEND K_TYPE anyName implementationDef? directiveList? fieldDefs
+  : description? K_EXTEND K_TYPE anyName implementationDef? directiveList? fieldDefs?
   ;
 
 fieldDefs

--- a/src/com/walmartlabs/lacinia/parser/common.clj
+++ b/src/com/walmartlabs/lacinia/parser/common.clj
@@ -97,6 +97,11 @@
   [to from]
   (with-meta to (meta from)))
 
+(defn add-meta
+  "Add metadata to object"
+  [to more-metadata]
+  (with-meta to (merge (meta to) more-metadata)))
+
 (defn blockstringvalue->String
   "Transform an ANTLR multi-line block string value into a Clojure string."
   [^String s]

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -217,7 +217,8 @@
 
 (defmethod xform :typeDef
   [prod]
-  (let [{:keys [anyName implementationDef fieldDefs description directiveList]} (tag prod)]
+  (let [{:keys [anyName implementationDef fieldDefs description directiveList]
+         :or   {fieldDefs (list :fieldDefs)}} (tag prod)]
     [[:objects (xform anyName)]
      (-> {:fields (xform fieldDefs)}
          (common/copy-meta anyName)

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -366,7 +366,8 @@
 
 (defmethod xform :interfaceDef
   [prod]
-  (let [{:keys [anyName fieldDefs description directiveList]} (tag prod)]
+  (let [{:keys [anyName fieldDefs description directiveList]
+         :or   {fieldDefs (list :fieldDefs)}} (tag prod)]
     [[:interfaces (xform anyName)]
      (-> {:fields (xform fieldDefs)}
          (common/copy-meta anyName)

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -72,7 +72,10 @@
                                                     (q (str (name k) "/" (name property))))
                                             (cond-> {:key k}
                                                     (seq locations) (assoc :locations locations)))))))
-                      (merge-with merge org v)))
+                      (merge {:fields (merge (get org :fields) (get v :fields))}
+                             (let [implements (into (get org :implements []) (get v :implements []))]
+                               (when (not-empty implements)
+                                 {:implements implements})))))
 
         (contains? m k)
         (let [locations (keepv meta [(get m k) v])]

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -64,8 +64,10 @@
           [{:fields (merge (get org :fields) (get v :fields))}
            (some->> (into (get org :implements []) (get v :implements []))
                     (distinct)
+                    (vec)
                     (#(if (not-empty %) % nil))
                     (assoc {} :implements))
+           ; TODO check and/or remove duplicate directives
            (some->> (into (get org :directives []) (get v :directives []))
                     (#(if (not-empty %) % nil))
                     (assoc {} :directives))

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -17,7 +17,7 @@
   {:added "0.22.0"}
   (:require
     #_ [io.pedestal.log :as log]
-    [com.walmartlabs.lacinia.internal-utils :refer [remove-vals keepv q]]
+    [com.walmartlabs.lacinia.internal-utils :refer [remove-vals keepv q qualified-name]]
     [com.walmartlabs.lacinia.parser.common :as common]
     [com.walmartlabs.lacinia.util :refer [inject-descriptions]]
     [com.walmartlabs.lacinia.schema :as schema]
@@ -56,7 +56,7 @@
     (when (contains? (get v :fields {}) property)
       (let [locations (keepv meta [org v])]
         (throw (ex-info (format "Field %s already defined in the existing schema. It cannot also be defined in this type extension."
-                                (q (str (name k) "/" (name property))))
+                                (q (qualified-name k property)))
                         (cond-> {:key k}
                                 (seq locations) (assoc :locations locations)))))))
   (reduce merge

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -228,7 +228,8 @@
 
 (defmethod xform :typeExtDef
   [prod]
-  (let [{:keys [anyName implementationDef fieldDefs description directiveList]} (tag prod)]
+  (let [{:keys [anyName implementationDef fieldDefs description directiveList]
+         :or   {fieldDefs (list :fieldDefs)}} (tag prod)]
     (with-meta [[:objects (xform anyName)]
                 (-> {:fields (xform fieldDefs)}
                     (common/copy-meta anyName)

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -75,7 +75,13 @@
                       (merge {:fields (merge (get org :fields) (get v :fields))}
                              (let [implements (into (get org :implements []) (get v :implements []))]
                                (when (not-empty implements)
-                                 {:implements implements})))))
+                                 {:implements implements}))
+                             (let [description (->> [(get org :description) (get v :description)]
+                                                    (remove nil?)
+                                                    (str/join " "))]
+                               (when (not-empty description)
+                                 {:description description})))))
+
 
         (contains? m k)
         (let [locations (keepv meta [(get m k) v])]

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -412,7 +412,8 @@
 
 (defmethod xform :inputTypeDef
   [prod]
-  (let [{:keys [anyName fieldDefs description directiveList]} (tag prod)]
+  (let [{:keys [anyName fieldDefs description directiveList]
+         :or   {fieldDefs (list :fieldDefs)}} (tag prod)]
     [[:input-objects (xform anyName)]
      (-> {:fields (xform fieldDefs)}
          (common/copy-meta anyName)

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -110,8 +110,12 @@
              :b {:type 'String}}}}}
          (parse-string "extend type Ebb { b: String } \n type Ebb { a: String }"))))
 
+(deftest schema-extend-type-existing-field-fails
+  (is (thrown-with-msg? Throwable #"Field `Ebb/a' already defined in the existing schema. It cannot also be defined in this type extension."
+                        (parse-string "type Ebb { a: String } \n extend type Ebb { a: String } \n "))))
+
 (deftest schema-extend-missing-type-fails
-  (is (thrown-with-msg? Throwable #"Cannot extend type objects `Ebb' because it does not exist in the existing schema"
+  (is (thrown-with-msg? Throwable #"Cannot extend type `Ebb' because it does not exist in the existing schema."
                         (parse-string (str "extend type Ebb { b: String }")))))
 
 (deftest schema-enums

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -103,6 +103,14 @@
          (parse-string (str "type Ebb { a: String }\n"
                             "extend type Ebb { b: String }")))))
 
+(deftest schema-extend-type-reverse-order
+  (is (= {:objects
+          {:Ebb
+           {:fields
+            {:a {:type 'String}
+             :b {:type 'String}}}}}
+         (parse-string "extend type Ebb { b: String } \n type Ebb { a: String }"))))
+
 (deftest schema-enums
   (is (= {:enums
           {:Target

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -100,8 +100,7 @@
            {:fields
             {:a {:type 'String}
              :b {:type 'String}}}}}
-         (parse-string (str "type Ebb { a: String }\n"
-                            "extend type Ebb { b: String }")))))
+         (parse-string "type Ebb { a: String } \n extend type Ebb { b: String }"))))
 
 (deftest schema-extend-type-reverse-order
   (is (= {:objects
@@ -110,6 +109,10 @@
             {:a {:type 'String}
              :b {:type 'String}}}}}
          (parse-string "extend type Ebb { b: String } \n type Ebb { a: String }"))))
+
+(deftest schema-extend-missing-type-fails
+  (is (thrown-with-msg? Throwable #"Cannot extend type objects `Ebb' because it does not exist in the existing schema"
+                        (parse-string (str "extend type Ebb { b: String }")))))
 
 (deftest schema-enums
   (is (= {:enums

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -94,6 +94,15 @@
              {:type 'String}}}}}
          (parse-string "type Ebb { type: String }"))))
 
+(deftest schema-extend-type
+  (is (= {:objects
+          {:Ebb
+           {:fields
+            {:a {:type 'String}
+             :b {:type 'String}}}}}
+         (parse-string (str "type Ebb { a: String }\n"
+                            "extend type Ebb { b: String }")))))
+
 (deftest schema-enums
   (is (= {:enums
           {:Target

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -151,6 +151,11 @@
                             "type Ebb { aa: String } "
                             "extend type Ebb implements A { a: String } ")))))
 
+(deftest schema-extend-type-does-not-remove-anything
+  (let [org-type " \"MyDescription\" type Ebb { a: String }"]
+    (is (= (parse-string org-type)
+           (parse-string (str org-type " extend type Ebb"))))))
+
 (deftest schema-extend-type-existing-field-fails
   (is (thrown-with-msg? Throwable #"Field `Ebb/a' already defined in the existing schema. It cannot also be defined in this type extension."
                         (parse-string "type Ebb { a: String } \n extend type Ebb { a: String } \n "))))

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -86,6 +86,13 @@
              {:type 'String}}}}}
          (parse-string "type Ebb { flow: String }"))))
 
+(deftest schema-empty-type
+  (is (= {:objects
+          {:Ebb
+           {:fields
+            {}}}}
+         (parse-string "type Ebb"))))
+
 (deftest schema-type-2
   (is (= {:objects
           {:Ebb

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -109,6 +109,16 @@
              :b {:type 'String}}}}}
          (parse-string "type Ebb { a: String } \n extend type Ebb { b: String }"))))
 
+(deftest schema-extend-type-empty
+  (is (= {:interfaces
+          {:A {:fields {:a {:type 'String}}}}
+          :objects
+          {:Ebb
+           {:fields
+            {:a {:type 'String}}
+            :implements [:A]}}}
+         (parse-string "interface A { a: String } \n type Ebb { a: String } \n extend type Ebb implements A "))))
+
 (deftest schema-extend-type-reverse-order
   (is (= {:objects
           {:Ebb

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -152,7 +152,7 @@
                             "extend type Ebb implements A { a: String } ")))))
 
 (deftest schema-extend-type-does-not-remove-anything
-  (let [org-type " \"MyDescription\" type Ebb { a: String }"]
+  (let [org-type " \"MyDescription\" type Ebb @X { a: String }"]
     (is (= (parse-string org-type)
            (parse-string (str org-type " extend type Ebb"))))))
 

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -110,6 +110,30 @@
              :b {:type 'String}}}}}
          (parse-string "extend type Ebb { b: String } \n type Ebb { a: String }"))))
 
+(deftest schema-type-extend-type-implements
+  (is (= {:interfaces
+          {:A {:fields {:a {:type 'String}}}
+           :B {:fields {:b {:type 'String}}}}
+          :objects
+          {:Ebb
+           {:fields
+            {:a {:type 'String}
+             :b {:type 'String}}
+            :implements [:A :B]}}}
+         (parse-string (str "interface A { a: String } interface B { b: String } "
+                            "       type Ebb implements A { a: String } "
+                            "extend type Ebb implements B { b: String } "))))
+  (is (= {:interfaces
+          {:A {:fields {:a {:type 'String}}}}
+          :objects
+          {:Ebb
+           {:fields {:aa {:type 'String}
+                     :a {:type 'String}}
+            :implements [:A]}}}
+         (parse-string (str "interface A { a: String } "
+                            "type Ebb { aa: String } "
+                            "extend type Ebb implements A { a: String } ")))))
+
 (deftest schema-extend-type-existing-field-fails
   (is (thrown-with-msg? Throwable #"Field `Ebb/a' already defined in the existing schema. It cannot also be defined in this type extension."
                         (parse-string "type Ebb { a: String } \n extend type Ebb { a: String } \n "))))


### PR DESCRIPTION
This pull request addresses #265 and #268 

The merging of `directives` for `extend type` is not perfect, and a `TODO` is added at that code line.

Thanks and kind regards.