### PR TITLE
Use possible enum serialisation in introspection of default value

### DIFF
--- a/dev-resources/enum-default-value-with-transformer-schema.edn
+++ b/dev-resources/enum-default-value-with-transformer-schema.edn
@@ -1,0 +1,14 @@
+{:objects
+ {:Country
+  {:fields
+   {:code {:type :CountryCode}}}}
+ :enums
+ {:CountryCode
+  {:values [:US]}}
+ :queries
+ {:countryByCode
+  {:type :Country
+   :resolve :placeholder
+   :args
+   {:code {:type :CountryCode
+           :default-value :country-codes/us}}}}}

--- a/src/com/walmartlabs/lacinia/introspection.clj
+++ b/src/com/walmartlabs/lacinia/introspection.clj
@@ -241,8 +241,10 @@
       (str serialized))))
 
 (defmethod emit-default-value :enum
-  [_ _ value]
-  (name value))
+  [schema type-map value]
+  (let [type-name  (:type type-map)
+        enum-def   (get schema type-name)]
+    (name ((:serialize enum-def) value))))
 
 (defmethod emit-default-value :list
   [schema type-map value]


### PR DESCRIPTION
With custom scalars, if you have a default value in your schema.edn, you can use a 'parsed' value and for introspection, lacinia will transform it back to a 'serialized' value.

However, with enums, you can have a 'parsed' value in your schema, but there was no logic to convert it back to a serialized value prior to introspection. That left us between a rock and hard place, we could put a non-parsed default value in the schema, but then the enums parse function would not run prior to passing it as an argument (but introspection was correct), or we could put a parsed default value in the schema, but then the introspection result would be wrong.

Like scalars, this change invokes a possibly customly defined serialize function prior to returning a default value for introspection. So, if you put a parsed enum value in schema.edn, all is well with introspection.