### PR TITLE
Allow ResolverResult mixed with raw values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ that identify the field, query location and path, and field arguments.
 This also applies to exceptions thrown when processing the result, such as an invalid
 enum value returned from a resolver function.
 
+Resolver functions can now return maps whose values are themselves ResolverResults.
+This can, in some cases, be easier that coordinating a parent resolver and a nested resolver.
+
 [Closed Issues](https://github.com/walmartlabs/lacinia/milestone/25?closed=1)
 
 ## 0.36.0 -- 13 Feb 2020

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ This also applies to exceptions thrown when processing the result, such as an in
 enum value returned from a resolver function.
 
 Resolver functions can now return maps whose values are themselves ResolverResults.
-This can, in some cases, be easier thaN coordinating a parent resolver and a nested resolver.
+This can, in some cases, be easier than coordinating a parent resolver and a nested resolver.
 
 [Closed Issues](https://github.com/walmartlabs/lacinia/milestone/25?closed=1)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ This also applies to exceptions thrown when processing the result, such as an in
 enum value returned from a resolver function.
 
 Resolver functions can now return maps whose values are themselves ResolverResults.
-This can, in some cases, be easier that coordinating a parent resolver and a nested resolver.
+This can, in some cases, be easier thaN coordinating a parent resolver and a nested resolver.
 
 [Closed Issues](https://github.com/walmartlabs/lacinia/milestone/25?closed=1)
 

--- a/docs/resolve/resolve-as.rst
+++ b/docs/resolve/resolve-as.rst
@@ -81,3 +81,28 @@ This places the type tag on the function, not on the symbol (as normally happens
 
 It doesn't matter whether the function invokes ``resolve-as`` or ``resolve-promise``, but returning
 nil or a bare value from a field resolver tagged with ResolverResult will cause runtime exceptions, so be careful.
+
+Default Resolvers
+-----------------
+
+When a field does not have an explicit resolver in the schema, a default resolver is provided by Lacinia
+(this is just one of the many operations that occur when compiling a schema);
+ultimately, every field has a resolver, but the vast majority are these default resolvers.
+
+The resolver  maps the field name directly to a map key; a field named ``user_name`` will default to a keyword key, ``:user_name``.
+
+Nested Resolver Results
+-----------------------
+
+Normally, a field resolver for a non-scalar field returns a map; the map is recusively selected by any nested fields
+(a field with a list type will return a seq of raw values).
+
+It is allowed that nested values are themselves ResolverResult instances; this is an alternative to defining resolvers
+for the nested fields, and only really makes sense for a ResolverResultPromise (an asynchronous result).
+
+This has an advantages: there's no need to define additional resolvers, and in some cases, no need to pass extra state
+in the context needed by the nested resolvers.
+
+The disadvantage is that the field in question may not be selected in the query and the asynchronous work being performed
+will simply be discarded.
+

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -132,8 +132,7 @@
                             :com.walmartlabs.lacinia/container-type-name resolved-type
                             constants/selection-key field-selection)
           field-resolver (field-selection-resolver schema field-selection resolved-type container-value)
-          start-ms (when (and (some? *timings)
-                              (not (-> field-resolver meta ::schema/default-resolver?)))
+          start-ms (when (some? *timings)
                      (System/currentTimeMillis))
           resolver-result (field-resolver resolve-context arguments container-value)]
       ;; If not collecting timing results, then the resolver-result is all we need.

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -15,16 +15,16 @@
 (ns com.walmartlabs.lacinia.executor
   "Mechanisms for executing parsed queries against compiled schemas."
   (:require
-   [com.walmartlabs.lacinia.internal-utils
-    :refer [cond-let map-vals remove-vals q aggregate-results transform-result to-message]]
-   [flatland.ordered.map :refer [ordered-map]]
-   [com.walmartlabs.lacinia.schema :as schema]
-   [com.walmartlabs.lacinia.resolve :as resolve
-    :refer [resolve-as resolve-promise]]
-   [com.walmartlabs.lacinia.selector-context :as sc]
-   [com.walmartlabs.lacinia.constants :as constants])
+    [com.walmartlabs.lacinia.internal-utils
+     :refer [cond-let map-vals remove-vals q aggregate-results transform-result to-message]]
+    [flatland.ordered.map :refer [ordered-map]]
+    [com.walmartlabs.lacinia.schema :as schema]
+    [com.walmartlabs.lacinia.resolve :as resolve
+     :refer [resolve-as resolve-promise]]
+    [com.walmartlabs.lacinia.selector-context :as sc]
+    [com.walmartlabs.lacinia.constants :as constants])
   (:import
-   (clojure.lang PersistentQueue)))
+    (clojure.lang PersistentQueue)))
 
 (defn ^:private ex-info-map
   [field-selection execution-context]
@@ -68,7 +68,7 @@
     (cond-> {:message message
              :locations locations
              :path path}
-      (seq extensions') (assoc :extensions extensions'))))
+            (seq extensions') (assoc :extensions extensions'))))
 
 (defn ^:private enhance-errors
   "From an error map, or a collection of error maps, add additional data to
@@ -90,27 +90,27 @@
   field of the concrete type is used as the source for the field resolver."
   [schema field-selection resolved-type value]
   (cond-let
-   (:concrete-type? field-selection)
-   (-> field-selection :field-definition :resolve)
+    (:concrete-type? field-selection)
+    (-> field-selection :field-definition :resolve)
 
-   :let [{:keys [field]} field-selection]
+    :let [{:keys [field]} field-selection]
 
-   (nil? resolved-type)
-   (throw (ex-info "Sanity check: value type tag is nil on abstract type."
-                   {:value value}))
+    (nil? resolved-type)
+    (throw (ex-info "Sanity check: value type tag is nil on abstract type."
+                    {:value value}))
 
-   :let [type (get schema resolved-type)]
+    :let [type (get schema resolved-type)]
 
-   (nil? type)
-   (throw (ex-info "Sanity check: invalid type tag on value."
-                   {:type-name resolved-type
-                    :value value}))
+    (nil? type)
+    (throw (ex-info "Sanity check: invalid type tag on value."
+                    {:type-name resolved-type
+                     :value value}))
 
-   :else
-   (or (get-in type [:fields field :resolve])
-       (throw (ex-info "Sanity check: field not present."
-                       {:type resolved-type
-                        :value value})))))
+    :else
+    (or (get-in type [:fields field :resolve])
+        (throw (ex-info "Sanity check: field not present."
+                        {:type resolved-type
+                         :value value})))))
 
 (defn ^:private invoke-resolver-for-field
   "Resolves the value for a field selection node.
@@ -129,8 +129,8 @@
           schema (get context constants/schema-key)
           resolved-type (:resolved-type execution-context)
           resolve-context (assoc context
-                                 :com.walmartlabs.lacinia/container-type-name resolved-type
-                                 constants/selection-key field-selection)
+                            :com.walmartlabs.lacinia/container-type-name resolved-type
+                            constants/selection-key field-selection)
           field-resolver (field-selection-resolver schema field-selection resolved-type container-value)
           start-ms (when (and (some? *timings)
                               (not (-> field-resolver meta ::schema/default-resolver?)))
@@ -170,16 +170,16 @@
 (declare ^:private resolve-and-select)
 
 (defrecord ExecutionContext
-    ;; context, resolved-value, and resolved-type change constantly during the process
-    ;; *errors is an Atom containing a vector, which accumulates
-    ;; error-maps during execution.
-    ;; *warnings is an Atom containing a vector of warnings (error maps that
-    ;; appear in the result as [:extensions :warnings].
-    ;; *timings is usually nil, or may be an Atom containing an empty map, which
-    ;; *extensions is an atom containing a map, if non-empty, it is added to the result map as :extensions
-    ;; accumulates timing data during execution.
-    ;; path is used when reporting errors
-    [context resolved-value resolved-type *errors *warnings *extensions *timings path])
+  ;; context, resolved-value, and resolved-type change constantly during the process
+  ;; *errors is an Atom containing a vector, which accumulates
+  ;; error-maps during execution.
+  ;; *warnings is an Atom containing a vector of warnings (error maps that
+  ;; appear in the result as [:extensions :warnings].
+  ;; *timings is usually nil, or may be an Atom containing an empty map, which
+  ;; *extensions is an atom containing a map, if non-empty, it is added to the result map as :extensions
+  ;; accumulates timing data during execution.
+  ;; path is used when reporting errors
+  [context resolved-value resolved-type *errors *warnings *extensions *timings path])
 
 (defn ^:private null-to-nil
   [v]
@@ -263,7 +263,7 @@
     (maybe-apply-fragment execution-context
                           ;; A bit of a hack:
                           (assoc fragment-spread-selection
-                                 :selections (:selections fragment-def))
+                            :selections (:selections fragment-def))
                           (:concrete-types fragment-def))))
 
 (defn ^:private apply-selection
@@ -367,10 +367,10 @@
                    resolved-type
                    (seq sub-selections))
             (execute-nested-selections
-             (assoc execution-context
-                    :resolved-value resolved-value
-                    :resolved-type resolved-type)
-             sub-selections)
+              (assoc execution-context
+                :resolved-value resolved-value
+                :resolved-type resolved-type)
+              sub-selections)
             (resolve-as resolved-value)))
         ;; In a concrete type, we know the selector from the field definition
         ;; (a field definition on a concrete object type).  Otherwise, we need
