### PR TITLE
Improve exceptions by identifying field and other data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@ to `com.walmartlabs.lacinia.parser.schema/parse-schema` which is now deprecated.
 The schema parser has been updated, to allow input values (within input types)
 to specify defaults, and to support extending input types.
 
+Exceptions thrown by resolver functions are now caught and wrapped as new exceptions
+that identify the field, query location and path, and field arguments.
+This also applies to exceptions thrown when processing the result, such as an invalid
+enum value returned from a resolver function.
+
 [Closed Issues](https://github.com/walmartlabs/lacinia/milestone/25?closed=1)
 
 ## 0.36.0 -- 13 Feb 2020

--- a/dev-resources/field-resolver-errors.edn
+++ b/dev-resources/field-resolver-errors.edn
@@ -1,10 +1,14 @@
-{:objects
+{:enums
+ {:Color {:values [RED GREEN BLUE]}}
+ :objects
  {:MyObject
   {:fields
    {:error_field
     {:type String
      :resolve :single-error}
 
+    :color {:type :Color
+            :resolve :color}
     :exception
     {:type String
      :args

--- a/docs/resolve/async.rst
+++ b/docs/resolve/async.rst
@@ -16,7 +16,7 @@ Instead of returning a normal value, an asynchronous field resolver
 returns a special kind of :doc:`ResolverResult <resolve-as>`, a
 ``ResolverResultPromise``.
 
-Such a promise is created by the :api:`resolve/resolve-promise function.
+Such a promise is created by the :api:`resolve/resolve-promise` function.
 
 The field resolver function returns immediately, but will typically perform some work in a background
 thread.

--- a/docs/resolve/exceptions.rst
+++ b/docs/resolve/exceptions.rst
@@ -3,11 +3,15 @@ Exceptions
 
 Field resolvers are responsible for catching any exceptions that occur.
 
-Uncaught exceptions will bubble up out of Lacinia code entirely.
+Uncaught exceptions are *not* converted to errors; they are caught, wrapped in a new
+exception to identify the field name, field arguments, query path, and query location, but
+then allowed to bubble up out of Lacinia entirely.
 
 This is not desirable: better to return a partial result along with errors.
 
 Field resolvers should catch exceptions and use :doc:`ResolverResults <resolve-as>`
 to communicate errors back to Lacinia for inclusion in the ``:errors`` key of the result.
 
-Failure to catch exceptions is even more damaging when using :doc:`async field resolvers <async>`.
+Failure to catch exceptions is even more damaging when using :doc:`async field resolvers <async>`,
+as this can cause query execution to entirely halt, due to resolver result promises never being
+delivered.

--- a/test/com/walmartlabs/lacinia/enums_test.clj
+++ b/test/com/walmartlabs/lacinia/enums_test.clj
@@ -24,9 +24,7 @@
     [clojure.java.io :as io]
     [clojure.edn :as edn]
     [com.walmartlabs.lacinia.util :as util]
-    [com.walmartlabs.lacinia :as lacinia])
-  (:import
-    (java.util Date)))
+    [com.walmartlabs.lacinia :as lacinia]))
 
 (def compiled-schema (schema/compile test-schema {:default-field-resolver schema/hyphenating-default-field-resolver}))
 
@@ -93,15 +91,6 @@
                                    :resolved-value   :ok
                                    :serialized-value :ok}}]}
            (utils/execute schema "{ current_status }")))))
-
-(deftest enum-resolver-must-return-named-value
-  (let [bad-value (Date.)
-        schema (utils/compile-schema "bad-resolver-enum.edn"
-                                     {:query/current-status (constantly bad-value)})]
-    (expect-exception
-      "Can't convert value to keyword."
-      {:value bad-value}
-      (utils/execute schema "{ current_status }"))))
 
 (deftest will-convert-to-keyword
   (let [schema (utils/compile-schema "bad-resolver-enum.edn"

--- a/test/com/walmartlabs/lacinia/enums_test.clj
+++ b/test/com/walmartlabs/lacinia/enums_test.clj
@@ -1,36 +1,36 @@
-; Copyright (c) 2017-present Walmart, Inc.
-;
-; Licensed under the Apache License, Version 2.0 (the "License")
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
+;; Copyright (c) 2017-present Walmart, Inc.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License")
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 
 (ns com.walmartlabs.lacinia.enums-test
   (:require
-    [clojure.test :refer [deftest is]]
-    [com.walmartlabs.test-schema :refer [test-schema]]
-    [com.walmartlabs.lacinia :refer [execute]]
-    [com.walmartlabs.lacinia.schema :as schema]
-    [com.walmartlabs.test-reporting :refer [reporting]]
-    [com.walmartlabs.test-utils :as utils :refer [expect-exception]]
-    [clojure.set :as set]
-    [clojure.java.io :as io]
-    [clojure.edn :as edn]
-    [com.walmartlabs.lacinia.util :as util]
-    [com.walmartlabs.lacinia :as lacinia]))
+   [clojure.test :refer [deftest is]]
+   [com.walmartlabs.test-schema :refer [test-schema]]
+   [com.walmartlabs.lacinia :refer [execute]]
+   [com.walmartlabs.lacinia.schema :as schema]
+   [com.walmartlabs.test-reporting :refer [reporting]]
+   [com.walmartlabs.test-utils :as utils :refer [expect-exception]]
+   [clojure.set :as set]
+   [clojure.java.io :as io]
+   [clojure.edn :as edn]
+   [com.walmartlabs.lacinia.util :as util]
+   [com.walmartlabs.lacinia :as lacinia]))
 
 (def compiled-schema (schema/compile test-schema {:default-field-resolver schema/hyphenating-default-field-resolver}))
 
 (defn q
   ([query]
-    (q query nil))
+   (q query nil))
   ([query vars]
    (utils/simplify (execute compiled-schema query vars nil))))
 
@@ -45,7 +45,7 @@
   (let [result (q "{ hero(episode: NEWHOPE) { name }}")
         hero-name (-> result :data :hero :name)]
     (reporting result
-      (is (= "Luke Skywalker" hero-name)))))
+               (is (= "Luke Skywalker" hero-name)))))
 
 (deftest handling-of-invalid-enum-value
   (let [result (q "{ hero (episode: CLONES) { name }}")
@@ -68,11 +68,11 @@
 
 (deftest enum-values-must-be-unique
   (expect-exception
-    "Values defined for enum `invalid' must be unique."
-    {:enum {:values [:yes 'yes "yes"]
-            :category :enum
-            :type-name :invalid}}
-    (schema/compile {:enums {:invalid {:values [:yes 'yes "yes"]}}})))
+   "Values defined for enum `invalid' must be unique."
+   {:enum {:values [:yes 'yes "yes"]
+           :category :enum
+           :type-name :invalid}}
+   (schema/compile {:enums {:invalid {:values [:yes 'yes "yes"]}}})))
 
 (deftest converts-var-value-from-string-to-enum
   (is (= {:data {:hero {:name "Luke Skywalker"}}}
@@ -172,12 +172,12 @@
 
     (is (= {:data {:echo {:input ":fu/bar"
                           :output :bad}}}
-           (-> (lacinia/execute schema
-                                "query ($in : status) {
+           (-> (execute schema
+                        "query ($in : status) {
                                   echo(in: $in) { input output }
                                 }"
-                                {:in "bad"}
-                                nil)
+                        {:in "bad"}
+                        nil)
                utils/simplify)))
 
     (is (= {:data   {:fail {:output nil}}

--- a/test/com/walmartlabs/lacinia/resolver_errors_test.clj
+++ b/test/com/walmartlabs/lacinia/resolver_errors_test.clj
@@ -1,24 +1,24 @@
-; Copyright (c) 2017-present Walmart, Inc.
-;
-; Licensed under the Apache License, Version 2.0 (the "License")
-; you may not use this file except in compliance with the License.
-; You may obtain a copy of the License at
-;
-;     http://www.apache.org/licenses/LICENSE-2.0
-;
-; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS,
-; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; See the License for the specific language governing permissions and
-; limitations under the License.
+;; Copyright (c) 2017-present Walmart, Inc.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License")
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
 
 (ns com.walmartlabs.lacinia.resolver-errors-test
   "Tests for errors and exceptions inside field resolvers, and for the exception converter."
   (:require
-    [clojure.test :refer [deftest is testing]]
-    [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
-    [com.walmartlabs.test-utils :refer [execute] :as utils]
-    [com.walmartlabs.lacinia.schema :as schema])
+   [clojure.test :refer [deftest is testing]]
+   [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
+   [com.walmartlabs.test-utils :refer [execute] :as utils]
+   [com.walmartlabs.lacinia.schema :as schema])
   (:import (clojure.lang ExceptionInfo)
            (java.awt Color)))
 
@@ -139,8 +139,8 @@
                                              :contents {:type '(list :item)
                                                         :resolve (fn [ctx args v]
                                                                    (resolve-as
-                                                                     (:contents v)
-                                                                     [{:message "Some error"}]))}}}}
+                                                                    (:contents v)
+                                                                    [{:message "Some error"}]))}}}}
                                   :queries
                                   {:container {:type :container
                                                :args {:id {:type 'String}}


### PR DESCRIPTION
This PR ensures that uncaught exceptions thrown by resolver functions, or by code immediately after (such as field serializers, etc.) are caught and re-wrapped with more information (the qualified field name, the query location and path, the field arguments, and so forth).