### PR TITLE
Add support for @deprecated directives on :argument-definition, :input-field-definition

### DIFF
--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1878,7 +1878,7 @@
                   (map-kvs compile-directive-args
                     (assoc directive-defs
                       :deprecated {:args {:reason {:type 'String}}
-                                   :locations #{:enum-value :field-definition :input-field-definition}})))))
+                                   :locations #{:argument-definition :enum-value :field-definition :input-field-definition}})))))
 
 (defn ^:private validate-directives-by-category
   [schema category]

--- a/src/com/walmartlabs/lacinia/schema.clj
+++ b/src/com/walmartlabs/lacinia/schema.clj
@@ -1878,7 +1878,7 @@
                   (map-kvs compile-directive-args
                     (assoc directive-defs
                       :deprecated {:args {:reason {:type 'String}}
-                                   :locations #{:field-definition :enum-value}})))))
+                                   :locations #{:enum-value :field-definition :input-field-definition}})))))
 
 (defn ^:private validate-directives-by-category
   [schema category]

--- a/test/com/walmartlabs/lacinia/directives_test.clj
+++ b/test/com/walmartlabs/lacinia/directives_test.clj
@@ -349,7 +349,8 @@
   (directive-test
     "Directive @deprecated on union `Ebb' is not applicable."
     {:allowed-locations #{:enum-value
-                          :field-definition}
+                          :field-definition
+                          :input-field-definition}
      :directive-type :deprecated
      :union :Ebb}
     {:objects
@@ -375,7 +376,8 @@
   (directive-test
     "Directive @deprecated on scalar `Ebb' is not applicable."
     {:allowed-locations #{:enum-value
-                          :field-definition}
+                          :field-definition
+                          :input-field-definition}
      :directive-type :deprecated
      :scalar :Ebb}
     {:scalars
@@ -493,6 +495,18 @@
     (is (= true
            (get-in schema [:Account :fields :id :deprecated])))))
 
+(deftest can-deprecate-input-fields
+  (let [schema (schema/compile
+                 {:input-objects
+                  {:Character
+                   {:description "A character"
+                    :fields {:name {:type '(non-null String)
+                                    :description "Character name"}
+                             :weapon {:type '(non-null String)
+                                      :directives [{:directive-type :deprecated}]
+                                      :description "Weapon of choice"}}}}})]
+    ;; Exception is not thrown
+    (is (any? schema))))
 
 (deftest can-deprecate-enum-values
   (let [schema (schema/compile

--- a/test/com/walmartlabs/lacinia/directives_test.clj
+++ b/test/com/walmartlabs/lacinia/directives_test.clj
@@ -348,7 +348,8 @@
 (deftest union-directive-inapplicable
   (directive-test
     "Directive @deprecated on union `Ebb' is not applicable."
-    {:allowed-locations #{:enum-value
+    {:allowed-locations #{:argument-definition
+                          :enum-value
                           :field-definition
                           :input-field-definition}
      :directive-type :deprecated
@@ -375,7 +376,8 @@
 (deftest scalar-directive-inapplicable
   (directive-test
     "Directive @deprecated on scalar `Ebb' is not applicable."
-    {:allowed-locations #{:enum-value
+    {:allowed-locations #{:argument-definition
+                          :enum-value
                           :field-definition
                           :input-field-definition}
      :directive-type :deprecated


### PR DESCRIPTION
Hi Walmart Labs,

While the @deprecated annotation is suported for enum values and type fields, it was not supported for input field definitions. GraphQL @deprecated directives are also valid on Input types in the most recent [Working Draft of the GraphQL Spec](http://spec.graphql.org/draft/#sec--deprecated).