### PR TITLE
Allow a Var to be a resolver function

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "0.39-alpha-3"
+(defproject com.walmartlabs/lacinia "0.39-alpha-4"
   :description "A GraphQL server implementation in Clojure"
   :url "https://github.com/walmartlabs/lacinia"
   :license {:name "Apache, Version 2.0"

--- a/src/com/walmartlabs/lacinia/resolve.clj
+++ b/src/com/walmartlabs/lacinia/resolve.clj
@@ -208,13 +208,25 @@
 (defn as-resolver-fn
   "Wraps a [[FieldResolver]] instance as a field resolver function.
 
-  If the field-resolver provided is a function, it is returned unchanged."
+  If the field-resolver provided is a function or a Var, it is returned unchanged.
+
+  Anything other value will cause an exception to be thrown."
   {:added "0.24.0"}
   [field-resolver]
-  (if (fn? field-resolver)
+  (cond
+    (fn? field-resolver)
     field-resolver
+
+    (var? field-resolver)
+    field-resolver
+
+    (satisfies? FieldResolver field-resolver)
     (fn [context args value]
-      (resolve-value field-resolver context args value))))
+      (resolve-value field-resolver context args value))
+
+    :else
+    (throw (ex-info "Not a field resolver function of FieldResolver instance."
+                    {:field-resolver field-resolver}))))
 
 (defn wrap-resolver-result
   "Wraps a resolver function or ([[FieldResolver]] instance), passing the result through a wrapper function.

--- a/test/com/walmartlabs/lacinia/resolve_test.clj
+++ b/test/com/walmartlabs/lacinia/resolve_test.clj
@@ -23,7 +23,8 @@
     [com.walmartlabs.lacinia.schema :as schema]
     [com.walmartlabs.lacinia.resolve :as resolve]
     [com.walmartlabs.lacinia.util :as util]
-    [com.walmartlabs.lacinia.selection :as sel]))
+    [com.walmartlabs.lacinia.selection :as sel])
+  (:import (clojure.lang ExceptionInfo)))
 
 (def resolve-contexts (atom []))
 
@@ -142,3 +143,15 @@
                                    (util/inject-resolvers {:queries/data data-resolver})))]
     (is (= {:data {:data {:value "Ahsoka Tano"}}}
            (tu/execute schema "{ data { value } }")))))
+
+(deftest as-resolver-fn-var
+  (is (identical? #'identity
+                  (resolve/as-resolver-fn #'identity))))
+
+(deftest invalid-arg-to-as-resolver-fn
+  (let [e (is (thrown? ExceptionInfo
+                       (resolve/as-resolver-fn :not-a-fn)))]
+    (is (= "Not a field resolver function of FieldResolver instance."
+           (ex-message e)))
+    (is (= {:field-resolver :not-a-fn}
+           (ex-data e)))))


### PR DESCRIPTION
In development mode, it is often useful to pass a Var (e.g, `#'my-resolver-fn`) so that changes to the Var during REPL oriented development can be accepted in realtime, without a re-start/re-compile of the schema.

This change fixes an edge case related to the new `:apply-field-directives` option and callback. 