### PR TITLE
Support non-null object fields that implement nullable interface fields.

### DIFF
--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -663,7 +663,7 @@
       ;; the object can be more specific than the interface.
       (and (= o-kind :non-null)
            (not= i-kind :non-null))
-      (recur schema i-kind o-type)
+      (recur schema interface-type o-type)
 
       ;; Otherwise :list must match :list, and :root must match :root,
       ;; and :non-null must match :non-null

--- a/test/com/walmartlabs/interface_test.clj
+++ b/test/com/walmartlabs/interface_test.clj
@@ -40,6 +40,13 @@
                        :fields {:first_name {:type String}
                                 :last_name {:type (list String)}}}}})
 
+(def compatible-field-multiplicity
+  '{:interfaces {:named {:fields {:first_name {:type String}
+                                  :last_name {:type (list String)}}}}
+    :objects {:person {:implements [:named]
+                       :fields {:first_name {:type String}
+                                :last_name {:type (list (non-null String))}}}}})
+
 (def incompatible-field-nullability
   '{:interfaces {:named {:fields {:first_name {:type (non-null String)}
                                   :last_name {:type String}}}}
@@ -47,6 +54,12 @@
                        :fields {:first_name {:type String}
                                 :last_name {:type String}}}}})
 
+(def compatible-field-nullability
+  '{:interfaces {:named {:fields {:first_name {:type String}
+                                  :last_name {:type String}}}}
+    :objects {:person {:implements [:named]
+                       :fields {:first_name {:type (non-null String)}
+                                :last_name {:type String}}}}})
 
 ;; Basically checking error cases; success cases show up in other
 ;; tests.
@@ -71,12 +84,18 @@
       "Object field is not compatible with extended interface type."
       {:field-name :person/last_name
        :interface-name :named}
-      (compile incompatible-field-multiplicity)))
+      (compile incompatible-field-multiplicity))
+
+    (is (some? (compile compatible-field-multiplicity))
+        "Object fields are allowed to be a list of non-nulls, even if the interface field is a list of nullables."))
 
   (testing "field nullability"
     (expect-exception
       "Object field is not compatible with extended interface type."
       {:field-name :person/first_name
        :interface-name :named}
-      (compile incompatible-field-nullability))))
+      (compile incompatible-field-nullability))
+
+    (is (some? (compile compatible-field-nullability))
+        "Object fields are allowed to be non-null, even if the interface field is nullable.")))
 


### PR DESCRIPTION
Hi there,
Thanks for the very useful library!

I found this bug while trying to write some graphql of the form:
```
interface IA {
    a: String
}

type A implements IA {
    a: String!
}
```

I read through https://spec.graphql.org/June2018/#ObjectTypeDefinition and from my understanding of:
> 4. An object field type is a valid sub‐type if it is a Non‐Null variant of a valid sub‐type of the interface field type.

is that it is intended to be supported.

Looking through the existing code it looks like Lacinia also intended to support it, but had a bug.
Hopefully this is a reasonable fix to the issue.

I'm not 100% sure whether I've got the tests in the right place, or if I could do something better than `is some?`. Please let me know if there is a better alternative.

All the best,
Daniel