### PR TITLE
trace namespace depends on dev-only dependencies

### DIFF
--- a/src/com/walmartlabs/lacinia/validation/no_unused_fragments.clj
+++ b/src/com/walmartlabs/lacinia/validation/no_unused_fragments.clj
@@ -16,8 +16,7 @@
   {:no-doc true}
   (:require
     [clojure.set :as set]
-    [com.walmartlabs.lacinia.trace :refer [trace]]
-    [com.walmartlabs.lacinia.internal-utils  :refer [q cond-let]])
+    [com.walmartlabs.lacinia.internal-utils :refer [q cond-let]])
   (:import (clojure.lang PersistentQueue)))
 
 (defn ^:private all-fragments-used


### PR DESCRIPTION
I attempted to upgrade to Lacinia 1.1, but production builds do not work because the trace namespace depends on a dev-only dependency (io.aviso/pretty through io.aviso/logging), and the no_unused_fragments pulls in the trace namespace. As a quick fix, remove the unused require; going forward, it looks like io.aviso needs to be included as a non-dev dep. Not sure if this is the path that should be taken, so I am refraining from adding it.