### PR TITLE
Providing a scalar value to an argument of type non-null list ends up with the scalar values wrapped as lists

### DIFF
--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -634,8 +634,8 @@
 (defmethod process-dynamic-argument :array
   [schema argument-definition arg]
   ;; Sneaky: strip off the outer layer of `(list T)` or `(non-null (list T))` to be just `T`:
-  (let [argument-definition' (cond-> (update argument-definition :type :type)
-                               (non-null-kind? argument-definition) (update :type :type))
+  (let [argument-definition' (cond-> (use-nested-type argument-definition)
+                               (non-null-kind? argument-definition) use-nested-type)
         extractors (mapv #(process-dynamic-argument schema argument-definition' %)
                          ;; The list of values for the array argument
                          (second arg))]

--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -633,8 +633,9 @@
 
 (defmethod process-dynamic-argument :array
   [schema argument-definition arg]
-  ;; Sneaky: strip off the outer layer of `(list T)` to be just `T`:
-  (let [argument-definition' (update argument-definition :type :type)
+  ;; Sneaky: strip off the outer layer of `(list T)` or `(non-null (list T))` to be just `T`:
+  (let [argument-definition' (cond-> (update argument-definition :type :type)
+                               (non-null-kind? argument-definition) (update :type :type))
         extractors (mapv #(process-dynamic-argument schema argument-definition' %)
                          ;; The list of values for the array argument
                          (second arg))]

--- a/test/com/walmartlabs/lacinia/arguments_test.clj
+++ b/test/com/walmartlabs/lacinia/arguments_test.clj
@@ -117,3 +117,23 @@
                                    :line 1}]
                       :message "Argument `s' is required, but no value was provided."}]}
            (execute schema "query($s : String) { echo(input: $s) }" {:s nil} nil)))))
+
+(deftest non-null-list-type-argument-with-variable
+  (let [schema (schema/compile {:queries
+                                {:echo
+                                 {:type :String
+                                  :args {:input {:type '(non-null (list (non-null Int)))}}
+                                  :resolve (fn [_ args _]
+                                             (str "Echo: " (:input args)))}}})]
+    (is (= {:data {:echo "Echo: [1]"}}
+           (execute schema "query($n : Int!) { echo(input: [$n]) }" {:n 1} nil)))
+
+    (is (= {:data {:echo "Echo: [1]"}}
+           (execute schema "query($n : Int!) { echo(input: $n) }" {:n 1} nil)))
+
+    (is (= {:data {:echo "Echo: [1 2]"}}
+           (execute schema "query($n1 : Int!, $n2 : Int!) { echo(input: [$n1, $n2]) }" {:n1 1 :n2 2} nil)))
+
+    (is (= {:data {:echo "Echo: [1 2]"}}
+           (execute schema "query($n1 : Int!, $n2 : Int!) { ... echo }
+                            fragment echo on Query { echo(input: [$n1, $n2]) }" {:n1 1 :n2 2} nil)))))


### PR DESCRIPTION
A bug occurs when dynamically inserting scalar variables into arguments of non-null list type.

```clojure
;; example
(let [schema (schema/compile {:queries
                              {:echo
                               {:type :String
                                :args {:input {:type '(non-null (list (non-null Int)))}}
                                :resolve (fn [_ args _]
                                           (str "Echo: " (:input args)))}}})]
  (execute schema "query($n1 : Int!, $n2 : Int!) { echo(input: [$n1, $n2]) }" {:n1 1 :n2 2} nil))

;; => {:data {:echo "Echo: [[1] [2]]"}} (unexpected, but current results)
;; => {:data {:echo "Echo: [1 2]"}} (expected)
```

This is caused by one less stripping of the `argument-definition` in the `process-dynamic-argument` method (when dispatch value is :array). In the case of `(non-null (list T))` argument type, there is one more level of `:kind :non-null` in argument-definition, so it has to be stripped twice.

I modified the `process-dynamic-argument` method so that the correct value is provided to the argument of non-null list type and added tests.