### PR TITLE
Tutorial refresh

### DIFF
--- a/docs/_examples/tutorial/project-1.clj
+++ b/docs/_examples/tutorial/project-1.clj
@@ -1,6 +1,7 @@
 (defproject clojure-game-geek "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]])
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
+            :url "https://www.eclipse.org/legal/epl-2.0/"}
+  :dependencies [[org.clojure/clojure "1.10.3"]]
+  :repl-options {:init-ns clojure-game-geek.core})

--- a/docs/_examples/tutorial/project-2.clj
+++ b/docs/_examples/tutorial/project-2.clj
@@ -1,7 +1,9 @@
 (defproject clojure-game-geek "0.1.0-SNAPSHOT"
   :description "A tiny BoardGameGeek clone written in Clojure with Lacinia"
   :url "https://github.com/walmartlabs/clojure-game-geek"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.walmartlabs/lacinia "0.21.0"]])
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
+            :url "https://www.eclipse.org/legal/epl-2.0/"}
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [com.walmartlabs/lacinia "1.1-beta-1"]
+                 [io.aviso/logging "1.0"]]
+  :repl-options {:init-ns user})

--- a/docs/_examples/tutorial/project-3.clj
+++ b/docs/_examples/tutorial/project-3.clj
@@ -1,8 +1,9 @@
 (defproject clojure-game-geek "0.1.0-SNAPSHOT"
   :description "A tiny BoardGameGeek clone written in Clojure with Lacinia"
   :url "https://github.com/walmartlabs/clojure-game-geek"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.walmartlabs/lacinia-pedestal "0.5.0"]
-                 [io.aviso/logging "0.2.0"]])
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
+            :url "https://www.eclipse.org/legal/epl-2.0/"}
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [com.walmartlabs/lacinia-pedestal "1.1-alpha-1"]
+                 [io.aviso/logging "1.0"]]
+  :repl-options {:init-ns user})

--- a/docs/_examples/tutorial/project-4.clj
+++ b/docs/_examples/tutorial/project-4.clj
@@ -1,9 +1,10 @@
 (defproject clojure-game-geek "0.1.0-SNAPSHOT"
   :description "A tiny BoardGameGeek clone written in Clojure with Lacinia"
   :url "https://github.com/walmartlabs/clojure-game-geek"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.stuartsierra/component "0.3.2"]
-                 [com.walmartlabs/lacinia-pedestal "0.5.0"]
-                 [io.aviso/logging "0.2.0"]])
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
+            :url "https://www.eclipse.org/legal/epl-2.0/"}
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [com.stuartsierra/component "1.0.0"]
+                 [com.walmartlabs/lacinia-pedestal "1.1-alpha-1"]
+                 [io.aviso/logging "1.0"]]
+  :repl-options {:init-ns user})

--- a/docs/_examples/tutorial/project-5.clj
+++ b/docs/_examples/tutorial/project-5.clj
@@ -1,13 +1,14 @@
 (defproject clojure-game-geek "0.1.0-SNAPSHOT"
   :description "A tiny BoardGameGeek clone written in Clojure with Lacinia"
   :url "https://github.com/walmartlabs/clojure-game-geek"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [com.stuartsierra/component "0.3.2"]
-                 [com.walmartlabs/lacinia "0.30.0"]
-                 [com.walmartlabs/lacinia-pedestal "0.10.0"]
-                 [org.clojure/java.jdbc "0.7.8"]
-                 [org.postgresql/postgresql "42.2.5.jre7"]
-                 [com.mchange/c3p0 "0.9.5.2"]
-                 [io.aviso/logging "0.3.1"]])
+  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
+            :url "https://www.eclipse.org/legal/epl-2.0/"}
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [com.stuartsierra/component "1.0.0"]
+                 [com.walmartlabs/lacinia "1.1-beta-1"]
+                 [com.walmartlabs/lacinia-pedestal "1.1-alpha-1"]
+                 [org.clojure/java.jdbc "0.7.12"]
+                 [org.postgresql/postgresql "42.3.1"]
+                 [com.mchange/c3p0 "0.9.5.5"]
+                 [io.aviso/logging "1.0"]]
+  :repl-options {:init-ns user})

--- a/docs/_examples/tutorial/server-1.clj
+++ b/docs/_examples/tutorial/server-1.clj
@@ -9,7 +9,8 @@
   (start [this]
     (assoc this :server (-> schema-provider
                             :schema
-                            (lp/service-map {:graphiql true})
+                            (lp/service-map {:graphiql true
+                                             :host "0.0.0.0"})
                             http/create-server
                             http/start)))
 
@@ -21,5 +22,4 @@
   []
   {:server (component/using (map->Server {})
                             [:schema-provider])})
-
 

--- a/docs/_examples/tutorial/server-2.clj
+++ b/docs/_examples/tutorial/server-2.clj
@@ -10,6 +10,7 @@
     (assoc this :server (-> schema-provider
                             :schema
                             (lp/service-map {:graphiql true
+                                             :host "0.0.0.0"
                                              :port port})
                             http/create-server
                             http/start)))
@@ -22,5 +23,3 @@
   []
   {:server (component/using (map->Server {:port 8888})
                             [:schema-provider])})
-
-