@@ -423,7 +423,18 @@
                                                           :arguments arguments
                                                           :location location} t)))))))
 
-        direct-fn (-> selection :field-definition :direct-fn)]
+        direct-fn (-> selection :field-definition :direct-fn)
+
+        ;; Given a ResolverResult from a field resolver, unwrap the field's RR and pass it through process-resolved-value.
+        ;; process-resolved-value also returns an RR and chain that RR's delivered value to the RR returned from this function.
+        unwrap-resolver-result (fn [field-resolver-result]
+                                 (let [final-result (resolve-promise)]
+                                   (resolve/on-deliver! field-resolver-result
+                                                        (fn receive-resolved-value-from-field [resolved-value]
+                                                          (resolve/on-deliver! (process-resolved-value resolved-value)
+                                                                               (fn deliver-selection-for-field [resolved-value]
+                                                                                 (resolve/deliver! final-result resolved-value)))))
+                                   final-result))]
 
     ;; For fragments, we start with a single value and it passes right through to
     ;; sub-selections, without changing value or type.
@@ -441,10 +452,14 @@
       ;; the selector, which returns a ResolverResult. Thus we've peeled back at least one layer
       ;; of ResolveResultPromise.
       direct-fn
-      (-> execution-context'
-          :resolved-value
-          direct-fn
-          process-resolved-value)
+      (let [resolved-value (-> execution-context'
+                               :resolved-value
+                               direct-fn)]
+        ;; Normally, resolved-value is a raw value, ready to be immediately processed; but in rare cases
+        ;; it may be a ResolverResult that needs to full job.
+        (if (resolve/is-resolver-result? resolved-value)
+          (unwrap-resolver-result resolved-value)
+          (process-resolved-value resolved-value)))
 
       ;; Here's where it comes together.  The field's selector
       ;; does the validations, and for list types, does the mapping.
