### PR TITLE
Fix runtime error when aggregating results with error-containing left-value

### DIFF
--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -181,9 +181,16 @@
   is an ResultTuple."
   [left-value right-value]
   (if (su/is-result-tuple? right-value)
-    (let [{:keys [alias value]} right-value]
-      (if (contains? left-value alias)
+    (let [{:keys [alias value]} right-value
+          left-alias-value (alias left-value)]
+      (cond
+        (= left-alias-value :com.walmartlabs.lacinia.schema/null)
+        left-value
+
+        (map? left-alias-value)
         (update left-value alias deep-merge-value value)
+
+        :else
         (assoc left-value alias value)))
     (deep-merge left-value right-value)))
 


### PR DESCRIPTION
The query below causes an infinite wait when executed.

```graphql
query HangingQuery($id: ID!) {
  node(id: $id) {
    ... on Post {
      ... on Post {
        author {
          alwaysError
        }
      }
      author {
        name
      }
    }
  }
}
```

On the other hand, if you reverse the order of the field declarations, it will not.

```graphql
query HangingQuery($id: ID!) {
  node(id: $id) {
    ... on Post {
      author {
        name
      }
      ... on Post {      # change the order
        author {
          alwaysError
        }
      }
    }
  }
}
```

It's worth noting that the fragment must be used to reproduce the error.

I guess in the process of doing `merge-selected-values`,
even though the left-value value is nil (which is resolved by alwaysError),
`update` to nil is called (which cause runtime error).

This PR fixes this issue.