### PR TITLE
Add a compilation option to apply field directives to streamer functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 [Closed Issues](https://github.com/walmartlabs/lacinia/issues?q=is%3Aclosed+milestone%3A1.2)
 
+Subscription streamer functions can now be wrapped to implement field definition directives
+using a new schema compilation option.
+
 ## 1.1 -- 14 Jan 2022
 
 This release features some significant efficiency improvements inside Lacinia.

--- a/dev-resources/subscriptions-schema.edn
+++ b/dev-resources/subscriptions-schema.edn
@@ -1,4 +1,7 @@
-{:objects
+{:directive-defs
+ {:instrument {:locations #{:field-definition}}}
+
+ :objects
  {:LogEvent
   {:fields
    {:severity {:type String}
@@ -7,6 +10,14 @@
  :subscriptions
  {:logs
   {:type :LogEvent
+   :args {:severity {:type String}
+          :fakeError {:type Boolean
+                      :default false}}
+   :stream :stream-logs}
+
+  :directive_logs
+  {:type :LogEvent
+   :directives [{:directive-type :instrument}]
    :args {:severity {:type String}
           :fakeError {:type Boolean
                       :default false}}

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -447,12 +447,15 @@
 
 (s/def ::apply-field-directives fn?)
 
+(s/def ::apply-subscription-field-directives fn?)
+
 (s/def ::disable-checks? boolean?)
 
 (s/def ::compile-options (s/keys :opt-un [::default-field-resolver
                                           ::promote-nils-to-empty-list?
                                           ::enable-introspection?
                                           ::apply-field-directives
+                                          ::apply-subscription-field-directives
                                           ::disable-checks?
                                           ::disable-java-objects?]))
 
@@ -1324,6 +1327,19 @@
     (assoc field-def :resolve (wrap-resolver-to-ensure-resolver-result resolver')
                      :direct-fn direct-fn)))
 
+(defn ^:private prepare-field-streamer
+  [schema options field-def]
+  (let [{:keys [apply-subscription-field-directives]} options
+        {:keys [compiled-directives]} field-def
+        streamer (:stream field-def)
+        streamer' (when (and streamer
+                             apply-subscription-field-directives
+                             (seq compiled-directives))
+                    (apply-subscription-field-directives (assoc field-def :compiled-schema schema) streamer))]
+    (if streamer'
+      (assoc field-def :stream streamer')
+      field-def)))
+
 ;;-------------------------------------------------------------------------------
 ;; ## Compile schema
 
@@ -1750,6 +1766,15 @@
   (map-types schema :object
              #(prepare-resolvers-in-object schema % options)))
 
+(defn ^:private prepare-streamers-in-object
+  [schema object-def options]
+  (update-fields-in-object object-def #(prepare-field-streamer schema options %)))
+
+(defn ^:private prepare-field-streamers
+  [schema options]
+  (map-types schema :object
+             #(prepare-streamers-in-object schema % options)))
+
 (defn ^:private inject-null-collapsers
   [schema]
   (reduce (fn [schema' kind]
@@ -1904,6 +1929,7 @@
         inject-null-collapsers
         ;; Last so that schema is as close to final and verified state as possible
         (prepare-field-resolvers options)
+        (prepare-field-streamers options)
         map->CompiledSchema)))
 
 (defn default-field-resolver
@@ -1980,6 +2006,14 @@
 
     The callback should be aware that the base resolver function may return a raw value, or a [[ResolverResult]].
     Generally, this option is used with the [[wrap-resolver-result]] function.
+
+    This processing occurs at the very end of schema compilation.
+
+  :apply-subscription-field-directives
+  : An optional callback function; for subscription fields that have any directives on the field definition,
+    the callback is invoked; it is passed the [[FieldDef]] (from which directives may be extracted)
+    and the streamer function from the subscription definition.
+    The callback may return a new streamer function, or return nil to use the existing streamer function.
 
     This processing occurs at the very end of schema compilation.
 


### PR DESCRIPTION
Resolver functions can be preprocessed during compilation of the schema using the option `:apply-field-directives`.  Add a new option `:apply-subscription-field-directives` to allow streamer functions to be preprocessed in the same way.