### PR TITLE
Add support for extending unions

### DIFF
--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -1,7 +1,7 @@
 grammar GraphqlSchema;
 
 graphqlSchema
-  : (schemaDef|typeDef|typeExtDef|inputTypeDef|inputTypeExtDef|unionDef|enumDef|interfaceDef|scalarDef|directiveDef)*
+  : (schemaDef|typeDef|typeExtDef|inputTypeDef|inputTypeExtDef|unionDef|unionExtDef|enumDef|interfaceDef|scalarDef|directiveDef)*
   ;
 
 description
@@ -111,6 +111,10 @@ scalarDef
 
 unionDef
   : description? K_UNION anyName directiveList? '=' unionTypes
+  ;
+
+unionExtDef
+  : description? K_EXTEND K_UNION anyName directiveList? '=' unionTypes
   ;
 
 unionTypes

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -62,6 +62,14 @@
                                 (q (qualified-name k property)))
                         (cond-> {:key k}
                           (seq locations) (assoc :locations locations)))))))
+  (doseq [member (get org :members [])]
+    (when (contains? (set (:members v)) member)
+      (let [locations (keepv meta [org v])]
+        (throw (ex-info (format "%s already member of union %s in the existing schema. It cannot also be defined in this union extension."
+                                (q member) (q k))
+                        (cond-> {:key k
+                                 :member member}
+                                (seq locations) (assoc :locations locations)))))))
   (reduce merge
           {}
           [(some->> (merge (get org :fields {}) (get v :fields {}))

--- a/src/com/walmartlabs/lacinia/parser/schema.clj
+++ b/src/com/walmartlabs/lacinia/parser/schema.clj
@@ -53,7 +53,7 @@
   [v]
   (get (meta v) :extension false))
 
-(defn ^:private merge-type-extension
+(defn ^:private merge-extension
   [k v org]
   (doseq [property (keys (get org :fields {}))]
     (when (contains? (get v :fields {}) property)
@@ -64,7 +64,13 @@
                           (seq locations) (assoc :locations locations)))))))
   (reduce merge
           {}
-          [{:fields (merge (get org :fields) (get v :fields))}
+          [(some->> (merge (get org :fields {}) (get v :fields {}))
+                    (#(if (not-empty %) % nil))
+                    (assoc {} :fields))
+           (some->> (into (get org :members []) (get v :members []))
+                    (vec)
+                    (#(if (not-empty %) % nil))
+                    (assoc {} :members))
            (some->> (into (get org :implements []) (get v :implements []))
                     (distinct)
                     (vec)
@@ -94,7 +100,7 @@
         (assoc m k v)
 
         (is-extension? v)
-        (update m k (partial merge-type-extension k v))
+        (update m k (partial merge-extension k v))
 
         (contains? m k)
         (let [locations (keepv meta [(get m k) v])]
@@ -405,6 +411,17 @@
          (common/copy-meta anyName)
          (apply-description description)
          (apply-directives directiveList))]))
+
+(defmethod xform :unionExtDef
+  [prod]
+  (let [{:keys [description anyName unionTypes directiveList]} (tag prod)]
+    (with-meta [[:unions (xform anyName)]
+                (-> {:members (xform unionTypes)}
+                    (common/copy-meta anyName)
+                    (common/add-meta extension-meta)
+                    (apply-description description)
+                    (apply-directives directiveList))]
+               extension-meta)))
 
 (defmethod xform :unionTypes
   [prod]

--- a/src/com/walmartlabs/lacinia/resolve.clj
+++ b/src/com/walmartlabs/lacinia/resolve.clj
@@ -59,7 +59,6 @@
 
     (some? error)
     (wrap-value value behavior (assert-error-map error))
-    (wrap-value value behavior (assert-error-map error))
 
     :else
     value))

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -184,7 +184,14 @@
   (is (= {:unions
           {:Matter
            {:members [:Solid :Liquid :Gas :Plasma :INPUT_OBJECT]}}}
-         (parse-string "union Matter = Solid | Liquid | Gas | Plasma | INPUT_OBJECT"))))
+         (parse-string "union Matter = Solid | Liquid | Gas | Plasma | INPUT_OBJECT")))
+
+  (testing "extensions"
+   (is (= {:unions
+           {:Matter
+            {:members [:Solid :Liquid :Gas :Plasma :INPUT_OBJECT]}}}
+          (parse-string (str "union Matter = Solid\n"
+                             "extend union Matter = Liquid | Gas | Plasma | INPUT_OBJECT"))))))
 
 (deftest schema-field-args
   (is (= {:objects
@@ -598,4 +605,3 @@
                                        :members [:File
                                                  :Directory]}}}
            schema))))
-


### PR DESCRIPTION
This adds support for Union extensions, as described in https://spec.graphql.org/June2018/#sec-Union-Extensions.


currently [master](https://github.com/walmartlabs/lacinia/commit/8289c32e4af9fbf73793894268140619dd79172e) adds a typo which prevents tests from being run, this PR also fixes that in 8ec4e9fe67e74653dfbb2e3bbe26356510ed6a52.