--- a/docs/_examples/tutorial/user-3.clj
+++ b/docs/_examples/tutorial/user-3.clj
@@ -37,7 +37,8 @@
 (defn start-server
   [_]
   (let [server (-> schema
-                   (lp/service-map {:graphiql true})
+                   (lp/service-map {:graphiql true
+                                    :host "0.0.0.0"})
                    http/create-server
                    http/start)]
     (browse-url "http://localhost:8888/")

--- a/docs/tutorial/create-project.rst
+++ b/docs/tutorial/create-project.rst
@@ -28,7 +28,7 @@ Our first step is to fill in a few details, including the dependency on Lacinia:
 
 .. literalinclude:: /_examples/tutorial/project-2.clj
    :caption: project.clj
-   :emphasize-lines: 2,3,7
+   :emphasize-lines: 2,3,7-9
 
 Lacinia has just a few dependencies of its own:
 

--- a/docs/tutorial/database-1.rst
+++ b/docs/tutorial/database-1.rst
@@ -15,13 +15,10 @@ Dependency Changes
 
 .. literalinclude:: /_examples/tutorial/project-5.clj
    :caption: project.clj
-   :emphasize-lines: 6,8-
+   :emphasize-lines: 8,10-12
 
 We're bringing in the latest versions of lacinia and lacinia-pedestal available at the time
-this page was written (something we'll
-likely do almost every chapter).
-Since these are now based on Clojure 1.9, it's a fine time to upgrade
-to that.
+this page was updated (something we'll likely do almost every chapter).
 
 We're also adding several new dependencies for accessing a PostgreSQL database:
 

--- a/docs/tutorial/database-2.rst
+++ b/docs/tutorial/database-2.rst
@@ -15,7 +15,7 @@ if you don't know what queries are even executing.
 
 .. literalinclude:: /_examples/tutorial/db-4.clj
    :caption: src/clojure_game_geek/db.clj
-   :emphasize-lines: 4,35-40
+   :emphasize-lines: 4,6,35-40
    :lines: 1-40
 
 We've introduced our own version of ``clojure.java.jdbc/query`` with

--- a/docs/tutorial/game-data.rst
+++ b/docs/tutorial/game-data.rst
@@ -44,7 +44,7 @@ to provide only what is most essential, or truly useful and universal.
 
 Lacinia explicitly `does not` provide a single function to read, parse, attach resolvers, and compile an EDN file in a single
 line.
-That may seem odd -- it feels like very application will just cut-and-paste something virtually identical to ``load-schema``.
+That may seem odd -- it feels like every application will just cut-and-paste something virtually identical to ``load-schema``.
 
 In fact, not all schemas will come directly from a single EDN file.
 Because the schema is Clojure `data` it can be constructed, modified, merged, and otherwise transformed

--- a/docs/tutorial/init-schema.rst
+++ b/docs/tutorial/init-schema.rst
@@ -142,20 +142,20 @@ directly in the REPL: no web browser necessary!
 
 With all that in place, we can launch a REPL and try it out::
 
-  14:26:41 ~/workspaces/github/clojure-game-geek > lein repl
-  nREPL server started on port 56053 on host 127.0.0.1 - nrepl://127.0.0.1:56053
-  REPL-y 0.3.7, nREPL 0.2.12
-  Clojure 1.8.0
-  Java HotSpot(TM) 64-Bit Server VM 1.8.0_74-b02
+   14:26:41 ~/workspaces/github/clojure-game-geek > lein repl
+   nREPL server started on port 46737 on host 127.0.0.1 - nrepl://127.0.0.1:46737
+   REPL-y 0.5.1, nREPL 0.8.3
+   Clojure 1.10.3
+   OpenJDK 64-Bit Server VM 17.0.1+1
       Docs: (doc function-name-here)
             (find-doc "part-of-name-here")
-    Source: (source function-name-here)
+   Source: (source function-name-here)
    Javadoc: (javadoc java-object-or-class-here)
       Exit: Control+D or (exit) or (quit)
    Results: Stored in vars *1, *2, *3, an exception in *e
-  
-  user=> (q "{ game_by_id(id: \"foo\") { id name summary }}")
-  {:data #ordered/map ([:game_by_id nil])}
+
+   user=> (q "{ game_by_id(id: \"foo\") { id name summary }}")
+   {:data #ordered/map ([:game_by_id nil])}
 
 The value returned makes use of an ordered map.
 Again, that's part of the GraphQL

--- a/docs/tutorial/member-ratings.rst
+++ b/docs/tutorial/member-ratings.rst
@@ -72,6 +72,11 @@ Testing it Out
 --------------
 
 Back at the REPL, we can test out the new functionality.
+We need the server started after the component refactoring::
+
+   (start)
+   => :started
+
 First, select the rating summary data for a game::
 
    (q "{ game_by_id(id: \"1237\") { name rating_summary { count average }}}")

--- a/docs/tutorial/pedestal.rst
+++ b/docs/tutorial/pedestal.rst
@@ -13,7 +13,7 @@ Add Dependencies
 
 .. literalinclude:: /_examples/tutorial/project-3.clj
    :caption: project.clj
-   :emphasize-lines: 7-8
+   :emphasize-lines: 7
 
 We've added two libraries: ``lacinia-pedestal`` and ``io.aviso/logging``.
 We no longer need to list ``lacinia``, as that is a transitive dependency of ``lacinia-pedestal``. [#deps]_

--- a/docs/tutorial/testing-1.rst
+++ b/docs/tutorial/testing-1.rst
@@ -20,7 +20,7 @@ a different port.
 
 .. literalinclude:: /_examples/tutorial/server-2.clj
    :caption: src/clojure_game_geek/server.clj
-   :emphasize-lines: 6,12-13,23
+   :emphasize-lines: 6,12-14,24
 
 We've added a bit of configuration for the ``:server`` component, the port to bind to.
 This will make it possible for our test code to use a different port.


### PR DESCRIPTION
While doing the tutorial, I used the latest dependency versions and everything worked well with a few clarifications I needed.

I've updated the tutorial documentation with some minor corrections. Adding `{:host "0.0.0.0"}` proved necessary to access GraphiQL at http://localhost:8888/