### PR TITLE
Update documentation now the repo is moved, and mention the generator…

### DIFF
--- a/docs/samples.rst
+++ b/docs/samples.rst
@@ -13,14 +13,16 @@ Sample Projects
   Built on top of Compojure and PostgreSQL.
   See `this blog post <https://jborden.github.io/2017/05/15/using-lacinia>`_ by the author.
 
-`open-bank-mark <https://github.com/openweb-nl/open-bank-mark>`_
+`open-bank-mark <https://github.com/openweb-nl/kafka-graphql-examples>`_
   This project consists of multiple components creating a bank simulation.
 
-  The `graphql-endpoint <https://github.com/openweb-nl/open-bank-mark/tree/master/graphql-endpoint>`_
+  The `graphql-endpoint <https://github.com/openweb-nl/kafka-graphql-examples/tree/master/graphql-endpoint>`_
   component consists of three services that all consume from Kafka.
   It's mainly working with subscriptions where a command is put to Kafka and the result is returned.
-  It is also possible to query for or subscribe to transactions.
+  It is also possible to query transactions, using a derived view.
   PostgreSQL is used to store user accounts for logging in, and to store all the transactions.
+  The `test module <https://github.com/openweb-nl/kafka-graphql-examples/blob/master/test/src/nl/openweb/test/generator.clj>`_
+  Contains a generator to load test the subscriptions and can be used as inspiration to do similar testing.
 
   Also part of the project is a `frontend <https://github.com/openweb-nl/open-bank-mark/tree/master/frontend>`_
   using `re-graph <https://github.com/oliyh/re-graph>`_.


### PR DESCRIPTION
… to test subscriptions.

In preparation for GraphQL summit I cleaned up the code, and removed some parts that where only used for doing the tests. Current setup is more focused on the graphql endpoint, and is stressing the endpoint directly for the load test.