### PR TITLE
Fix endless loop when field/argument type is bare

### DIFF
--- a/dev-resources/select-type-schema.edn
+++ b/dev-resources/select-type-schema.edn
@@ -13,6 +13,7 @@
   :Item
   {:fields
    {:quantity {:type (non-null Int)}
+    :description {:type String}
     :product {:type (non-null Product)}}}
 
   :Product
@@ -23,4 +24,5 @@
   :Query
   {:fields
    {:order {:type :Order
-           :args {:id {:type (non-null String)}}}}}}}
+           :args {:id {:type (non-null String)}
+                  :search {:type String}}}}}}}

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -515,10 +515,10 @@
   (kind [_]
     (assoc type :compiled-schema compiled-schema))
 
-  (root-type [_]
-    (select-type compiled-schema (root-type-name type)))
+  (root-type [this]
+    (select-type compiled-schema (root-type-name this)))
 
-  (root-type-name [_] (root-type-name type))
+  (root-type-name [this] (root-type-name this))
 
   selection/QualifiedName
 
@@ -791,10 +791,10 @@
   (kind [_]
     (assoc type :compiled-schema compiled-schema))
 
-  (root-type [element]
-    (select-type compiled-schema (root-type-name element)))
+  (root-type [this]
+    (select-type compiled-schema (root-type-name this)))
 
-  (root-type-name [element] (root-type-name element)))
+  (root-type-name [this] (root-type-name this)))
 
 (defn ^:private compile-arg
   [arg-name arg-def]

--- a/test/com/walmartlabs/lacinia/select_type_test.clj
+++ b/test/com/walmartlabs/lacinia/select_type_test.clj
@@ -32,6 +32,26 @@
     (is (some? items))
     (is (= :object (sel/type-category items)))))
 
+(deftest root-type-of-simple-field
+  (let [item-field (-> (schema/select-type schema :Item)
+                       sel/fields
+                       :description)]
+    (is (= :String (sel/root-type-name item-field)))
+    (is (= :String (-> item-field
+                       sel/root-type
+                       sel/type-name)))))
+
+(deftest root-type-of-simple-argument
+  (let [search-argument (-> (schema/select-type schema :Query)
+                            sel/fields
+                            :order
+                            sel/argument-defs
+                            :search)]
+    (is (= :String (sel/root-type-name search-argument)))
+    (is (= :String (-> search-argument
+                       sel/root-type
+                       sel/type-name)))))
+
 (defn ^:private kind-types [kind]
   (when (some? kind)
     (cons (sel/kind-type kind)


### PR DESCRIPTION
Strangely, the earlier tests worked because they handled the more complicated cases.