### PR TITLE
Replace the old example project with a refreshed one.

### DIFF
--- a/docs/samples.rst
+++ b/docs/samples.rst
@@ -13,20 +13,12 @@ Sample Projects
   Built on top of Compojure and PostgreSQL.
   See `this blog post <https://jborden.github.io/2017/05/15/using-lacinia>`_ by the author.
 
-`open-bank-mark <https://github.com/openweb-nl/kafka-graphql-examples>`_
+`Event sourcing tutorial <https://github.com/gklijs/bob2021>`_
   This project consists of multiple components creating a bank simulation.
-
-  The `graphql-endpoint <https://github.com/openweb-nl/kafka-graphql-examples/tree/master/graphql-endpoint>`_
-  component consists of three services that all consume from Kafka.
-  It's mainly working with subscriptions where a command is put to Kafka and the result is returned.
-  It is also possible to query transactions, using a derived view.
-  PostgreSQL is used to store user accounts for logging in, and to store all the transactions.
-  The `test module <https://github.com/openweb-nl/kafka-graphql-examples/blob/master/test/src/nl/openweb/test/generator.clj>`_
-  Contains a generator to load test the subscriptions and can be used as inspiration to do similar testing.
-
-  Also part of the project is a `frontend <https://github.com/openweb-nl/open-bank-mark/tree/master/frontend>`_
+  The `graphql-endpoint <https://github.com/gklijs/bob2021/tree/master/graphql-endpoint>`_
+  leverages Kafka to do queries, mutations and subscriptions.
+  Also part of the project is a `frontend <https://github.com/gklijs/bob2021/tree/master/frontend>`_
   using `re-graph <https://github.com/oliyh/re-graph>`_.
-  Users can login, transfer money, and get an overview of all the bank accounts.
   
 `Fullstack Learning Project <https://promesante.github.io/2019/08/14/clojure_graphql_fullstack_learning_project_part_1.html>`_ 
   A port of `The Fullstack Tutorial for GraphQL <https://www.howtographql.com/>`_, ported to Clojure and Lacinia.


### PR DESCRIPTION
New example is using the latest version of lacina-pedestal, and uses setting the host, so it works from docker.
Also the rest of the project has been updated to be more event sourcing, and not longer (also) relying on a sql database.