### PR TITLE
Add explicit dependency on io.aviso/pretty

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,6 +11,7 @@
                 joda-time/joda-time {:mvn/version "2.10.13"}
                 com.walmartlabs/test-reporting {:mvn/version "1.1"}
                 io.aviso/logging {:mvn/version "1.0"}
+                io.aviso/pretty {:mvn/version "1.1"}
                 io.pedestal/pedestal.log {:mvn/version "0.5.9"}
                 org.clojure/test.check {:mvn/version "1.1.1"}
                 org.clojure/data.csv {:mvn/version "1.0.0"}


### PR DESCRIPTION
https://github.com/walmartlabs/lacinia/blob/master/src/com/walmartlabs/lacinia/trace.clj requires io.aviso.exception, which is transitively pulled in through io.aviso/logging, even though it is an explicit project dependency.