### PR TITLE
mutable-context.edn typo: Requires lacina instead of lacinia

### DIFF
--- a/docs/_examples/mutable-context.edn
+++ b/docs/_examples/mutable-context.edn
@@ -1,4 +1,4 @@
-(require '[com.walmartlabs.lacina.resolve :as resolve])
+(require '[com.walmartlabs.lacinia.resolve :as resolve])
 
 (defn resolve-products
   [_ args _]


### PR DESCRIPTION
```
[com.walmartlabs.lacina.resolve :as resolve]
```