### PR TITLE
Fix bug with true/false/null literal values in SDL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ per [the GraphQL specification](http://spec.graphql.org/June2018/#sec-Root-Opera
 Added function `com.walmartlabs.lacinia.executor/selection` which provides access to 
 the details about the selection, including directives and nested selections.
 
+Fixed problems with the literal values `true`, `false`, and `null` when parsing Schema Definition Language files.
 ## 0.37.0 -- 30 Jun 2020
 
 Added new function `com.walmartlabs.lacinia.util/inject-streamers`, used to

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [org.clojure/data.json "1.0.0"]]
   :source-paths ["src"]
   :profiles {:dev {:dependencies [[criterium "0.4.6"]
-                                  [expound "0.8.5"]
+                                  [expound "0.8.6"]
                                   [joda-time "2.10.6"]
                                   [com.walmartlabs/test-reporting "1.0.0"]
                                   [io.aviso/logging "0.3.2"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "0.38.0-alpha-2"
+(defproject com.walmartlabs/lacinia "0.38.0-alpha-3"
   :description "A GraphQL server implementation in Clojure"
   :url "https://github.com/walmartlabs/lacinia"
   :license {:name "Apache, Version 2.0"

--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -224,7 +224,7 @@ K_TRUE         : 'true'         ;
 K_FALSE        : 'false'        ;
 K_NULL         : 'null'         ;
 
-BooleanValue
+booleanValue
     : K_TRUE
     | K_FALSE
     ;
@@ -238,8 +238,8 @@ value
     | FloatValue
     | StringValue
     | BlockStringValue
-    | BooleanValue
-    | NullValue
+    | booleanValue
+    | nullValue
     | enumValue
     | arrayValue
     | objectValue
@@ -261,7 +261,7 @@ objectField
     : anyName ':' value
     ;
 
-NullValue
+nullValue
     : K_NULL
     ;
 

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -352,9 +352,13 @@
   [prod]
   (xform-second prod))
 
-(defmethod xform :booleanvalue
+(defmethod xform :booleanValue
   [prod]
-  (Boolean/valueOf ^String (second prod)))
+  (Boolean/valueOf ^String (-> prod second second)))
+
+(defmethod xform :nullValue
+  [_]
+  nil)
 
 (defmethod xform :intvalue
   [prod]


### PR DESCRIPTION
A bug in the SDL grammar meant that it was not possible to define a field, argument, or directive argument as having a default value of `true`, `false`, or `null`.