### PR TITLE
Emphasize line 6

### DIFF
--- a/docs/tutorial/mutable-database.rst
+++ b/docs/tutorial/mutable-database.rst
@@ -71,7 +71,7 @@ system namespace
 
 .. literalinclude:: /_examples/tutorial/system-2.clj
    :caption: src/clojure_game_geek/system.clj
-   :emphasize-lines: 13
+   :emphasize-lines: 6,13
 
 The ``:db`` component doesn't effectively exist until it is part of the system map.
 This change adds it in.


### PR DESCRIPTION
The 6th line (of system namespace) is missing from the newly added (emphasized) line.