### PR TITLE
"Undefined enum value" errors return selector errors instead of throwing

### DIFF
--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -711,10 +711,10 @@
                          :let [serialized (serializer resolved-value)]
 
                          (not (possible-values serialized))
-                         (throw (ex-info "Field resolver returned an undefined enum value."
-                                         {:resolved-value resolved-value
-                                          :serialized-value serialized
-                                          :enum-values possible-values}))
+                         (selector-error selector-context (error "Field resolver returned an undefined enum value."
+                                                                 {:resolved-value resolved-value
+                                                                  :serialized-value serialized
+                                                                  :enum-values possible-values}))
 
                          :else
                          (selector (assoc selector-context :resolved-value serialized)))))

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -660,7 +660,7 @@
 
         selector (if (= :scalar category)
                    (let [serializer (:serialize field-type)]
-                     (fn select-coerion [selector-context]
+                     (fn select-coercion [selector-context]
                        (cond-let
 
                          :let [{:keys [resolved-value]} selector-context]

--- a/test/com/walmartlabs/lacinia/enums_test.clj
+++ b/test/com/walmartlabs/lacinia/enums_test.clj
@@ -84,13 +84,15 @@
 (deftest resolver-must-return-defined-enum
   (let [schema (utils/compile-schema "bad-resolver-enum.edn"
                                      {:query/current-status (constantly :ok)})]
-    (expect-exception
-      "Field resolver returned an undefined enum value."
-      {:enum-values #{:bad
-                      :good}
-       :resolved-value :ok
-       :serialized-value :ok}
-      (utils/execute schema "{ current_status }"))))
+    (is (= {:data   {:current_status nil}
+            :errors [{:locations  [{:column 3 :line 1}]
+                      :message    "Field resolver returned an undefined enum value."
+                      :path       [:current_status]
+                      :extensions {:enum-values      #{:bad
+                                                       :good}
+                                   :resolved-value   :ok
+                                   :serialized-value :ok}}]}
+           (utils/execute schema "{ current_status }")))))
 
 (deftest enum-resolver-must-return-named-value
   (let [bad-value (Date.)
@@ -189,10 +191,14 @@
                                 nil)
                utils/simplify)))
 
-    (expect-exception
-      "Field resolver returned an undefined enum value."
-      {:enum-values #{:bad
-                      :good}
-       :resolved-value :not/found
-       :serialized-value :indifferent}
-      (utils/execute schema "{ fail { output } }"))))
+    (is (= {:data   {:fail {:output nil}}
+            :errors [{:extensions {:enum-values      #{:bad
+                                                       :good}
+                                   :resolved-value   :not/found
+                                   :serialized-value :indifferent}
+                      :locations  [{:column 10
+                                    :line   1}]
+                      :message    "Field resolver returned an undefined enum value."
+                      :path       [:fail
+                                   :output]}]}
+           (utils/execute schema "{ fail { output } }")))))


### PR DESCRIPTION
# Current behavior:
After running a resolver, if we validate an enum field and find an invalid value, we throw an exception.

This seems sensible on the surface. However, if this happens while running an asynchronous resolver, the exception is throw in the secondary thread, after it `deliver!`s the promise. At that point, we cannot do anything with this error: the promise has already been delivered, so we cannot deliver a `(with-error ...)` value.

The result is that the secondary thread swallows the exception, and the main thread hangs forever, because we never finished handling the callback.

# Solution
When we find an undefined enum value, we return a `selector-error` instead of throwing an exception, just like we do when we have a coercion failure, for example.