### PR TITLE
Don't transform empty objects to nils

### DIFF
--- a/dev-resources/empty-input-objects.edn
+++ b/dev-resources/empty-input-objects.edn
@@ -1,0 +1,10 @@
+{:input-objects
+ {:root_input
+  {:fields {:name {:type String}}}}
+
+ :queries
+ {:print_input
+  {:type String
+   :args
+   {:input {:type :root_input}}
+   :resolve :query/print-input}}}

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -326,7 +326,7 @@
                                                               (q k))
                                                       {:schema-type type-name})))
             object-value (reduce-kv process-object-field
-                                    nil
+                                    {}
                                     arg-value)
             with-defaults (merge default-values object-value)]
         (doseq [k required-keys]

--- a/test/com/walmartlabs/input_objects_test.clj
+++ b/test/com/walmartlabs/input_objects_test.clj
@@ -18,6 +18,13 @@
     [com.walmartlabs.lacinia.schema :as schema]
     [com.walmartlabs.test-utils :refer [compile-schema execute expect-exception]]))
 
+(deftest coerce-empty-input-objects-to-empty-hashmaps
+  (let [schema (compile-schema "empty-input-objects.edn"
+                               {:query/print-input (fn [_ args _]
+                                                     (pr-str args))})]
+    (is (= {:data {:print_input "{:input {}}"}}
+           (execute schema "query { print_input (input: {})}")))))
+
 (deftest null-checks-within-nullable-field
   (let [schema (compile-schema "nested-non-nullable-fields-schema.edn"
                                {:mutation/create-game (fn [_ args _]


### PR DESCRIPTION
This pull request fixes the incorrect coercion of empty input objects to nils.

Previously, the query
```
query {
    print_input (input: {})
}
```
would incorrectly pass `{:input nil}` args hashmap to the resolver of `print_input` while the correct args hashmap would be `{:input {}}`.