### PR TITLE
Do not allow an InputObject as a field type (outside of another IO)

### DIFF
--- a/dev-resources/com/walmartlabs/test_schema.clj
+++ b/dev-resources/com/walmartlabs/test_schema.clj
@@ -188,7 +188,7 @@
     :echoArgs
     {:fields {:integer {:type 'Int}
               :integerArray {:type '(list Int)}
-              :inputObject {:type :testInputObject}}}
+              :inputObject {:type 'String}}}
 
     :galaxy_date
     {:fields {:date {:type :Date}}}
@@ -312,7 +312,7 @@
                       :integerArray {:type '(list Int)}
                       :inputObject {:type :testInputObject}}
                :resolve (fn [ctx args v]
-                          args)}
+                          (update args :inputObject pr-str))}
     :now {:type :galaxy_date
           :resolve (fn [ctx args v]
                      {:date (java.util.Date.)})}

--- a/test/com/walmartlabs/input_objects_test.clj
+++ b/test/com/walmartlabs/input_objects_test.clj
@@ -135,3 +135,28 @@
                      {:Six
                       {:fields
                        {:count {:type :Int}}}}})))
+
+(deftest input-object-not-allowed-as-normal-field
+  (expect-exception
+    "Field `Web/spider' is type `Creepy', input objects may only be used as field arguments."
+    {:field-name :Web/spider
+     :schema-types {:input-object [:Creepy]
+                    :object [:MutationRoot
+                             :QueryRoot
+                             :SubscriptionRoot
+                             :Web]
+                    :scalar [:Boolean
+                             :Float
+                             :ID
+                             :Int
+                             :String]}}
+    (schema/compile
+      {:input-objects
+       {:Creepy
+        {:fields
+         {:legs {:type :Int}}}}
+       :objects
+       {:Web
+        {:fields
+         {:spider {:type :Creepy}}}}})))
+

--- a/test/com/walmartlabs/input_objects_test.clj
+++ b/test/com/walmartlabs/input_objects_test.clj
@@ -122,34 +122,13 @@
                       {:fields
                        {:legs {:type :Six}}}}})))
 
-(deftest invalid-field-type
-  (expect-exception
-    "Field `Insect/legs' must be a scalar type, an enum, or an input-object."
-    {:field-name :Insect/legs
-     :field-type :Six}
-    (schema/compile {:input-objects
-                     {:Insect
-                      {:fields
-                       {:legs {:type :Six}}}}
-                     :objects
-                     {:Six
-                      {:fields
-                       {:count {:type :Int}}}}})))
-
 (deftest input-object-not-allowed-as-normal-field
   (expect-exception
     "Field `Web/spider' is type `Creepy', input objects may only be used as field arguments."
     {:field-name :Web/spider
-     :schema-types {:input-object [:Creepy]
-                    :object [:MutationRoot
-                             :QueryRoot
-                             :SubscriptionRoot
-                             :Web]
-                    :scalar [:Boolean
-                             :Float
-                             :ID
-                             :Int
-                             :String]}}
+     :schema-types {:scalar [:Boolean :Float :ID :Int :String],
+                    :object [:MutationRoot :QueryRoot :SubscriptionRoot :Web],
+                    :input-object [:Creepy]}}
     (schema/compile
       {:input-objects
        {:Creepy
@@ -159,4 +138,19 @@
        {:Web
         {:fields
          {:spider {:type :Creepy}}}}})))
+
+(deftest object-fields-must-be-scalar-enum-or-input-object
+  (expect-exception
+    "Field `Turtle/friend' is type `Hare', input objects may only contain fields that are scalar, enum, or input object."
+    {:field-name :Turtle/friend
+     :schema-types  {:scalar [:Boolean :Float :ID :Int :String],
+                     :object [:Hare :MutationRoot :QueryRoot :SubscriptionRoot],
+                     :input-object [:Turtle]}}
+    (schema/compile
+      {:input-objects
+       {:Turtle {:fields {:friend {:type :Hare}}}}
+       :objects
+       {:Hare
+        {:fields
+         {:speed {:type :Int}}}}})))
 

--- a/test/com/walmartlabs/introspection_test.clj
+++ b/test/com/walmartlabs/introspection_test.clj
@@ -1015,8 +1015,8 @@
                                :description nil
                                :isDeprecated false
                                :name "inputObject"
-                               :type {:kind :INPUT_OBJECT
-                                      :name "testInputObject"
+                               :type {:kind :SCALAR
+                                      :name "String"
                                       :ofType nil}}
                               {:args []
                                :deprecationReason nil

--- a/test/com/walmartlabs/lacinia/validator_test.clj
+++ b/test/com/walmartlabs/lacinia/validator_test.clj
@@ -310,27 +310,6 @@
 
              (execute compiled-schema q {} nil)))))
 
