### PR TITLE
Fix extlink for GraphQL Spec

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -328,5 +328,5 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 def setup(app):
   app.add_stylesheet("css/custom.css")
 
-extlinks = {'spec': ('http://facebook.github.io/graphql/June2018/#sec-%s', ''),
+extlinks = {'spec': ('https://graphql.github.io/graphql-spec/June2018/#sec-%s', ''),
             'clojure' : ('https://clojure.org/%s', '')}


### PR DESCRIPTION
http://facebook.github.io/graphql/... redirects to https://graphql.github.io/graphql-spec/ landing page, not to the particular topic we were trying to read about.