### PR TITLE
Fix an issue where error paths in collections were missing indices

### DIFF
--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -847,7 +847,7 @@
                       (fn [i v]
                         (unwrapper (-> selector-context
                                        (assoc :resolved-value v)
-                                       (update :path conj i))))
+                                       (update-in [:execution-context :path] conj i))))
                       resolved-value))))))
 
     :non-null

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -458,7 +458,15 @@
               :errors [{:message "Non-nullable field was null."
                         :locations [{:line 1
                                      :column 20}]
-                        :path [:hero :friends :arch_enemy]}]}
+                        :path [:hero :friends 0 :arch_enemy]}
+                       {:message "Non-nullable field was null."
+                        :locations [{:line 1
+                                     :column 20}]
+                        :path [:hero :friends 1 :arch_enemy]}
+                       {:message "Non-nullable field was null."
+                        :locations [{:line 1
+                                     :column 20}]
+                        :path [:hero :friends 2 :arch_enemy]}]}
              executed)
           "nulls the first nullable object after a non-nullable field returns null")))
   (testing "nullable list of nullable objects (friends) with nullable selections containing non-nullable field"
@@ -468,7 +476,15 @@
               :errors [{:message "Non-nullable field was null."
                         :locations [{:line 1
                                      :column 34}]
-                        :path [:hero :friends :best_friend :foo]}]}
+                        :path [:hero :friends 0 :best_friend :foo]}
+                       {:message "Non-nullable field was null."
+                        :locations [{:line 1
+                                     :column 34}]
+                        :path [:hero :friends 1 :best_friend :foo]}
+                       {:message "Non-nullable field was null."
+                        :locations [{:line 1
+                                     :column 34}]
+                        :path [:hero :friends 2 :best_friend :foo]}]}
              executed)
           "nulls the first nullable object after a non-nullable field returns null")))
   (testing "non-nullable list of nullable objects (family) with non-nullable selections"
@@ -478,7 +494,15 @@
               :errors [{:message "Non-nullable field was null."
                         :locations [{:line 1
                                      :column 19}]
-                        :path [:hero :family :arch_enemy]}]}
+                        :path [:hero :family 0 :arch_enemy]}
+                       {:message "Non-nullable field was null."
+                        :locations [{:line 1
+                                     :column 19}]
+                        :path [:hero :family 1 :arch_enemy]}
+                       {:message "Non-nullable field was null."
+                        :locations [{:line 1
+                                     :column 19}]
+                        :path [:hero :family 2 :arch_enemy]}]}
              executed)
           "nulls the first nullable object after a non-nullable field returns null"))))
 


### PR DESCRIPTION
When a collection is resolved, and a field resolver of one of its members raises an error, [the spec](https://graphql.github.io/graphql-spec/June2018/#sec-Errors) says that this error _should_ have a key `:path` with an index into that collection.

E.g. in this query:

```GraphQL
query {
  hero {
    friends {
      name
    }
  }
}
```

If the second friend is nil, and name is required, an error with path `[:hero :friends 1 :name]` should be returned. This index is added to the `selector-context`, but should have been added
in the `execution-context` inside this `selector-context`. This caused this error path to inadvertently be `[:hero :friends :name]` (note the missing index).

Please note that this change can potentially add extra errors to the result because this index breaks the uniqueness of the error map. If consumers depend on the exact identity of errors, they could be surprised by this change. However, the change made here brings lacinia closer to the GraphQL specification.