### PR TITLE
support spreading fragments on root query

### DIFF
--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -344,7 +344,7 @@
           (apply-errors selection-context :errors :*errors)
           (apply-errors selection-context :warnings :*warnings)
 
-          (if (and (some? resolved-value)
+          (if (and (or (= [] (:path execution-context)) (some? resolved-value))
                    resolved-type
                    (seq sub-selections))
             (execute-nested-selections

--- a/src/com/walmartlabs/lacinia/validation/no_unused_fragments.clj
+++ b/src/com/walmartlabs/lacinia/validation/no_unused_fragments.clj
@@ -47,7 +47,7 @@
                                     {f-name location})
                                   fragments))
         f-definitions (set (keys fragments))
-        f-names-used (all-fragments-used fragments selections)]
+        f-names-used (all-fragments-used fragments [{:selections selections}])]
     (for [unused-f-definition (set/difference f-definitions f-names-used)]
       {:message (format "Fragment %s is never used."
                         (q unused-f-definition))

--- a/test/com/walmartlabs/lacinia/fragments_tests.clj
+++ b/test/com/walmartlabs/lacinia/fragments_tests.clj
@@ -43,6 +43,20 @@
            }
            }"))))
 
+(deftest query-root-fragment
+  (is (= {:data {:characters [{:name "R2-D2"
+                               :power "AC"}
+                              {:name "Luke"
+                               :home_world "Tatooine"}]}}
+         (q "{ ... on QueryRoot {
+           characters {
+           name
+           ... on droid { power }
+           ... on human { home_world }
+           }
+           }
+           }"))))
+
 (deftest named-fragments
   (is (= {:data {:characters [{:name "R2-D2"
                                :power "AC"}


### PR DESCRIPTION
as described in a few places including here:
https://github.com/facebook/relay/issues/1937#issuecomment-324780567

I was getting the error message "Fragment Viewer_root is never used." when sending a query like the following to Lacinia:

```
query {
  ...Viewer_root
}

fragment Viewer_root on QueryRoot {
  viewer {
    id
    username
  }
}
```