### PR TITLE
fix `resolve-as` behaviour in subscriptions

### DIFF
--- a/dev-resources/subscriptions-schema.edn
+++ b/dev-resources/subscriptions-schema.edn
@@ -7,5 +7,7 @@
  :subscriptions
  {:logs
   {:type :LogEvent
-   :args {:severity {:type String}}
+   :args {:severity {:type String}
+          :fakeError {:type Boolean
+                      :default false}}
    :stream :stream-logs}}}


### PR DESCRIPTION
While testing out the latest performance improvements, and noticed that the global `:error` key wasn't working for subscriptions specifically. 27f251b00358197f7a75a7b8b4ba3e3671d5214a adds a test asserting the expected behaviour. Using `git bisect` I noticed the behaviour was happening since f6371f3bf3fc93d9f3623b6352bf0933bf198dc7.

As a 'quick fix' I reverted the change with f4a95981f6bf41e50e08f93cd02b8db3b25ff850 to fix the test; definitely open for suggestions though :) 