@@ -454,13 +469,7 @@
       ;; The result is a scalar value, a map, or a list of maps or scalar values.
 
       :else
-      (let [final-result (resolve-promise)]
-        (resolve/on-deliver! (invoke-resolver-for-field execution-context' selection)
-                             (fn receive-resolved-value-from-field [resolved-value]
-                               (resolve/on-deliver! (process-resolved-value resolved-value)
-                                                    (fn deliver-selection-for-field [resolved-value]
-                                                      (resolve/deliver! final-result resolved-value)))))
-        final-result))))
+      (unwrap-resolver-result (invoke-resolver-for-field execution-context' selection)))))
 
 (defn execute-query
   "Entrypoint for execution of a query.
@@ -480,7 +489,7 @@
         *timings (when (:com.walmartlabs.lacinia/enable-timing? context)
                    (atom []))
         context' (assoc context constants/schema-key
-                        (get parsed-query constants/schema-key))
+                                (get parsed-query constants/schema-key))
         ;; Outside of subscriptions, the ::resolved-value is nil.
         ;; For subscriptions, the :resolved-value will be set to a non-nil value before
         ;; executing the query.
@@ -507,10 +516,10 @@
                                                extensions @*extensions]
                                            (resolve/deliver! result-promise
                                                              (cond-> {:data data}
-                                                               (seq extensions) (assoc :extensions extensions)
-                                                               *timings (assoc-in [:extensions :timings] @*timings)
-                                                               errors (assoc :errors (distinct errors))
-                                                               warnings (assoc-in [:extensions :warnings] (distinct warnings)))))))))
+                                                                     (seq extensions) (assoc :extensions extensions)
+                                                                     *timings (assoc-in [:extensions :timings] @*timings)
+                                                                     errors (assoc :errors (distinct errors))
+                                                                     warnings (assoc-in [:extensions :warnings] (distinct warnings)))))))))
               (catch Throwable t
                 (resolve/deliver! result-promise t))))]
 
@@ -590,8 +599,8 @@
   [node]
   (let [{:keys [field alias arguments]} node]
     (cond-> {:name (to-field-name node)}
-      (not (= field alias)) (assoc :alias alias)
-      (seq arguments) (assoc :args arguments))))
+            (not (= field alias)) (assoc :alias alias)
+            (seq arguments) (assoc :args arguments))))
 
 (defn selections-seq2
   "An enhancement of [[selections-seq]] that returns a map for each node:


### PR DESCRIPTION
Prior to this PR, a field resolver that returns a map whose values included a ResolverResult (normally, a ResolverResultPromise) would operate incorrectly. An optimization in Lacinia for fields with a default field resolver would cause Lacinia  to ignore the fact that the nested value was an RR and just attempt to convert it to an output value; So the `str` of the ResolverResult if the field type was String, or an exception if the field type was numeric, etc.

This change tests the actual value returned by the field's default field resolver and ensures that it is unwrapped and otherwise processed the same.