### PR TITLE
Fix behaviour for default executor

### DIFF
--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -68,10 +68,12 @@
                                  (^Thread newThread [_ ^Runnable runnable]
                                    (Thread. runnable
                                             (format "GraphQL Executor #%d" (swap! *thread-id inc)))))]
-    (ThreadPoolExecutor. (int 0) (int 10)
-                         1 TimeUnit/SECONDS
-                         queue
-                         factory)))
+    (doto
+      (ThreadPoolExecutor. (int 10) (int 10)
+                           1 TimeUnit/SECONDS
+                           queue
+                           factory)
+      (.allowCoreThreadTimeOut true))))
 
 (def ^:private graphql-identifier #"(?ix) _* [a-z] [a-z0-9_]*")
 


### PR DESCRIPTION
With zero corePoolSize and unlimited queue it doesn't increase the pool size and it keep using one single thread. If the intention was an unlimited queue with limited thread usage and keepAlive functionality with zero minimal thread then this change looks right for that.