### PR TITLE
Fix error when merging lists in fragments

### DIFF
--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -17,7 +17,7 @@
   (:require
     [com.walmartlabs.lacinia.internal-utils
      :refer [cond-let q to-message
-             deep-merge deep-merge-value keepv get-nested]]
+             deep-merge keepv get-nested]]
     [flatland.ordered.map :refer [ordered-map]]
     [com.walmartlabs.lacinia.select-utils :as su]
     [com.walmartlabs.lacinia.resolve-utils :refer [transform-result aggregate-results]]
@@ -183,7 +183,7 @@
   (if (su/is-result-tuple? right-value)
     (let [{:keys [alias value]} right-value]
       (if (contains? left-value alias)
-        (update left-value alias deep-merge-value value)
+        (update left-value alias deep-merge value)
         (assoc left-value alias value)))
     (deep-merge left-value right-value)))
 
@@ -611,5 +611,3 @@
   (let [{:keys [root selections]} parsed-query]
     {constants/parsed-query-key parsed-query
      constants/selection-key (->RootSelections root selections)}))
-
-

--- a/src/com/walmartlabs/lacinia/internal_utils.clj
+++ b/src/com/walmartlabs/lacinia/internal_utils.clj
@@ -407,27 +407,21 @@
            nil
           coll))
 
-(declare deep-merge)
-
-(defn deep-merge-value
+(defn deep-merge
+  "Merges two maps together.  Later map override earlier.
+  If a key is sequential, then each element in the list is merged."
   [left right]
   (cond
     (and (map? left) (map? right))
-    (deep-merge left right)
+    (merge-with deep-merge left right)
 
     (and (sequential? left) (sequential? right))
     (mapv deep-merge left right)
 
-  (or (map? right) (sequential? right))
+    (or (map? right) (sequential? right))
     (throw (ex-info "unable to deep merge"
                     {:left left
                      :right right}))
 
     :else
     right))
-
-(defn deep-merge
-  "Merges two maps together.  Later map override earlier.
-  If a key is sequential, then each element in the list is merged."
-  [left-value right-value]
-  (merge-with deep-merge-value left-value right-value))

--- a/test/com/walmartlabs/lacinia/merge_selections_test.clj
+++ b/test/com/walmartlabs/lacinia/merge_selections_test.clj
@@ -152,3 +152,18 @@ query ($who : String) {
     }
   }
 }"))))
+
+(deftest merge-list-in-fragment
+  (is (= {:data {:luke {:name "Luke Skywalker"
+                        :appears_in [:NEWHOPE :EMPIRE :JEDI]}}}
+         (q "
+{
+  luke: human(id: \"1000\") {
+    name
+    appears_in
+    ...props
+  }
+}
+fragment props on human {
+  appears_in
+}"))))


### PR DESCRIPTION
We noticed some exceptions being thrown after upgrading from 0.38.0 to 1.0

It seemed that when there is a list field both on an object and in a fragment, lacinia was attempting to do a map merge on the lists.

I've added a test which simulates the problem we had, and modified internal-utils/deep-merge so that it works on maps, sequentials and any other values.