### PR TITLE
Detect when a non-null field is bound to a missing variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 0.35.0 -- UNRELEASED
 
+Lacinia now uses the fully qualified field and argument name as :extension data
+when reporting errors in fields, field arguments, and variables.
 
 ## 0.34.0 -- 16 Aug 2019
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## 0.35.0 -- UNRELEASED
 
-Lacinia now uses the fully qualified field and argument name as :extension data
+Lacinia now uses the fully qualified field and argument name as `:extension` data
 when reporting errors in fields, field arguments, and variables.
 
 ## 0.34.0 -- 16 Aug 2019

--- a/test/com/walmartlabs/input_objects_test.clj
+++ b/test/com/walmartlabs/input_objects_test.clj
@@ -36,8 +36,8 @@
     (is (= {:data {:create_game "nil"}}
            (execute schema "mutation { create_game }")))
 
-    (is (= {:errors [{:extensions {:argument :game_data
-                                   :field :create_game
+    (is (= {:errors [{:extensions {:argument :__Mutations/create_game.game_data
+                                   :field :__Mutations/create_game
                                    :missing-key :id
                                    :required-keys [:id]
                                    :schema-type :game_template}
@@ -48,8 +48,8 @@
 
     ;; TODO: Missing some needed context from above
 
-    (is (= {:errors [{:extensions {:argument :game_data
-                                   :field :create_game
+    (is (= {:errors [{:extensions {:argument :__Mutations/create_game.game_data
+                                   :field :__Mutations/create_game
                                    :missing-key :id
                                    :required-keys [:id]
                                    :schema-type :game_template}
@@ -88,8 +88,8 @@
            (execute schema
                     "{ search(filter: {terms: \"lego\", max_count: 5}) }")))
 
-    (is (= {:errors [{:extensions {:argument :filter
-                                   :field :search
+    (is (= {:errors [{:extensions {:argument :__Queries/search.filter
+                                   :field :__Queries/search
                                    :schema-type :Filter}
                       :locations [{:column 3
                                    :line 1}]
@@ -97,8 +97,8 @@
            (execute schema
                     "{ search(filter: {term: \"lego\", max_count: 5}) }")))
 
-    (is (= {:errors [{:extensions {:argument :filter
-                                   :field :search
+    (is (= {:errors [{:extensions {:argument :__Queries/search.filter
+                                   :field :__Queries/search
                                    :field-name :term
                                    :input-object-fields [:max_count
                                                          :terms]

--- a/test/com/walmartlabs/interface_test.clj
+++ b/test/com/walmartlabs/interface_test.clj
@@ -18,8 +18,7 @@
   (:require
     [clojure.test :refer [deftest is testing]]
     [com.walmartlabs.test-utils :refer [expect-exception]]
-    [com.walmartlabs.lacinia.schema :refer [compile]])
-  (:import (clojure.lang ExceptionInfo)))
+    [com.walmartlabs.lacinia.schema :refer [compile]]))
 
 (def field-not-implemented
   '{:interfaces {:named {:fields {:first_name {:type String}

--- a/test/com/walmartlabs/lacinia/arguments_test.clj
+++ b/test/com/walmartlabs/lacinia/arguments_test.clj
@@ -101,8 +101,8 @@
     (is (= {:data {:echo "Echo: Default"}}
            (execute schema "query($s : String) { echo(input: $s) }" nil nil)))
 
-    (is (= {:errors [{:extensions {:argument :input
-                                   :field :echo
+    (is (= {:errors [{:extensions {:argument :__Queries/echo.input
+                                   :field :__Queries/echo
                                    :variable-name :s}
                       :locations [{:column 23
                                    :line 1}]
@@ -110,7 +110,7 @@
            (execute schema "query($s : String!) { echo(input: $s) }" nil nil)))
 
     (is (= {:errors [{:extensions {:argument :__Queries/echo.input
-                                   :field :echo}
+                                   :field :__Queries/echo}
                       :locations [{:column 22
                                    :line 1}]
                       :message "Argument `s' is required, but no value was provided."}]}

--- a/test/com/walmartlabs/lacinia/custom_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/custom_scalars_test.clj
@@ -97,8 +97,8 @@
                                                            :name "Luke Skywalker"})}}})
               q1 "{ human(id: \"1003\") { id, name }}"
               q2 "{ events { lookup }}"]
-          (is (= {:errors [{:extensions {:argument :id
-                                         :field :human
+          (is (= {:errors [{:extensions {:argument :__Queries/human.id
+                                         :field :__Queries/human
                                          :type-name :EventId
                                          :value "1003"}
                             :locations [{:column 3
@@ -179,8 +179,8 @@
                                                            :name "Luke Skywalker"})}}})
               q1 "{ human(id: \"1003\") { id, name }}"
               q2 "{ events { lookup }}"]
-          (is (= {:errors [{:extensions {:argument :id
-                                         :field :human
+          (is (= {:errors [{:extensions {:argument :__Queries/human.id
+                                         :field :__Queries/human
                                          :type-name :EventId
                                          :value "1003"}
                             :locations [{:column 3
@@ -228,8 +228,8 @@
                     {:asOf "2017-04-05"}
                     nil))
         "should return parsed and serialized value")
-    (is (= {:errors [{:extensions {:argument :asOf
-                                   :field :today
+    (is (= {:errors [{:extensions {:argument :__Queries/today.asOf
+                                   :field :__Queries/today
                                    :type-name :Date
                                    :value "abc"}
                       :locations [{:column 31
@@ -290,8 +290,8 @@
                     {:between []}
                     nil))
         "should return empty list (:between can be an empty list) ")
-    (is (= {:errors [{:extensions {:argument :between
-                                   :field :sundays
+    (is (= {:errors [{:extensions {:argument :__Queries/sundays.between
+                                   :field :__Queries/sundays
                                    :variable-name :between}
                       :locations [{:column 31
                                    :line 2}]
@@ -302,8 +302,8 @@
                     {:between nil}
                     nil))
         "should return an error")
-    (is (= {:errors [{:extensions {:argument :between
-                                   :field :sundays
+    (is (= {:errors [{:extensions {:argument :__Queries/sundays.between
+                                   :field :__Queries/sundays
                                    :variable-name :between}
                       :locations [{:column 31
                                    :line 2}]
@@ -314,8 +314,8 @@
                     {:between [nil]}
                     nil))
         "should return an error")
-    (is (= {:errors [{:extensions {:argument :between
-                                   :field :sundays
+    (is (= {:errors [{:extensions {:argument :__Queries/sundays.between
+                                   :field :__Queries/sundays
                                    :variable-name :between}
                       :locations [{:column 31
                                    :line 2}]
@@ -326,8 +326,8 @@
                     {:between ["2017-03-01" nil]}
                     nil))
         "should return an error")
-    (is (= {:errors [{:extensions {:argument :between
-                                   :field :sundays
+    (is (= {:errors [{:extensions {:argument :__Queries/sundays.between
+                                   :field :__Queries/sundays
                                    :variable-name :between}
                       :locations [{:column 31
                                    :line 2}]
@@ -354,8 +354,8 @@
                       {:words [[["foo" "bar"]]]}
                       nil))
           "should return nested list")
-      (is (= {:errors [{:extensions {:argument :words
-                                     :field :shout
+      (is (= {:errors [{:extensions {:argument :__Queries/shout.words
+                                     :field :__Queries/shout
                                      :variable-name :words}
                         :locations [{:column 31
                                      :line 2}]
@@ -394,8 +394,8 @@
                       {:words [[[nil]]]}
                       nil))
           "should return an error")
-      (is (= {:errors [{:extensions {:argument :words
-                                     :field :shout
+      (is (= {:errors [{:extensions {:argument :__Queries/shout.words
+                                     :field :__Queries/shout
                                      :variable-name :words}
                         :locations [{:column 31
                                      :line 2}]
@@ -422,8 +422,8 @@
                                                     :args {:words {:type '(list (list (list (non-null :CustomType))))}}
                                                     :resolve (fn [ctx args v]
                                                                (:words args))}}})]
-      (is (= {:errors [{:extensions {:argument :words
-                                     :field :shout
+      (is (= {:errors [{:extensions {:argument :__Queries/shout.words
+                                     :field :__Queries/shout
                                      :variable-name :words}
                         :locations [{:column 31
                                      :line 2}]
@@ -434,8 +434,8 @@
                       {:words [[[nil]]]}
                       nil))
           "should return an error")
-      (is (= {:errors [{:extensions {:argument :words
-                                     :field :shout
+      (is (= {:errors [{:extensions {:argument :__Queries/shout.words
+                                     :field :__Queries/shout
                                      :variable-name :words}
                         :locations [{:column 31
                                      :line 2}]
@@ -514,8 +514,8 @@
       (is (= {:errors [{:locations [{:column 3
                                      :line 1}]
                         :message "Exception applying arguments to field `dupe': For argument `in', scalar value is not parsable as type `LimitedInt': Just don't like 5."
-                        :extensions {:argument :in
-                                     :field :dupe
+                        :extensions {:argument :__Queries/dupe.in
+                                     :field :__Queries/dupe
                                      :type-name :LimitedInt
                                      :value 5}}]}
              (execute schema
@@ -550,8 +550,8 @@
                                      {:queries/make-data (fn [_ args _]
                                                            args)
                                       :queries/bad-data (constantly {:value "not-a-number"})})]
-    (is (= {:errors [{:extensions {:argument :value
-                                   :field :make_data
+    (is (= {:errors [{:extensions {:argument :__Queries/make_data.value
+                                   :field :__Queries/make_data
                                    :type-name :Int
                                    :value "get real"}
                       :locations [{:column 3

--- a/test/com/walmartlabs/lacinia/enums_test.clj
+++ b/test/com/walmartlabs/lacinia/enums_test.clj
@@ -53,11 +53,11 @@
     (is (= {:extensions {:allowed-values #{:EMPIRE
                                            :JEDI
                                            :NEWHOPE}
-                         :argument :episode
+                         :argument :__Queries/hero.episode
                          :enum-type :episode
                          :value :CLONES
-                         ;; TODO: This is the location of 'hero', should be location of 'episode' or 'CLONES'.
-                         :field :hero}
+                         :field :__Queries/hero}
+            ;; TODO: This is the location of 'hero', should be location of 'episode' or 'CLONES'.
             :locations [{:column 3
                          :line 1}]
             :message "Exception applying arguments to field `hero': For argument `episode', provided argument value `CLONES' is not member of enum type."}

--- a/test/com/walmartlabs/lacinia/object_scalars_test.clj
+++ b/test/com/walmartlabs/lacinia/object_scalars_test.clj
@@ -73,8 +73,9 @@
                        :order "asc"}))))
 
 (deftest var-nested-in-map-not-allowed
-  (is (= {:errors [{:extensions {:argument :input
-                                 :field :echo}
+  (is (= {:errors [{:extensions {:argument :__Queries/echo.input
+                                 :field :__Queries/echo
+                                 :variable-name :input}
                     :locations [{:column 21
                                  :line 1}]
                     :message "Exception applying arguments to field `echo': Argument `input' contains a scalar argument with nested variables, which is not allowed."}]}

--- a/test/com/walmartlabs/lacinia/scalar_tests.clj
+++ b/test/com/walmartlabs/lacinia/scalar_tests.clj
@@ -52,8 +52,8 @@
          (utils/execute id-schema "{ convert(value: \"r2d2\") }"))))
 
 (deftest non-numeric-id-is-failure
-  (is (= {:errors [{:extensions {:argument :value
-                                 :field :convert
+  (is (= {:errors [{:extensions {:argument :__Queries/convert.value
+                                 :field :__Queries/convert
                                  :type-name :ID
                                  :value 3.41}
                     :locations [{:column 3
@@ -81,8 +81,8 @@
                               :resolve (fn [_ args _]
                                          (:value args))}}}))
 (deftest int-parse-only-numbers
-  (is (= {:errors [{:extensions {:argument :value
-                                 :field :convert
+  (is (= {:errors [{:extensions {:argument :__Queries/convert.value
+                                 :field :__Queries/convert
                                  :type-name :Int
                                  :value 98.6}
                     :locations [{:column 3
@@ -96,8 +96,8 @@
            (utils/execute int-schema (str "{ convert(value: " v ") }"))))))
 
 (deftest int-too-small
-  (is (= {:errors [{:extensions {:argument :value
-                                 :field :convert
+  (is (= {:errors [{:extensions {:argument :__Queries/convert.value
+                                 :field :__Queries/convert
                                  :type-name :Int
                                  :value "-2147483649"}
                     :locations [{:column 3
@@ -106,8 +106,8 @@
          (utils/execute int-schema "{ convert(value: -2147483649) }"))))
 
 (deftest int-too-large
-  (is (= {:errors [{:extensions {:argument :value
-                                 :field :convert
+  (is (= {:errors [{:extensions {:argument :__Queries/convert.value
+                                 :field :__Queries/convert
                                  :type-name :Int
                                  :value "2147483648"}
                     :locations [{:column 3
@@ -209,8 +209,8 @@
                                          (:value args))}}}))
 
 (deftest string-parse-only-string
-  (is (= {:errors [{:extensions {:argument :value
-                                 :field :convert
+  (is (= {:errors [{:extensions {:argument :__Queries/convert.value
+                                 :field :__Queries/convert
                                  :type-name :String
                                  :value 98.6}
                     :locations [{:column 3
@@ -231,8 +231,8 @@
          (utils/execute boolean-schema "{ convert(value: true) }"))))
 
 (deftest boolean-parse-only-boolean
-  (is (= {:errors [{:extensions {:argument :value
-                                 :field :convert
+  (is (= {:errors [{:extensions {:argument :__Queries/convert.value
+                                 :field :__Queries/convert
                                  :type-name :Boolean
                                  :value "sure"}
                     :locations [{:column 3

--- a/test/com/walmartlabs/lacinia/validator_test.clj
+++ b/test/com/walmartlabs/lacinia/validator_test.clj
@@ -272,8 +272,8 @@
 
 (deftest query-argument-validations
     (let [q "{ echoArgs(integer: \"hello world\") { integer } }"]
-      (is (= {:errors [{:extensions {:argument :integer
-                                     :field :echoArgs
+      (is (= {:errors [{:extensions {:argument :__Queries/echoArgs.integer
+                                     :field :__Queries/echoArgs
                                      :type-name :Int
                                      :value "hello world"}
                         :locations [{:column 3
@@ -283,11 +283,10 @@
 
   (testing "undefined argument"
     (let [q "{ echoArgs(undefinedArg: 1) { integer } }"]
-      (is (= {:errors [{:extensions {:argument :undefinedArg
+      (is (= {:errors [{:extensions {:field :__Queries/echoArgs
                                      :defined-arguments [:integer
                                                          :integerArray
-                                                         :inputObject]
-                                     :field :echoArgs}
+                                                         :inputObject]}
                         :locations [{:column 3
                                      :line 1}]
                         :message "Exception applying arguments to field `echoArgs': Unknown argument `undefinedArg'."}]}
@@ -300,8 +299,8 @@
                                       string: \"five\",
                                       nestedInputObject: {integerArray: \"hello world\",
                                                           date: \"1983-08-13\"}}) { integer }}"]
-      (is (= {:errors [{:extensions {:argument :inputObject
-                                     :field :echoArgs
+      (is (= {:errors [{:extensions {:argument :__Queries/echoArgs.inputObject
+                                     :field :__Queries/echoArgs
                                      :type-name :Int
                                      :value "hello world"}
                         :locations [{:column 3
@@ -312,8 +311,8 @@
 
   (testing "invalid array element"
     (let [q "{echoArgs(integer: 3, integerArray: [1, 2, \"foo\"]) { integer }}"]
-      (is (= {:errors [{:extensions {:argument :integerArray
-                                     :field :echoArgs
+      (is (= {:errors [{:extensions {:argument :__Queries/echoArgs.integerArray
+                                     :field :__Queries/echoArgs
                                      :type-name :Int
                                      :value "foo"}
                         :locations [{:column 2
@@ -324,21 +323,21 @@
 
   (testing "Non-nullable arguments"
     (let [q "mutation { addHeroEpisodes(episodes: []) { name appears_in } }"]
-      (is (= {:errors [{:extensions {:field :addHeroEpisodes
+      (is (= {:errors [{:extensions {:field :__Mutations/addHeroEpisodes
                                      :missing-arguments [:id]}
                         :locations [{:column 12
                                      :line 1}]
                         :message "Exception applying arguments to field `addHeroEpisodes': Not all non-nullable arguments have supplied values."}]}
              (execute compiled-schema q nil nil))))
     (let [q "mutation { addHeroEpisodes(id:\"1004\") { name appears_in } }"]
-      (is (= {:errors [{:extensions {:field :addHeroEpisodes
+      (is (= {:errors [{:extensions {:field :__Mutations/addHeroEpisodes
                                      :missing-arguments [:episodes]}
                         :locations [{:column 12
                                      :line 1}]
                         :message "Exception applying arguments to field `addHeroEpisodes': Not all non-nullable arguments have supplied values."}]}
              (execute compiled-schema q nil nil))))
     (let [q "mutation { addHeroEpisodes { name appears_in } }"]
-      (is (= {:errors [{:extensions {:field :addHeroEpisodes
+      (is (= {:errors [{:extensions {:field :__Mutations/addHeroEpisodes
                                      :missing-arguments [:episodes :id]}
                         :locations [{:column 12
                                      :line 1}]

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -234,9 +234,9 @@
            (execute default-schema q {:someId luke-id} nil)))
     (is (= {:data {:human {:name "Han Solo"}}}
            (execute default-schema q {:someId han-id} nil)))
-    (is (= {:errors [{:extensions {:argument :id
+    (is (= {:errors [{:extensions {:argument :__Queries/human.id
                                    :variable-name :someId
-                                   :field :human}
+                                   :field :__Queries/human}
                       :locations [{:column 14
                                    :line 2}]
                       :message "No value was provided for variable `someId', which is non-nullable."}]}


### PR DESCRIPTION
This was missed, allowing the nil to pass through the argument,
and cause NPEs inside resolver code.

As a drive by, I changed some of the exceptions to include fully qualified field and argument names (i.e., "Queries/get_movie.id" rather than just "id").