### PR TITLE
Do not coerce nil into empty vector when an argument type is list and null is given

### DIFF
--- a/src/com/walmartlabs/lacinia/parser.clj
+++ b/src/com/walmartlabs/lacinia/parser.clj
@@ -359,8 +359,10 @@
       (throw-exception "Provided argument value is an array, but the argument is not a list.")
 
       :list
-      (let [fake-argument-def (use-nested-type argument-definition)]
-        (mapv #(process-literal-argument schema fake-argument-def %) arg-value)))))
+      ;; if arg-value is nil, should return nil (no coercion is required)
+      (when (some? arg-value)
+        (let [fake-argument-def (use-nested-type argument-definition)]
+          (mapv #(process-literal-argument schema fake-argument-def %) arg-value))))))
 
 (defn ^:private decapitalize
   [s]

--- a/test/com/walmartlabs/lacinia/arguments_test.clj
+++ b/test/com/walmartlabs/lacinia/arguments_test.clj
@@ -117,3 +117,30 @@
                                    :line 1}]
                       :message "Argument `s' is required, but no value was provided."}]}
            (execute schema "query($s : String) { echo(input: $s) }" {:s nil} nil)))))
+
+(deftest scalar-is-coerced-into-vector-when-arg-type-is-list
+  (let [schema (schema/compile {:queries
+                                {:echo
+                                 {:type '(list (non-null Int))
+                                  :args {:input {:type '(list (non-null Int))}}
+                                  :resolve (fn [_ args _]
+                                             (:input args))}}})]
+
+    (is (= {:data {:echo [1]}}
+           (execute schema "query { echo (input: 1) }" nil nil)))
+
+    (is (= {:data {:echo [1]}}
+           (execute schema "query($s: Int) { echo (input: $s) }" {:s 1} nil)))))
+
+(deftest null-is-not-coerced-into-vector-when-arg-type-is-list
+  (let [schema (schema/compile {:queries
+                                {:echo
+                                 {:type '(list (non-null Int))
+                                  :args {:input {:type '(list (non-null Int))}}
+                                  :resolve (fn [_ args _]
+                                             (:input args))}}})]
+    (is (= {:data {:echo nil}}
+           (execute schema "query { echo(input: null) }" nil nil)))
+
+    (is (= {:data {:echo nil}}
+           (execute schema "query($s: Int) { echo(input: $s) }" {:s nil} nil)))))

--- a/test/com/walmartlabs/lacinia_test.clj
+++ b/test/com/walmartlabs/lacinia_test.clj
@@ -116,9 +116,9 @@
       (let [q "query { echoArgs (integerArray: [1 null 3], inputObject: {string: null}) { integerArray inputObject  } }"]
         (is (= {:data {:echoArgs {:integerArray [1 nil 3] :inputObject (pr-str {:string nil})}}}
                (execute default-schema q {} nil)))))
-    (testing "null list/object values become null-ish"
+    (testing "null list/object values become null"
       (let [q "query { echoArgs (integerArray: null, inputObject: null) { integerArray inputObject } }"]
-        (is (= {:data {:echoArgs {:integerArray []
+        (is (= {:data {:echoArgs {:integerArray nil
                                   :inputObject "nil"}}}
                (execute default-schema q {} nil)))))))
 
@@ -624,6 +624,6 @@
                   integerArray
                }
              }"]
-      (is (= {:data {:echoArgs {:integerArray []}}}
+      (is (= {:data {:echoArgs {:integerArray nil}}}
              (execute default-schema q nil nil))
-          "should coerce null to an empty array"))))
+          "shouldn't coerce null to an empty array"))))


### PR DESCRIPTION
Hi team!

Currently, when literal `null` is passed as an input to a `List` type argument, it gets coerced into an empty vector, which is incorrect. 

```clojure
(let [schema (schema/compile {:queries
                                {:echo
                                 {:type :String
                                  :args {:input {:type '(list (non-null Int))}}
                                  :resolve (fn [_ args _]
                                             (str "Echo: " (:input args)))}}})]
    (execute schema "query { echo(input: null) }" nil nil))
=> {:data #ordered/map([:echo "Echo: []"])}
```
(The example format is borrowed from @duddlf23 's one :) )

However, according to https://spec.graphql.org/October2021/#sec-List.Input-Coercion, the input value should be coerced to list only if it is "not a list and not a null". So the correct result of the coercion should be `nil` in this case.

This is because the `mapv` function returns an empty vector when its input is `nil`. In the body of the multimethod `process-literal-argument :array`, `mapv` is called even if the arg-value is `nil`.  https://github.com/walmartlabs/lacinia/blob/3f3ca1eb5b4e8baef48ad56ab661739cda0dd8fb/src/com/walmartlabs/lacinia/parser.clj#L363

This PR fixes `process-literal-argument` to return `nil` by not passing the `arg-value` to `mapv` if it is `nil`.

Co-authored-by: Hyunwoo Nam <namenu@gmail.com>