-  (testing "valid deeply nested input-object property of type list but of single value"
-    (let [q "{ echoArgs(integer: 1,
-                        integerArray: [2, 3],
-                        inputObject: {integer: 4,
-                                      string: \"five\",
-                                      nestedInputObject: {integerArray: 6,
-                                                          date: \"1983-08-13\"}}) {
-                integer,
-                inputObject {
-                   integer
-                   nestedInputObject {
-                      integerArray
-                   }
-                }
-              }
-            }"]
-      (is (= {:data {:echoArgs {:integer 1,
-                                :inputObject {:integer 4,
-                                              :nestedInputObject {:integerArray [6]}}}}}
-             (execute compiled-schema q {} nil)))))
-
   (testing "invalid array element"
     (let [q "{echoArgs(integer: 3, integerArray: [1, 2, \"foo\"]) { integer }}"]
       (is (= {:errors [{:extensions {:argument :integerArray
@@ -341,33 +320,6 @@
                                      :line 1}]
                         :message "Exception applying arguments to field `echoArgs': For argument `integerArray', unable to convert \"foo\" to scalar type `Int'."}]}
 
-             (execute compiled-schema q {} nil)))))
-
-  (testing "valid arguments"
-    (let [q "{ echoArgs(integer: 1,
-                        integerArray: [2, 3],
-                        inputObject: {integer: 4,
-                                      string: \"five\",
-                                      nestedInputObject: {integerArray: [6, 7],
-                                                          date: \"1983-08-13\"}}) {
-                 integer
-                 integerArray
-                 inputObject {
-                   integer
-                   string
-                   nestedInputObject {
-                     integerArray
-                     date
-                   }
-                 }
-               }
-             }"]
-      (is (= {:data {:echoArgs {:integer 1
-                                :integerArray [2, 3]
-                                :inputObject {:integer 4
-                                              :string "five"
-                                              :nestedInputObject {:integerArray [6, 7]
-                                                                  :date "A long time ago"}}}}}
              (execute compiled-schema q {} nil)))))
 
   (testing "Non-nullable arguments"

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -108,17 +108,17 @@
         (is (= {:data {:changeHeroHomePlanet {:name "Leia Organa" :homePlanet "Alderaan"}}}
                (execute default-schema q {:id "1003"} nil)))))
     (testing "nested object element values"
-      (let [q "query { echoArgs (integerArray: [1 null 3], inputObject: {string: \"yes\", nestedInputObject: {integerArray: [4 5 6]}}) { integerArray inputObject { string nestedInputObject {integerArray} } } }"]
-        (is (= {:data {:echoArgs {:integerArray [1 nil 3] :inputObject {:string "yes" :nestedInputObject {:integerArray [4 5 6]}}}}}
+      (let [q "query { echoArgs (integerArray: [1 null 3], inputObject: {string: \"yes\", nestedInputObject: {integerArray: [4 5 6]}}) { integerArray inputObject } }"]
+        (is (= {:data {:echoArgs {:integerArray [1 nil 3] :inputObject (pr-str {:string "yes" :nestedInputObject {:integerArray [4 5 6]}})}}}
                (execute default-schema q {} nil)))))
     (testing "null list/object element values"
-      (let [q "query { echoArgs (integerArray: [1 null 3], inputObject: {string: null}) { integerArray inputObject { string } } }"]
-        (is (= {:data {:echoArgs {:integerArray [1 nil 3] :inputObject {:string nil}}}}
+      (let [q "query { echoArgs (integerArray: [1 null 3], inputObject: {string: null}) { integerArray inputObject  } }"]
+        (is (= {:data {:echoArgs {:integerArray [1 nil 3] :inputObject (pr-str {:string nil})}}}
                (execute default-schema q {} nil)))))
     (testing "null list/object values become null-ish"
-      (let [q "query { echoArgs (integerArray: null, inputObject: null) { integerArray inputObject { string } } }"]
+      (let [q "query { echoArgs (integerArray: null, inputObject: null) { integerArray inputObject } }"]
         (is (= {:data {:echoArgs {:integerArray []
-                                  :inputObject nil}}}
+                                  :inputObject "nil"}}}
                (execute default-schema q {} nil)))))))
 
 (deftest nested-query
@@ -241,13 +241,6 @@
                                    :line 2}]
                       :message "No value was provided for variable `someId', which is non-nullable."}]}
            (execute default-schema q {} nil)))))
-
-(deftest nested-variable-query
-  (let [q "query EchoArgs($inputObject: testInputObject) { echoArgs (inputObject: $inputObject) {  inputObject { string nestedInputObject {date name} } } }"
-        inputObject {:string "yes",
-                     :nestedInputObject {:date "2017-05-11T08:53:19.184-00:00" :name "Test"}}]
-    (is (= {:data {:echoArgs {:inputObject {:string "yes" :nestedInputObject {:date "A long time ago" :name "Test"}}}}}
-           (execute default-schema q {:inputObject inputObject} nil)))))
 
 (deftest aliased-query
   (let [q "query FetchLukeAliased {
@@ -640,14 +633,10 @@
 
   (testing "field argument of a list type of an input object is a single integer"
     (let [q "{ echoArgs (inputObject: { nestedInputObject: { integerArray: 6 }}) {
-                  inputObject {
-                    nestedInputObject {
-                      integerArray
-                    }
-                  }
+                  inputObject
                 }
              }"]
-      (is (= {:data {:echoArgs {:inputObject {:nestedInputObject {:integerArray [6]}}}}}
+      (is (= {:data {:echoArgs {:inputObject (pr-str {:nestedInputObject {:integerArray [6]}})}}}
              (execute default-schema q {} nil))
           "should accept single value and coerce it to a list of size one")))
 


### PR DESCRIPTION
Even some of our tests bent the rules here, and needed correction.

Fixes #254