### PR TITLE
Don't stringify keys for defaults argument of input objects type

### DIFF
--- a/src/com/walmartlabs/lacinia/introspection.clj
+++ b/src/com/walmartlabs/lacinia/introspection.clj
@@ -264,9 +264,8 @@
                                                           (:type field-def)
                                                           (get value field-name))]
                       (when field-value
-                        (str \"
-                             (name field-name)
-                             "\":"
+                        (str (name field-name)
+                             ":"
                              field-value))))
                   (->> type-def :fields vals (sort-by :field-name)))]
     (str "{"

--- a/test/com/walmartlabs/introspection_test.clj
+++ b/test/com/walmartlabs/introspection_test.clj
@@ -1451,7 +1451,7 @@
     (is (= {:data
             {:__type
              {:fields
-              [{:args [{:defaultValue "{\"checked\":false,\"count\":20,\"target\":3.14,\"title\":\"gorge\"}"
+              [{:args [{:defaultValue "{checked:false,count:20,target:3.14,title:\"gorge\"}"
                         :name "filter"}]
                 :name "search"}]}}}
            (utils/execute schema fields-and-args-query)))


### PR DESCRIPTION
The spec says that literals for input object values should not be JSON like (e.g. with string keys), but instead JS like (e.g. with name keys). This also applies for default values in introspection.

In these spec sections:
1. https://spec.graphql.org/June2018/#sec-Field-Arguments

DefaultValue here points to the shared DefaultValue, and that points to the normal Value.

2. https://spec.graphql.org/June2018/#ObjectValue

ObjectValue here does not permit quoted names. The example here is also without quotes.

The reference implementation also doesn't stringify keys:

https://codesandbox.io/s/elastic-wildflower-glwsh?file=/src/index.js

Unlike the reference implementation, this change does not add spaces between entries in the default value. I think thats fine, and more in line with how lacinia prints default values of array-typed fields.