### PR TITLE
Allow directive arguments to be enums or input objects as well as scalara

### DIFF
--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1515,8 +1515,8 @@
                                                     {:arg-name arg-name
                                                      :arg-type-name arg-type-name
                                                      :schema-types (type-map schema)})))
-                                  (when-not (= :scalar (:category arg-type))
-                                    (throw (ex-info "Directive argument is not a scalar type."
+                                  (when-not (#{:enum :scalar :input-object} (:category arg-type))
+                                    (throw (ex-info "Directive argument is not a scalar, enum, or input object type."
                                                     {:arg-name arg-name
                                                      :arg-type-name arg-type-name
                                                      :schema-types (type-map schema)})))

--- a/test/com/walmartlabs/lacinia/directives_test.clj
+++ b/test/com/walmartlabs/lacinia/directives_test.clj
@@ -223,6 +223,20 @@
   [expected-msg expected-ex-data schema]
   `(expect-exception ~expected-msg ~expected-ex-data (schema/compile ~schema)))
 
+(deftest scalars-allowed-for-directive-args
+  (schema/compile
+    '{:directive-defs {:auth {:args {:logFailure {:type Boolean
+                                                  :default-value true}
+                                     :operationName {:default-value nil
+                                                     :type String}
+                                     :roles {:default-value [:ADMIN :MANAGER]
+                                             :type (list :Role)}}
+                              :locations #{:field-definition}}}
+      :enums {:Role {:values [{:enum-value :ADMIN}
+                              {:enum-value :MANAGER}
+                              {:enum-value :WORKER}
+                              {:enum-value :GUEST}]}}}))
+
 (deftest unknown-argument-type-for-directive
   (directive-test
     "Unknown argument type."
@@ -242,7 +256,7 @@
 
 (deftest incorrect-argument-type-for-directive
   (directive-test
-    "Directive argument is not a scalar type."
+    "Directive argument is not a scalar, enum, or input object type."
     {:arg-name :user
      :arg-type-name :User
      :schema-types {:object [:Mutation


### PR DESCRIPTION
Another oversight with respect to directives.