### PR TITLE
Improvements to the executor namespace preview API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## 0.34.0 -- UNRELEASED
+
+The new function `com.walmartlabs.lacinia.executor/parsed-query->context`
+makes it possible to use the preview API functions in the executor
+namespace even before the query is executed, for example, from 
+a Pedestal interceptor.
+
+New preview API function `com.walmartlabs.lacinia.executor/selections-seq2`
+improves on `selections-seq`, returning the name, alias, and arguments of
+each selected field.
+
 ## 0.33.0 -- 23 May 2019
 
 GraphQL Schema Definition Language documents can now contain empty types, and use

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "0.33.0"
+(defproject com.walmartlabs/lacinia "0.34.0-SNAPSHOT"
   :description "A GraphQL server implementation in Clojure"
   :url "https://github.com/walmartlabs/lacinia"
   :license {:name "Apache, Version 2.0"
@@ -12,9 +12,9 @@
                  "vendor-src"]
   :profiles {:dev {:dependencies [[criterium "0.4.5"]
                                   [expound "0.7.2"]
-                                  [joda-time "2.10.1"]
+                                  [joda-time "2.10.2"]
                                   [com.walmartlabs/test-reporting "0.1.0"]
-                                  [io.aviso/logging "0.3.1"]
+                                  [io.aviso/logging "0.3.2"]
                                   [io.pedestal/pedestal.log "0.5.5"]
                                   [org.clojure/test.check "0.9.0"]
                                   [org.clojure/data.csv "0.1.4"]

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -536,14 +536,10 @@
   "Identifies the qualified field name for a selection node.  May return nil
   for meta-fields such as __typename."
   [node]
-  (-> node :field-definition :qualified-name))
+  (get-in node [:field-definition :qualified-name]))
 
-(defn selections-seq
-  "A width-first traversal of selections tree, returning a lazy sequence
-  of qualified field names.  A qualified field name is a namespaced keyword,
-  the namespace is the containing type, e.g. :User/name."
-  {:added "0.17.0"}
-  [context]
+(defn ^:private walk-selections
+  [context node-xform]
   (let [parsed-query (get context constants/parsed-query-key)
         selection (get context constants/selection-key)
         step (fn step [queue]
@@ -558,7 +554,39 @@
          ;; in what's beneath the selection
          next
          (filter #(= :field (:selection-type %)))
-         (keep to-field-name))))
+         (keep node-xform))))
+
+(defn selections-seq
+  "A width-first traversal of the selections tree, returning a lazy sequence
+  of qualified field names.  A qualified field name is a namespaced keyword,
+  the namespace is the containing type, e.g. :User/name.
+
+  Fragments are flattened (as if always selected)."
+  {:added "0.17.0"}
+  [context]
+  (walk-selections context to-field-name))
+
+(defn ^:private to-field-data
+  [node]
+  (let [{:keys [field alias arguments]} node]
+    (cond-> {:name (to-field-name node)}
+      (not (= field alias)) (assoc :alias alias)
+      (seq arguments) (assoc :args arguments))))
+
+(defn selections-seq2
+  "An enhancement of [[selections-seq]] that returns a map for each node:
+
+  :name
+  : The qualified field name
+
+  :args
+  : The arguments of the field (if any)
+
+  :alias
+  : The alias for the field, if any"
+  {:added "0.34.0"}
+  [context]
+  (walk-selections context to-field-data))
 
 (defn selects-field?
   "Invoked by a field resolver to determine if a particular field is selected anywhere within the selection
@@ -617,7 +645,7 @@
    :alias is the alias for the field (most fields do not have aliases).
 
    A vector is returned because the selection for an outer field may, via aliases, reference
-   the same inner field multiple times (with different arguments and/or sub-selections).
+   the same inner field multiple times (with different arguments, aliases, and/or sub-selections).
 
    Each key of a nested map is present only if a value is provided; for scalar fields with no arguments, the
    nested map will be nil.
@@ -628,4 +656,20 @@
   (let [parsed-query (get context constants/parsed-query-key)
         selection (get context constants/selection-key)]
     (build-selections-map parsed-query (:selections selection))))
+
+(defn parsed-query->context
+  "Converts a parsed query, prior to execution, into a context compatible with preview API:
+
+  * [[selections-tree]]
+  * [[selects-field?]]
+  * [[selections-seq]]
+
+  This is used to preview the execution of the query prior to execution."
+  {:added "0.34.0"}
+  [parsed-query]
+  (let [{:keys [root selections]} parsed-query]
+    {constants/parsed-query-key parsed-query
+     constants/selection-key {:selection-type :field
+                              :field-definition root
+                              :selections selections}}))
 


### PR DESCRIPTION
This makes a couple of enhancements to the preview API.

It fully supports using the preview API before query execution; the preview API then reflects the root operation(s).

A new function to get more useful data out of the selected fields.

Some benchmarks (see `perf`):

selections-tree:  134 µs
selections-tree + walk the tree (based on what eReceipts does): 479 µs
selections-seq: 78 µs
selections-seq2: 236 µs

The upshot is that we can get things done a little faster and without using undocumented/unsupported APIs.