### PR TITLE
Update schema support: input value defaults and input extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## 0.37.0 -- UNRELEASED
 
+The schema parser has been updated, to allow input values (within input types)
+to specify defaults, and to support extending input types.
+
 [Closed Issues](https://github.com/walmartlabs/lacinia/milestone/25?closed=1)
 
 ## 0.36.0 -- 13 Feb 2020

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  "vendor-src"]
   :profiles {:dev {:dependencies [[criterium "0.4.5"]
                                   [expound "0.8.4"]
-                                  [joda-time "2.10.5"]
+                                  [joda-time "2.10.6"]
                                   [com.walmartlabs/test-reporting "0.1.0"]
                                   [io.aviso/logging "0.3.2"]
                                   [io.pedestal/pedestal.log "0.5.5"]

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -86,7 +86,15 @@ implementationDef
   ;
 
 inputTypeDef
-  : description? K_INPUT anyName directiveList? fieldDefs?
+  : description? K_INPUT anyName directiveList? inputValueDefs?
+  ;
+
+inputValueDefs
+  : '{' inputValueDef+ '}'
+  ;
+
+inputValueDef
+  : description? anyName ':' typeSpec defaultValue? directiveList?
   ;
 
 interfaceDef

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -1,7 +1,7 @@
 grammar GraphqlSchema;
 
 graphqlSchema
-  : (schemaDef|typeDef|typeExtDef|inputTypeDef|unionDef|enumDef|interfaceDef|scalarDef|directiveDef)*
+  : (schemaDef|typeDef|typeExtDef|inputTypeDef|inputTypeExtDef|unionDef|enumDef|interfaceDef|scalarDef|directiveDef)*
   ;
 
 description
@@ -87,6 +87,10 @@ implementationDef
 
 inputTypeDef
   : description? K_INPUT anyName directiveList? inputValueDefs?
+  ;
+
+inputTypeExtDef
+  : description? K_EXTEND K_INPUT anyName directiveList? inputValueDefs?
   ;
 
 inputValueDefs

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -265,10 +265,8 @@
            {:Ebb
             {:directives [{:directive-type :InputObject}]
              :fields {:flow {:type String
-                             :args {:direction {:directives [{:directive-type :Arg}]
-                                                :type String}}
                              :directives [{:directive-type :Field}]}}}}}
-         (parse-string "input Ebb @InputObject { flow(direction : String @Arg) : String @Field }"))))
+         (parse-string "input Ebb @InputObject { flow : String @Field }"))))
 
 (deftest object-directives
   (is (= '{:objects
@@ -329,6 +327,23 @@
 	weight: Int!
 	category: String  = \"feline\"
 }"))))
+
+(deftest extend-input-object
+  (is (= '{:input-objects
+           {:Animal
+            {:fields
+             {:name {:type (non-null String)}
+              :weight {:type (non-null Int)}
+              :category {:type String :default-value "feline"}}}}}
+         (parse-string "input Animal {
+	  name: String!
+	  weight: Int!
+	}
+
+	extend input Animal {
+	  category: String  = \"feline\"
+  }"))))
+
 
 (deftest schema-directives
   (is (= {:roots {:query :Query}

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -53,15 +53,15 @@
 
 (def ^:private streamer-map {:Subscription {:new_character new-character}})
 
-(defn ^:private parse-schema [path options]
+(defn ^:private parse-schema [path attach]
   (-> path
       resource
       slurp
-      (parser/parse-schema options)))
+      (parser/parse-schema attach)))
 
 (defn ^:private parse-string
   [s]
-  (parser/parse-schema s {}))
+  (parser/parse-schema s))
 
 ;; Warm up with some very targeted parser tests
 ;; (these are invaluable after any large changes to the grammar).
@@ -316,6 +316,19 @@
                                     :default-value 10
                                     :directives [{:directive-type :Flow}]}}}}}}}
          (parse-string "type Ebb { flow(direction: String @Trace, level : Int = 10 @Flow) : String }"))))
+
+(deftest input-object-field-with-default-value
+  (is (= '{:input-objects
+           {:Animal
+            {:fields
+             {:name {:type (non-null String)}
+              :weight {:type (non-null Int)}
+              :category {:type String :default-value "feline"}}}}}
+         (parse-string "input Animal {
+	name: String!
+	weight: Int!
+	category: String  = \"feline\"
+}"))))
 
 (deftest schema-directives
   (is (= {:roots {:query :Query}


### PR DESCRIPTION
Previously, when parsing the input type from a schema, it was not possible to specify a default value for an input value; the grammar and parser have been extended to support this.

In addition, support for `extend input` has been added.