### PR TITLE
Add support for implementing Apollo GraphQL federation services

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 Optional request tracing is now designed to be compatible with Apollo GraphQL's implementation.
 
+New support for [Apollo GraphQL Federation](https://www.apollographql.com/docs/apollo-server/federation/introduction/).
+
 ## 0.37.0 -- 30 Jun 2020
 
 Added new function `com.walmartlabs.lacinia.util/inject-streamers`, used to
@@ -15,7 +17,7 @@ to `com.walmartlabs.lacinia.parser.schema/parse-schema` which is now deprecated.
 The schema parser has been updated, to allow input values (within input types)
 to specify defaults, and to support extending input types.
 
-The preview API (`selections-seq2`, etc.) now recognize the `@include` and
+The preview API functions (`selections-seq2`, etc.) now recognize the `@include` and
 `@skip` directives.
 
 Exceptions thrown by resolver functions are now caught and wrapped as new exceptions

--- a/dev-resources/no-entities-federation.sdl
+++ b/dev-resources/no-entities-federation.sdl
@@ -1,0 +1,8 @@
+type User  {
+    id: Int!
+    name: String
+}
+
+# Just want a union to show that _entities is not present
+
+union Stuff = User

--- a/dev-resources/simple-federation.sdl
+++ b/dev-resources/simple-federation.sdl
@@ -1,6 +1,11 @@
 type User @key(fields: "id") {
     id: Int!
-    name: String
+    name: String!
+}
+
+type Account @key(fields: "acct_number") {
+  acct_number: String!
+  name: String!
 }
 
 type Product @key(fields: "upc") @extends {

--- a/dev-resources/simple-federation.sdl
+++ b/dev-resources/simple-federation.sdl
@@ -1,0 +1,9 @@
+type User @key(fields: "id") {
+    id: ID!
+    name: String
+}
+
+type Product @key(fields: "upc") @extends {
+  upc: String! @external
+  reviewed_by: User
+}

--- a/dev-resources/simple-federation.sdl
+++ b/dev-resources/simple-federation.sdl
@@ -1,5 +1,5 @@
 type User @key(fields: "id") {
-    id: ID!
+    id: Int!
     name: String
 }
 

--- a/dev-resources/simple-federation.sdl
+++ b/dev-resources/simple-federation.sdl
@@ -3,6 +3,12 @@ type User @key(fields: "id") {
     name: String!
 }
 
+type Query {
+    user_by_id(id: Int!) : User
+}
+
+schema { query: Query }
+
 type Account @key(fields: "acct_number") {
   acct_number: String!
   name: String!

--- a/docs/_examples/fed/external.gql
+++ b/docs/_examples/fed/external.gql
@@ -1,0 +1,16 @@
+type User @extends @key(fields: "id") {
+  id: String! @external
+  favoriteProducts: [Product]
+}
+
+type Product @key(fields: "upc") {
+  upc: String!
+  name: String!
+  price: Int!
+}
+
+type Query {
+    productByUpc(upc: String!) : Product
+}
+
+schema { query: Query }

--- a/docs/_examples/fed/internal.gql
+++ b/docs/_examples/fed/internal.gql
@@ -1,0 +1,10 @@
+type User @key(fields: "id") {
+  id: String!
+  name: String!
+}
+
+type Query {
+  userById(id:String!) : User
+}
+
+schema { query: Query }

--- a/docs/_examples/fed/products.edn
+++ b/docs/_examples/fed/products.edn
@@ -1,0 +1,58 @@
+(ns products.server
+  (:require
+   [io.pedestal.http :as http]
+   [clojure.java.io :as io]
+   [com.walmartlabs.lacinia.pedestal2 :as lp]
+   [com.walmartlabs.lacinia.parser.schema :refer [parse-schema]]
+   [com.walmartlabs.lacinia.schema :as schema]
+   [com.walmartlabs.lacinia.util :as util]))
+
+(defn resolve-users-external
+  [_ _ reps]
+  (for [{:keys [id]} reps]
+    (schema/tag-with-type {:id id} 
+                          :User)))
+
+(defn get-product-by-upc
+  [context upc]
+  ;; Peform DB query here, return map with :upc, :name, :price
+  )
+
+(defn get-favorite-products-for-user
+  [context user-id]
+  ;; Perform DB query here, return seq of maps with :upc, :name, :price
+  )
+
+(defn resolve-products-internal
+  [context _ reps]
+  (for [{:keys [upc]} reps
+        :let [product (get-product-by-upc context upc)]]
+    (schema/tag-with-type product :Product)))
+
+(defn resolve-product-by-upc
+  [context {:keys [upc]} _]
+  (get-product-by-upc context upc))
+
+(defn resolve-favorite-products
+  [context _ user]
+  (let [{:keys [id]} user]
+    (get-favorite-products-for-user context id)))
+
+(defn products-schema
+  []
+  (-> "products.gql"
+      io/resource
+      slurp
+      (parse-schema {:federation {:entity-resolvers {:Product resolve-products-internal
+                                                     :User resolve-users-external}}})
+      (util/inject-resolvers {:Query/productByUpc #'resolve-product-by-upc
+                              :User/favoriteProducts #'resolve-favorite-products})
+      schema/compile))
+
+(defn start
+  []
+  (-> (products-schema)
+      lp/default-service
+      http/create-server
+      http/start))
+ 

--- a/docs/_examples/fed/query.gql
+++ b/docs/_examples/fed/query.gql
@@ -1,0 +1,6 @@
+{ 
+    userById(id: "124c41") { 
+        name 
+        favoriteProducts { upc name price } 
+    } 
+}

--- a/docs/_examples/fed/schema.gql
+++ b/docs/_examples/fed/schema.gql
@@ -1,0 +1,9 @@
+scalar _Any
+scalar _FieldSet
+
+# a union of all types that use the @key directive
+union _Entity
+
+extend type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'com.walmartlabs/lacinia'
-copyright = u'2015-2018, Walmartlabs'
+copyright = u'2015-2020, Walmartlabs'
 author = u'Lacinia Contributors'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/federation/external.rst
+++ b/docs/federation/external.rst
@@ -1,0 +1,39 @@
+External Entities
+=================
+
+The previous example showed an internal entity that can be extended; this example shows a different service providing
+its own internal entity, but also extending the ``User`` entity.
+
+.. literalinclude:: /_examples/fed/external.gql
+
+Note the use of the ``@extends`` directive, this indicates that ``User`` (in the products service) is a stub for the full
+``User`` entity in the users service.
+
+You must ensure that the external ``User`` includes the same ``@key`` directive (or directives), and the same primary key
+fields; here ``id`` must be present, since it is part of the primary key.
+The ``@external`` directive indicates that the field is provided by another service (the users service).
+
+The ``favoriteProducts`` field on ``User`` is an addition provided by this service, the products service.
+Like any other field, a resolver must be provided for it.
+We'll see how that works shortly.
+
+Notice that this service adds the ``productByUpc`` query to the ``Query`` object; the Apollo GraphQL gateway
+merges together all the queries defined by all the implementing services.
+
+Again, the point of the gateway is that it mixes and matches from all the implementing services; clients should
+*only* go through the gateway since that's the only place where this merged view of all the individual schemas
+exists.
+
+The gateway is capable of building a plan that involves multiple steps to satisfy a client query.
+
+For example, consider this gateway query:
+
+.. literalinclude:: /_examples/fed/query.gql
+
+The gateway will start with a query to the users service; it will invoke the ``userById`` query there and will
+select both the ``name`` field (as specified in the client query) and the ``id`` field (since that's specified
+in the ``@key`` directive on the ``User`` entity).
+
+A second query will be sent to the products service.
+This query is used to get those favorite products; but to understand exactly
+how that works, we must first discuss `representations`.

--- a/docs/federation/implementation.rst
+++ b/docs/federation/implementation.rst
@@ -1,0 +1,49 @@
+Service Implementation
+======================
+
+At this point, we've discussed what goes into each implementing service's schema, and a bit about how
+each service is responsible for resolving representations; let's finally see how this all fits together with
+Lacinia.
+
+Below is a sketch of how this comes together in the products service:
+
+.. literalinclude:: /_examples/fed/products.edn
+
+The ``resolve-users-external`` function is used to convert a seq of ``User`` representations
+into a seq of ``User`` entity stubs; this is called from the resolver for the ``_entities`` query whose type
+is a list of the ``_Entities`` union, therefore each value :doc:`must be tagged </resolve/type-tags>` with the ``:User`` type.
+
+.. sidebar:: Return type
+
+    Return type here is just like a normal field resolver that returns GraphQL list; it may be seq of values, or a
+    :doc:`ResolverResult </resolve/resolve-as>` that delivers such a seq.
+
+``resolve-products-internal`` does the same for ``Product`` representations, but since this is the
+products service, the expected behavior is to perform a query against an external data store and
+ensure the results match the structure of the ``Product`` entity.
+
+``resolve-product-by-upc`` is the resolver function for the ``productByUpc`` query.
+Since the field type is ``Product`` there's no need to tag the value.
+
+``resolve-favorite-products`` is the resolver function for the ``User/favoriteProducts`` field.
+This is passed the ``User`` (provided by ``resolve-users-external``); it extracts the ``id`` and passes
+it to ``get-favorite-products-for-user``.
+
+The remainder is bare-bones scaffolding to read, parse, and compile the schema and build a Pedestal
+service endpoint around it.
+
+Pay careful attention to the call to :api:`parser-schema/parse-schema`; the presence of the
+``:federation`` option is critical; this adds the necessary base types and directives
+before parsing the schema definition, and then adds the ``_entities`` query and ``_Entities`` union
+afterwards, among other things.
+
+The ``:entity-resolvers`` map is critical; this maps from a type name to a entity resolver;
+this information is used to build the field resolver function for the ``_entities`` query.
+
+.. warning::
+
+    A lot of details are left out of this, such as initializing the database and storing
+    the database connection into the application context, where functions like
+    ``get-product-by-upc`` can access it.  
+    
+    This is only a sketch to help you connect the dots.

--- a/docs/federation/index.rst
+++ b/docs/federation/index.rst
@@ -1,0 +1,63 @@
+Apollo GraphQL Federation
+=========================
+
+GraphQL federation is a concept, spearheaded by
+`Apollo GraphQL <https://www.apollographql.com/docs/apollo-server/federation/introduction/>`_, a Node-based JavaScript project,
+whereby multiple GraphQL schemas can be combined, behind a single `gateway` service.
+It's a useful concept, as it allows different teams to stand up their own schemas and services, written in
+any language, and dynamically combine them into a single "super" schema.
+
+Each service's schema can evolve independentently (as long as that evolution is backwards compatible), and can deploy
+on its own cycle. The gateway becomes the primary entrypoint for all clients, and it knows how to break
+service-spanning queries apart and build a overall query plan.
+
+Lacinia has been extended, starting in 0.38.0, to support acting as an implementing service; there is no plan
+at this time to act as a gateway.
+
+.. warning::
+
+    At this time, only a schema defined with the :doc:`Schema Definition Language </schema/parsing>`, can be extended to act as
+    a service implementation.
+
+Essentially, federation allows a set of services to each provide their own types, queries, mutations and organizes things so that
+each service can provide additional fields to the types provided by the other services.
+
+The `Apollo GraphQL documentation <https://www.apollographql.com/docs/apollo-server/federation/introduction/#concern-based-separation>`_ includes
+a basic example, where a users service exposes a ``User`` type (and related queries), a products service exposes
+a ``Product`` type, and a reviews service exposes a ``Review`` type.
+
+Without federation, these individual services are useful, but limited.
+A smart client could know about all three services, and send a series of requests to each, to build 
+up a model of, say, a particular user and the products that user has reviewed.
+
+For example:
+
+* Query the users service for the user, providing the user's unique id
+* Query the reviews service to get a list of reviews for that specific user (again, passing the user's unique id)
+* Query the products service for details (name, price, etc.) for each product reviewed by the user
+
+... but this is a lot to heap on the client developers; each client will have to manage three sets of GraphQL endpoints, and know exactly
+which fields are needed to bridge relationships between the different services.
+
+Instead, federation allows the Apollo GraphQL gateway to merge together the three individual services into one composite service.
+The client is only needs access to the single gateway enpoint, and is free to make complex queries that
+span from ``User`` to ``Review`` to ``Product`` seamlessly;
+the gateway service is responsible for communicating to the implementing services.
+
+A GraphQL type (or interface) that can span services this way is called an `entity`.
+
+In federation terms, the ``User`` entity is `internal` to the users service, and `external` to the other two services.
+The users service defines all the fields of the ``User`` entity, and can add new fields whenever necessary while staying
+backwards compatible, just as with a traditional GraphQL schema.
+
+In the other schemas, the ``User`` type is `external`; just a kind of stub for ``User`` is defined in the schemas for
+the products and reviews service. The full type, and the stub, must agree on fields that define the primary key
+for the entity. 
+
+.. toctree::
+    :hidden:
+
+    internal
+    external
+    reps
+    implementation

--- a/docs/federation/internal.rst
+++ b/docs/federation/internal.rst
@@ -1,0 +1,29 @@
+Internal Entities
+=================
+
+Defining an entity that is internal is quite straight-forward, it is almost the same as in
+traditional GraphQL.
+
+.. sidebar:: Examples
+
+   Here, and in the remaining examples, we've simplified the example from
+   Apollo GraphQL's documentation to just two services:
+   users and products.
+
+.. literalinclude:: /_examples/fed/internal.gql
+
+When federation is enabled, a 
+`number of new directives <https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#key>`_ are automatically available, 
+including ``@key``, which defines the primary key, or primary keys, for the entity.
+
+The above example would be the schema for a users service that can be extended by other services.
+
+.. warning::
+
+   Lacinia's default name for the object containing queries is ``QueryRoot``, whereas the default for Apollo and 
+   `most other GraphQL libraries <https://graphql.org/learn/schema/#the-query-and-mutation-types>`_ is ``Query``.  
+
+   Because of this, and because `Apollo doesn't do the right thing here <https://github.com/apollographql/apollo-server/issues/4554>`_,
+   it is necessary to override Lacinia's default by adding ``schema { query : Query }``.
+
+   The same holds true for mutations, which must be on a type named ``Mutation``.

--- a/docs/federation/reps.rst
+++ b/docs/federation/reps.rst
@@ -1,0 +1,46 @@
+Representations
+===============
+
+A `representation` is a map that can be transferred from one implementing service to another, within the same federation.
+This is necessary to allow work started in one service to continue in another; consider the query:
+
+.. literalinclude:: /_examples/fed/query.gql
+
+The gateway will query the ``User/favoriteProducts`` field on the products service as the second step on this query ... but
+where does the ``User`` come from?
+
+After the gateway performs the initial query on the users service, it builds a representation of the specific ``User``
+to pass to the products service, using information from the ``@key`` directive:
+
+.. code-block:: json
+
+    {"__typename": "User",
+     "id": "124c41"}
+
+This representation is JSON, and is be passed to an implementing service's ``_entities`` query, which is automaticaly added
+to the implementing service's schema by Lacinia:
+
+.. literalinclude:: /_examples/fed/schema.gql
+
+The ``_Entity`` union will contain all entities, internal or external, in the local schema; for the products service, this
+will be ``User`` and ``Product``.
+
+The ``_entities`` query exists to convert some number of representations (here, as scalar type ``_Any``) into entities
+(either stub entities or full entities).
+The gateway sends a request that passes the representations in, and uses fragments to extract the data needed
+by the original client query::
+
+    query($representations:[_Any!]!) {
+        _entities(representations:$representations) {
+            ... on User {
+                favoriteProducts {upc name price}
+            }
+        }
+    }
+
+So, in the products service, the ``_entities`` resolver converts the representation into a stub ``User`` object,
+containing just enough information so that the ``favoriteProducts`` resolver can perform whatever database query
+it uses.
+The response from the products service is merged together with the response from the users service and a final
+response can be returned to the gateway service's client.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ responding with JSON, it is also exceptionally useful for allowing backend syste
    custom-scalars
    roots
    tracing
+   federation/index
    introspection
    spec
    schema/parsing

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject com.walmartlabs/lacinia "0.37.0"
   :description "A GraphQL server implementation in Clojure"
   :url "https://github.com/walmartlabs/lacinia"
-  :license {:name "Apache, Version 2.0"'
+  :license {:name "Apache, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :plugins [[lein-codox "0.10.7"]
             [test2junit "1.2.5"]]

--- a/project.clj
+++ b/project.clj
@@ -1,22 +1,22 @@
 (defproject com.walmartlabs/lacinia "0.37.0"
   :description "A GraphQL server implementation in Clojure"
   :url "https://github.com/walmartlabs/lacinia"
-  :license {:name "Apache, Version 2.0"
+  :license {:name "Apache, Version 2.0"'
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :plugins [[lein-codox "0.10.7"]
             [test2junit "1.2.5"]]
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [clj-antlr "0.2.5"]
+                 [clj-antlr "0.2.6"]
                  [org.flatland/ordered "1.5.9"]
                  [org.clojure/data.json "1.0.0"]]
   :source-paths ["src"]
-  :profiles {:dev {:dependencies [[criterium "0.4.5"]
+  :profiles {:dev {:dependencies [[criterium "0.4.6"]
                                   [expound "0.8.5"]
                                   [joda-time "2.10.6"]
                                   [com.walmartlabs/test-reporting "1.0.0"]
                                   [io.aviso/logging "0.3.2"]
                                   [io.pedestal/pedestal.log "0.5.5"]
-                                  [org.clojure/test.check "1.0.0"]
+                                  [org.clojure/test.check "1.1.0"]
                                   [org.clojure/data.csv "1.0.0"]
                                   [org.clojure/tools.cli "1.0.194"]]}}
   :aliases {"benchmarks" ["run" "-m" "perf"]}

--- a/src/com/walmartlabs/lacinia/federation.clj
+++ b/src/com/walmartlabs/lacinia/federation.clj
@@ -1,0 +1,110 @@
+(ns com.walmartlabs.lacinia.federation
+  (:require
+    [com.walmartlabs.lacinia.resolve :as resolve]
+    [com.walmartlabs.lacinia.internal-utils :as utils]
+    [com.walmartlabs.lacinia.schema :as schema]
+    [clojure.spec.alpha :as s]))
+
+(def foundation-types
+  "Map of annotations and types to automatically include into an SDL
+  schema used for federation."
+  {:scalars
+   {:_Any {:parse identity
+           :serialize identity}
+    :_FieldSet {:parse identity
+                :serialize identity}}
+
+   :objects
+   {:_Service
+    {:fields
+     {:sdl {:type '(non-null String)}}}}
+
+   :directive-defs
+   {:external {:locations #{:field-definition}}
+    :requires {:args {:fields {:type '(non-null :_FieldSet)}}
+               :locations #{:field-definition}}
+    :provides {:args {:fields {:type '(non-null :_FieldSet)}}
+               :locations #{:field-definition}}
+    :key {:args {:fields {:type '(non-null :_FieldSet)}}
+          :locations #{:object :interface}}
+
+    ;; We will need this as the schema model doesn't
+    ;; track the concept of "extends" (it's handled by
+    ;; the SDL schema parser).
+    :extends {:locations #{:object :interface}}}})
+
+(defn ^:private is-entity?
+  [type-def]
+  (some #(-> % :directive-type (= :key))
+        (:directives type-def)))
+
+(defn ^:private find-entity-names
+  [schema]
+  (->> schema
+       :objects
+       (reduce-kv (fn [coll type-name type-def]
+                    (if (is-entity? type-def)
+                      (conj coll type-name)
+                      coll))
+                  [])
+       sort
+       seq))
+
+(defn ^:private prevent-collision
+  [m ks]
+  (when (some? (get-in m ks))
+    (throw (IllegalStateException. (str "Key " (pr-str ks) " already exists in schema")))))
+
+(defn ^:private entities-resolver-factory
+  "Entity resolvers are special resolvers. They are passed
+  the context, no args, and a seq of representations and return a seq
+  of entities for those representations.
+
+  entity-resolvers is a map of keyword to resolver fn."
+  [entity-resolvers]
+  (fn [context args _]
+    (let [{:keys [representations]} args
+          grouped (group-by :__typename representations)
+          results (reduce-kv
+                    (fn [coll type-name reps]
+                      (let [resolver (get entity-resolvers (keyword type-name))
+                            result (resolver context {} reps)
+                            result' (if (resolve/is-resolver-result? result)
+                                      result
+                                      (resolve/resolve-as result))]
+                        (conj coll result')))
+                    []
+                    grouped)]
+      ;; Quick optimization; don't do the aggregation if there's only a single
+      ;; result (very common case).
+      (if (= 1 (count results))
+        (first results)
+        (utils/aggregate-results results #(reduce into [] %))))))
+
+(defn inject-federation
+  "Called after SDL parsing to extend the input schema
+  (not the compiled schema) with federation support."
+  [schema sdl entity-resolvers]
+  (let [entity-names (find-entity-names schema)
+        entities-resolver (entities-resolver-factory entity-resolvers)
+        query-root (get-in schema [:roots :query] :QueryRoot)]
+    ;; TODO: Ensure each non-external entity has a matching entity resolver.
+    ;; TODO: Only add _Entity and _entities if there are entities
+    (prevent-collision schema [:unions :_Entity])
+    (prevent-collision schema [:objects query-root :fields :_service])
+    (prevent-collision schema [:objects query-root :fields :_entities])
+    (-> schema
+        (assoc-in [:objects :_Service :fields :sdl]
+                  {:type :String})
+        (assoc-in [:unions :_Entity :members] entity-names)
+        (assoc-in [:objects query-root :fields :_service]
+                  {:type '(non-null :_Service)
+                   :resolve (fn [_ _ _] {:sdl sdl})})
+        (assoc-in [:objects query-root :fields :_entities]
+                  {:type '(non-null (list :_Entity))
+                   :args
+                   {:representations
+                    {:type '(non-null (list (non-null :_Any)))}}
+                   :resolve entities-resolver}))))
+
+(s/def ::entity-resolvers (s/map-of simple-keyword? ::schema/function-or-var))

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -21,6 +21,7 @@
     [com.walmartlabs.lacinia.parser.common :as common]
     [com.walmartlabs.lacinia.util :refer [inject-descriptions]]
     [com.walmartlabs.lacinia.schema :as schema]
+    [com.walmartlabs.lacinia.federation :as federation]
     [clojure.spec.alpha :as s]
     [clojure.string :as str])
   (:import
@@ -60,7 +61,7 @@
         (throw (ex-info (format "Field %s already defined in the existing schema. It cannot also be defined in this type extension."
                                 (q (qualified-name k property)))
                         (cond-> {:key k}
-                                (seq locations) (assoc :locations locations)))))))
+                          (seq locations) (assoc :locations locations)))))))
   (reduce merge
           {}
           [{:fields (merge (get org :fields) (get v :fields))}
@@ -87,7 +88,7 @@
           (throw (ex-info (format "Cannot extend type %s because it does not exist in the existing schema."
                                   (q k))
                           (cond-> {:key k}
-                                  (seq locations) (assoc :locations locations)))))
+                            (seq locations) (assoc :locations locations)))))
 
         (not (contains? m k))
         (assoc m k v)
@@ -101,7 +102,7 @@
                                   content
                                   (q k))
                           (cond-> {:key k}
-                                  (seq locations) (assoc :locations locations)))))))
+                            (seq locations) (assoc :locations locations)))))))
 
 (defn ^:private checked-map
   "Given a seq of key/value tuples, assembles a map, checking that keys do not conflict
@@ -141,18 +142,18 @@
 ;; Perhaps at some point we can merge it all into a single, unified grammar.
 
 (defmulti ^:private xform
-          "Transform an Antlr production into a result.
+  "Transform an Antlr production into a result.
 
-          Antlr productions are recursive lists; the first element is a type
-          (from the grammar), and the rest of the list are nested productions.
+  Antlr productions are recursive lists; the first element is a type
+  (from the grammar), and the rest of the list are nested productions.
 
-          Meta data on the production is the location (line, column) of the production."
-          first
-          ;; When debugging/developing, this is incredibly useful:
-          #_(fn [prod]
-              (log/trace :dispatch prod)
-              (first prod))
-          :default ::default)
+  Meta data on the production is the location (line, column) of the production."
+  first
+  ;; When debugging/developing, this is incredibly useful:
+  #_(fn [prod]
+      (log/trace :dispatch prod)
+      (first prod))
+  :default ::default)
 
 (defn ^:private xform-second
   [prod]
@@ -161,7 +162,7 @@
 (defn ^:private apply-description
   [parsed descripion-prod]
   (cond-> parsed
-          descripion-prod (assoc :description (xform descripion-prod))))
+    descripion-prod (assoc :description (xform descripion-prod))))
 
 (defn ^:private apply-directives
   [element directiveList]
@@ -502,7 +503,7 @@
 
 (defn ^:private xform-schema
   "Given an ANTLR parse tree, returns a Lacinia schema."
-  [antlr-tree resolvers scalars streamers documentation]
+  [antlr-tree empty-schema resolvers scalars streamers documentation]
   (let [schema (->> antlr-tree
                     rest
                     (map xform)
@@ -518,7 +519,7 @@
                                   (update-in schema path'
                                              assoc-check
                                              (-> path' last name) k value))))
-                            {}))]
+                            empty-schema))]
     (-> schema
         (attach-field-fns :resolve resolvers)
         (attach-field-fns :stream streamers)
@@ -535,17 +536,21 @@
   Directives may be declared and used, but validation of directives is
   also deferred downstream.
 
-  The `attach` map is deprecated, but still supported.
+  Most keys of the `attach` map are deprecated, but still supported.
   Documentation can now be provided inline in the schema document,
   and directives, streamers, and etc. can be added as needed via
   functions in the [[com.walmartlabs.lacinia.util]] namespace.
 
   `attach` should be a map consisting of the following keys:
 
-  `:resolvers` is expected to be a map of:
+  `:federation` enables support for GraphQL federation. It contains a
+  sub-key, `:entity-resolvers` which maps from keyword entity name to
+  an entity resolver function.
+
+  `:resolvers` (deprecated) is expected to be a map of:
   {:type-name {:field-name resolver-fn}}
 
-  `:scalars` is expected to be a map of:
+  `:scalars` (deprecated) is expected to be a map of:
   {:scalar-name {:parse parse-spec
                  :serialize serialize-spec}}
 
@@ -553,10 +558,10 @@
 
   The provided scalar maps are merged into the scalars parsed from the document.
 
-  `:streamers` is expected to be a map of:
+  `:streamers` (deprecated) is expected to be a map of:
   {:type-name {:subscription-field-name stream-fn}}
 
-  `:documentation` is expected to be a map of:
+  `:documentation` (deprecated) is expected to be a map of:
   {:type-name doc-str
    :type-name/field-name doc-str
    :type-name/field-name.arg-name doc-str}"
@@ -567,17 +572,24 @@
      (throw (ex-info (str "Arguments to parse-schema do not conform to spec:\n" (with-out-str (s/explain-out ed)))
                      ed)))
 
-   (let [{:keys [resolvers scalars streamers documentation]} attach]
-     (xform-schema (try
-                     (common/antlr-parse grammar schema-string)
-                     (catch ParseError e
-                       (let [failures (common/parse-failures e)]
-                         (throw (ex-info "Failed to parse GraphQL schema."
-                                         {:errors failures})))))
-                   resolvers
-                   scalars
-                   streamers
-                   documentation))))
+   (let [{:keys [resolvers scalars streamers documentation federation]} attach
+         empty-schema (if federation
+                        federation/foundation-types
+                        {})
+         antlr-tree (try
+                      (common/antlr-parse grammar schema-string)
+                      (catch ParseError e
+                        (let [failures (common/parse-failures e)]
+                          (throw (ex-info "Failed to parse GraphQL schema."
+                                          {:errors failures})))))]
+     (cond-> (xform-schema antlr-tree
+                           empty-schema
+                           resolvers
+                           scalars
+                           streamers
+                           documentation)
+       federation (federation/inject-federation schema-string
+                                                (:entity-resolvers federation))))))
 
 (s/def ::field-fn (s/map-of simple-keyword? (s/or :function ::schema/function-or-var
                                                   :keyword simple-keyword?)))
@@ -593,10 +605,13 @@
 (s/def ::resolvers ::fn-map)
 (s/def ::streamers ::fn-map)
 
+(s/def ::federation (s/keys :req-un [::federation/entity-resolvers]))
+
 (s/def ::parse-schema-args (s/or
                              :supported string?
-                             :deprecated (s/cat :schema-string string?
-                                                :attachments (s/keys :opt-un [::resolvers
-                                                                              ::streamers
-                                                                              ::scalars
-                                                                              ::documentation]))))
+                             :attach (s/cat :schema-string string?
+                                            :attachments (s/keys :opt-un [::resolvers
+                                                                          ::streamers
+                                                                          ::scalars
+                                                                          ::documentation
+                                                                          ::federation]))))

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -545,7 +545,7 @@
 
   `:federation` enables support for GraphQL federation. It contains a
   sub-key, `:entity-resolvers` which maps from keyword entity name to
-  an entity resolver function.
+  an entity resolver function (or FieldResolver instance).
 
   `:resolvers` (deprecated) is expected to be a map of:
   {:type-name {:field-name resolver-fn}}

--- a/test/com/walmartlabs/lacinia/federation_tests.clj
+++ b/test/com/walmartlabs/lacinia/federation_tests.clj
@@ -1,0 +1,14 @@
+(ns com.walmartlabs.lacinia.federation-tests
+  (:require
+    [clojure.test :refer [deftest is]]
+    [com.walmartlabs.lacinia.parser.schema :refer [parse-schema]]
+    [com.walmartlabs.test-utils :refer [execute]]
+    [com.walmartlabs.lacinia.schema :as schema]))
+
+(deftest essentials
+  (let [sdl (slurp "dev-resources/simple-federation.sdl")
+        schema (-> (parse-schema sdl {:federation {:entity-resolvers {:User (fn [_ _ _] nil)}}})
+                   schema/compile)]
+    (is (= {:data {:_service {:sdl sdl}}}
+           (execute schema
+                    "{ _service { sdl }}")))))

--- a/test/com/walmartlabs/lacinia/federation_tests.clj
+++ b/test/com/walmartlabs/lacinia/federation_tests.clj
@@ -1,14 +1,110 @@
+; Copyright (c) 2020-present Walmart, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License")
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
 (ns com.walmartlabs.lacinia.federation-tests
   (:require
     [clojure.test :refer [deftest is]]
     [com.walmartlabs.lacinia.parser.schema :refer [parse-schema]]
     [com.walmartlabs.test-utils :refer [execute]]
+    [com.walmartlabs.test-reporting :refer [reporting]]
     [com.walmartlabs.lacinia.schema :as schema]))
 
 (deftest essentials
   (let [sdl (slurp "dev-resources/simple-federation.sdl")
-        schema (-> (parse-schema sdl {:federation {:entity-resolvers {:User (fn [_ _ _] nil)}}})
-                   schema/compile)]
+        schema (schema/compile
+                 (parse-schema sdl {:federation {:entity-resolvers {:User (fn [_ _ _] nil)}}}))]
+
     (is (= {:data {:_service {:sdl sdl}}}
            (execute schema
-                    "{ _service { sdl }}")))))
+                    "{ _service { sdl }}")))
+
+    (is (= {:data {:entities {:members [{:name "Product"}
+                                        {:name "User"}]
+                              :name "_Entity"}}}
+           (execute schema
+                    "{ entities: __type(name: \"_Entity\") { name members: possibleTypes { name }}}")))))
+
+(defn ^:private resolve-user
+  [_ _ reps]
+  (for [{:keys [id]} reps]
+    (schema/tag-with-type
+      {:id id
+       :name (str "User #" id)}
+      :User)))
+
+(def entities-query
+  "
+query($reps : [_Any!]!) {
+  entities: _entities(representations: $reps) {
+    __typename
+
+    ... on User { id name }
+    }
+  }
+}")
+
+(deftest entity-resolvers
+  (let [sdl (slurp "dev-resources/simple-federation.sdl")
+        schema (schema/compile
+                 (parse-schema sdl {:federation {:entity-resolvers
+                                                 {:User resolve-user}}}))]
+
+    (is (= {:data {:entities []}}
+           (execute schema
+                    entities-query
+                    {:reps []}
+                    nil)))
+
+    (is (= {:data {:entities [{:__typename :User
+                               :id 1001
+                               :name "User #1001"}
+                              {:__typename :User
+                               :id 2002
+                               :name "User #2002"}]}}
+           (execute schema
+                    entities-query
+                    {:reps [{:__typename "User"
+                             :id 1001}
+                            {:__typename "User"
+                             :id 2002}]}
+                    nil)))))
+
+(deftest no-entities
+  (let [sdl (slurp "dev-resources/no-entities-federation.sdl")
+        schema (schema/compile
+                 (parse-schema sdl {:federation {:entity-resolvers {}}}))
+        result (->> (execute schema
+                             "
+                             {
+                               schema: __schema {
+                                 query: queryType {
+                                   fields { name }
+                                 }
+                                 types { kind name }
+                               }
+                             }"
+                             ))
+        field-names (->> result
+                         :data :schema :query :fields
+                         (map :name)
+                         (into #{}))
+        union-names (->> result
+                         :data :schema :types
+                         (filter #(-> % :kind (= :UNION)))
+                         (map :name)
+                         (into #{}))]
+    (reporting result
+               (is (contains? field-names "_service"))
+               (is (not (contains? field-names "_entities")))
+               (is (= #{"Stuff"} union-names)))))


### PR DESCRIPTION
This extends Lacinia so that a Lacinia schema can be a service implementation within a Apollo GraphQL federated schema.

This first pass is limited to SDL-defined schemas, but that may change in the future.

I actually created a couple of services (using mocked data) and connected them using Apollo GraphQL, figuring out quite a few things along the way.