### PR TITLE
Make ArgumentDef protocol support Directives

### DIFF
--- a/dev-resources/selection/argument-def-directive.sdl
+++ b/dev-resources/selection/argument-def-directive.sdl
@@ -1,0 +1,5 @@
+directive @non_negative on ARGUMENT_DEFINITION
+
+type Query {
+    sqrt(num: Float! @non_negative) : Float!
+}

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -791,7 +791,7 @@
                t)))))
 
 (defrecord ArgumentDef [arg-name compiled-schema type qualified-name root-type-name
-                        description directives default-value has-default-value? is-required?]
+                        description directives compiled-directives default-value has-default-value? is-required?]
 
   selection/ArgumentDef
 
@@ -807,21 +807,26 @@
   (root-type [_]
     (select-type compiled-schema root-type-name))
 
-  (root-type-name [_] root-type-name))
+  (root-type-name [_] root-type-name)
+
+  selection/Directives
+
+  (directives [_] compiled-directives))
 
 (defn ^:private compile-arg
   [arg-name arg-def]
   (let [arg-def' (-> (rewrite-type arg-def) map->ArgumentDef)
         has-default-value? (contains? arg-def :default-value)
         is-required? (and (= :non-null (get-nested arg-def' [:type :kind]))
-                       (not has-default-value?))]
-    (assoc arg-def'
-           :arg-name arg-name
-           :root-type-name (root-type-name arg-def')
-           ;; Older code used (contains? arg :default-value) but that doesn't work anymore
-           ;; with a record that has a default-value field, so ... even more fields.
-           :has-default-value? has-default-value?
-           :is-required? is-required?)))
+                          (not has-default-value?))]
+    (-> arg-def'
+        (assoc :arg-name arg-name
+               :root-type-name (root-type-name arg-def')
+               ;; Older code used (contains? arg :default-value) but that doesn't work anymore
+               ;; with a record that has a default-value field, so ... even more fields.
+               :has-default-value? has-default-value?
+               :is-required? is-required?)
+        compile-directives)))
 
 (defn ^:private is-null?
   [v]

--- a/src/com/walmartlabs/lacinia/selection.clj
+++ b/src/com/walmartlabs/lacinia/selection.clj
@@ -39,7 +39,7 @@
     "Returns a map of keyword name to [[ArgumentDef]], or nil."))
 
 (defprotocol ArgumentDef
-  "An argument definition, implements [[Type]] and [[QualifiedName]].")
+  "An argument definition, implements [[Type]], [[QualifiedName]] and [[Directives]].")
 
 (defprotocol Directive
 

--- a/test/com/walmartlabs/lacinia/parser/selection_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/selection_test.clj
@@ -321,6 +321,25 @@
             [:role "basic"]]
            @*facts))))
 
+(deftest access-to-argument-def-directives
+  (let [res (fn [context {:keys [num]} _]
+              (is (= [:non_negative] (-> context
+                                         executor/selection
+                                         selection/field
+                                         selection/argument-defs
+                                         :num
+                                         selection/directives
+                                         keys)))
+              (Math/sqrt num))
+        schema (-> "selection/argument-def-directive.sdl"
+                   io/resource
+                   slurp
+                   parse-schema
+                   (util/inject-resolvers {:Query/sqrt res})
+                   schema/compile)]
+    (is (= {:data {:sqrt (Math/sqrt 4.0)}}
+           (execute schema "{ sqrt(num: 4.0) }")))))
+
 (deftest directive-args
   (let [f (fn [context _ _]
             (let [limit (->> context


### PR DESCRIPTION
Add support for `Directives` to `ArgumentDef` so that field resolver functions can navigate from the `FieldSelection` instance returned by `com.walmartlabs.lacinia.executor/selection` to any directives placed on their arguments in the schema.