### PR TITLE
Change output from selections-tree to account for aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,13 @@
 GraphQL Schema Definition Language documents can now contain empty types, and use
 `extend type`.
 
+### **Breaking Change**: com.walmartlabs.lacinia.executor/selections-tree
+
+`selections-tree` has changed; the value for a key is now a vector of nodes
+(each possibly nil) rather than just a single node; this is to account for
+the fact that a selection set may reference the same field, using different
+aliases (and different arguments and sub-selections).
+
 [Closed Issues](https://github.com/walmartlabs/lacinia/milestone/21?closed=1)
 
 ## 0.32.0 -- 4 Feb 2019

--- a/docs/_examples/selections-tree.edn
+++ b/docs/_examples/selections-tree.edn
@@ -1,4 +1,4 @@
-{:character/friends {:selections
-                     {:character/name nil}}
- :human/home_planet nil
- :character/name nil}
+{:character/friends [{:selections
+                      {:character/name [nil]}}]
+ :human/home_planet [nil]
+ :character/name [nil]}

--- a/docs/resolve/selections.rst
+++ b/docs/resolve/selections.rst
@@ -132,12 +132,20 @@ For the above query, it would return the following structure:
 .. literalinclude:: ../_examples/selections-tree.edn
    :language: clojure
 
+Each key in the map identifies a specific field by the qualified field name, such as
+``:character/friends``.
+The value is a vector of how that field is used; it is a vector because the same field
+may appear in the selection multiple times, using aliases.
+
 This shows, for example, that ``:character/name`` is used in two different ways (inside the
 ``hero`` query itself, and within the ``friends`` field).
 
 For fields with arguments, an ``:args`` key is present, with the exact values which will be
 supplied to the the nested field's resolver.
 
-Fields with neither arguments nor sub-selections are represented as nil.
+For fields with an alias, an ``:alias`` key will be present; the value is a keyword for the alias
+(as provided in the client query).
+
+Fields without arguments, sub-selections, on an alias are represented as nil.
 
 

--- a/project.clj
+++ b/project.clj
@@ -11,14 +11,14 @@
   :source-paths ["src"
                  "vendor-src"]
   :profiles {:dev {:dependencies [[criterium "0.4.4"]
-                                  [expound "0.7.1"]
-                                  [joda-time "2.10"]
+                                  [expound "0.7.2"]
+                                  [joda-time "2.10.1"]
                                   [com.walmartlabs/test-reporting "0.1.0"]
                                   [io.aviso/logging "0.3.1"]
-                                  [io.pedestal/pedestal.log "0.5.4"]
+                                  [io.pedestal/pedestal.log "0.5.5"]
                                   [org.clojure/test.check "0.9.0"]
                                   [org.clojure/data.csv "0.1.4"]
-                                  [org.clojure/tools.cli "0.3.7"]]}}
+                                  [org.clojure/tools.cli "0.4.1"]]}}
   :aliases {"benchmarks" ["run" "-m" "perf"]}
   :jvm-opts ["-Xmx1g" "-XX:-OmitStackTraceInFastThrow"]
   :test2junit-output-dir ~(or (System/getenv "CIRCLE_TEST_REPORTS") "target/test2junit")

--- a/test/com/walmartlabs/lacinia/optimize_resolve.clj
+++ b/test/com/walmartlabs/lacinia/optimize_resolve.clj
@@ -1,0 +1,77 @@
+; Copyright (c) 2018-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+(ns com.walmartlabs.lacinia.optimize-resolve
+  (:require
+    [criterium.core :refer [quick-bench]]
+    [com.walmartlabs.lacinia.resolve :as resolve
+     :refer [resolve-as]]))
+
+
+(defn extract-result
+  [result]
+  (let [p (promise)]
+    (resolve/on-deliver! result p)
+    ;; Now, block until it is ready:
+    @p))
+
+(defn combine-results-serial
+  [results]
+  (reduce
+    #(resolve/combine-results conj %1 %2)
+    (resolve-as [])
+    results))
+
+(defn combine-results-parallel
+  [results]
+  (let [n (count results)]
+    (if (zero? n)
+      (resolve-as [])
+      (let [*remaining (atom n)
+            result-array (object-array n)
+            output-result (resolve/resolve-promise)]
+        (doall
+          (map-indexed
+            (fn [i result]
+              (resolve/on-deliver! result
+                                   (fn [value]
+                                     (aset result-array i value)
+                                     (when (zero? (swap! *remaining dec))
+                                       (resolve/deliver! output-result
+                                                         (vec result-array))))))
+            results))
+        output-result))))
+
+(defn make-results
+  [n]
+  (into []
+        (for [i (range n)]
+          (resolve/resolve-as i))))
+
+(comment
+  (let [n 5000
+        results (make-results n)]
+    (println "**** START:" n "****")
+    (println "Serial:")
+    (quick-bench
+      (extract-result
+        (combine-results-parallel results)))
+
+    (println "Parallel:")
+    (quick-bench
+      (extract-result
+        (combine-results-serial results)))
+
+    nil)
+
+  )


### PR DESCRIPTION
The existing implementation is simpler, but fails when a selection includes the same field more than once, including via a fragment.  The new version maps each qualified field name to a vector of usage maps; the usage maps may include an :alias key.

 Fixes #262 