### PR TITLE
Update documentation with invoke streamer example

### DIFF
--- a/docs/_examples/invoke-streamer.edn
+++ b/docs/_examples/invoke-streamer.edn
@@ -1,0 +1,16 @@
+(require
+  '[com.walmartlabs.lacinia.executor :as executor]
+   [com.walmartlabs.lacinia.parser :as parser]
+   [com.walmartlabs.lacinia.constants :as constants])
+
+(let [prepared-query (-> schema
+                         (parser/parse-query query)
+                         (parser/prepare-with-query-variables variables))
+      source-stream-callback (fn [data]
+                               ;; Do something with the data
+                               ;; e.g. send it to a websocket client
+                               )
+      cleanup-fn (executor/invoke-streamer
+                   {constants/parsed-query-key prepared-query} source-stream-callback)]
+  ;; Do something with the cleanup-fn e.g. call it when a websocket connection is closed
+  )

--- a/docs/subscriptions/streamer.rst
+++ b/docs/subscriptions/streamer.rst
@@ -50,6 +50,19 @@ until ``nil`` is passed to the source stream callback.
 
 In either case, the cleanup callback will then be invoked.
 
+Invoking the streamer
+---------------------
+
+The streamer must be invoked with the parsed query and source stream callback in order to setup the
+subscription using :api:`executor/invoke-streamer`.
+
+.. literalinclude:: ../_examples/invoke-streamer.edn
+  :language: clojure
+
+Typically subscriptions are used with websockets so this example could be adapted to receive a message
+with a query and variables from a connected websocket client. Then any messages received by the source
+stream callback can be pushed to the client.
+
 Timing
 ------
 


### PR DESCRIPTION
This PR updates the documentation with an explanation and example of invoking the streamer when setting up a subscription. I thought this maybe helpful for others as I was confused from the docs how the source stream callback was used with the streamer.

If I can make any improvements to this please let me know.