### PR TITLE
Restore support for ResolverResult passed to subscription stream callback

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -51,5 +51,5 @@
    :exec-fn codox.main/generate-docs
    :exec-args {:metadata {:doc/format :markdown}
                :name "com.walmartlabs/lacinia"
-               :version "1.1-alpha-5"
+               :version "1.1-alpha-5a"
                :description "Clojure-native implementation of GraphQL"}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -51,5 +51,5 @@
    :exec-fn codox.main/generate-docs
    :exec-args {:metadata {:doc/format :markdown}
                :name "com.walmartlabs/lacinia"
-               :version "1.1-alpha-4"
+               :version "1.1-alpha-5"
                :description "Clojure-native implementation of GraphQL"}}}}

--- a/dev-resources/subscriptions-schema.edn
+++ b/dev-resources/subscriptions-schema.edn
@@ -7,5 +7,7 @@
  :subscriptions
  {:logs
   {:type :LogEvent
-   :args {:severity {:type String}}
+   :args {:severity {:type String}
+          :fakeError {:type Boolean
+                      :default false}}
    :stream :stream-logs}}}

--- a/docs/subscriptions/streamer.rst
+++ b/docs/subscriptions/streamer.rst
@@ -81,7 +81,7 @@ the callback will be invoked asynchronously.
 Notes
 -----
 
-The value based to the source stream callback is normally a plain, non-nil value.
+The value passed to the source stream callback is normally a plain, non-nil value.
 
 It may be a wrapped value (e.g., via :api:`resolve/with-error`).
 This will be handled inside :api:`execute/execute-query` (which is invoked with the value passed to the callback).

--- a/docs/subscriptions/streamer.rst
+++ b/docs/subscriptions/streamer.rst
@@ -78,4 +78,15 @@ are converted to responses in the response stream.
 Likewise, when the subscription is closed (by either the client or by the streamer itself),
 the callback will be invoked asynchronously.
 
+Notes
+-----
+
+The value based to the source stream callback is normally a plain, non-nil value.
+
+It may be a wrapped value (e.g., via :api:`resolve/with-error`).
+This will be handled inside :api:`execute/execute-query` (which is invoked with the value passed to the callback).
+
+For historical reasons, it may also be a ResolverResult; it is the implementation's job to obtain
+the resolved value from this result before calling ``execute-query``; this is handled by lacinia-pedestal, for example.
+
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "1.1-alpha-5"
+(defproject com.walmartlabs/lacinia "1.1-alpha-5a"
   :description "A GraphQL server implementation in Clojure"
   :url "https://github.com/walmartlabs/lacinia"
   :license {:name "Apache, Version 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "1.1-alpha-4"
+(defproject com.walmartlabs/lacinia "1.1-alpha-5"
   :description "A GraphQL server implementation in Clojure"
   :url "https://github.com/walmartlabs/lacinia"
   :license {:name "Apache, Version 2.0"

--- a/src/com/walmartlabs/lacinia/resolve.clj
+++ b/src/com/walmartlabs/lacinia/resolve.clj
@@ -59,7 +59,6 @@
 
     (some? error)
     (wrap-value value behavior (assert-error-map error))
-    (wrap-value value behavior (assert-error-map error))
 
     :else
     value))


### PR DESCRIPTION
This was not previously documented, but has some valid use (such as `(resolve-as nil {...})` to indicate an error in the initial subscription query. Earlier changes in version 1.1 removed this support.

Fully fixing this requires changes to lacinia-pedestal as well: https://github.com/walmartlabs/lacinia-pedestal/tree/hls/wrapped-values-in-subscriptions

