### PR TITLE
tracing-tests hangs on Java 21

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -8,14 +8,17 @@ on:
       - master
 jobs:
   build:
+    strategy:
+      matrix:
+        java-version: ["11", "17", "21"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: ${{ matrix.java-version }}
           distribution: 'corretto'
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@10.2
@@ -23,7 +26,7 @@ jobs:
           cli: 1.11.1.1165
 
       - name: Cache clojure dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/test/com/walmartlabs/lacinia/tracing_test.clj
+++ b/test/com/walmartlabs/lacinia/tracing_test.clj
@@ -26,6 +26,8 @@
     [com.walmartlabs.lacinia.tracing :as tracing]
     [com.walmartlabs.lacinia.schema :as schema]))
 
+(set! *warn-on-reflection* true)
+
 (def ^:private enable-timing  (tracing/enable-tracing nil))
 
 ;; Used to convert nanos to millis
@@ -41,7 +43,7 @@
   [_ _ value]
   (let [resolved-value (resolve/resolve-promise)
         f (fn []
-            (Thread/sleep (::delay value))
+            (Thread/sleep ^long (::delay value))
             (resolve/deliver! resolved-value (::slow value)))
         thread (Thread. ^Runnable f)]
     (.start thread)


### PR DESCRIPTION
`com.walmartlabs.lacinia.tracing-test` hangs with following errors.

```
Exception in thread "Thread-4" Exception in thread "Thread-5" java.lang.IllegalArgumentException: No matching method sleep found taking 1 args
        at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:154)
        at clojure.lang.Reflector.invokeStaticMethod(Reflector.java:332)
        at com.walmartlabs.lacinia.tracing_test$resolve_slow$f__22220.invoke(tracing_test.clj:44)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.base/java.lang.Thread.run(Thread.java:1583)
java.lang.IllegalArgumentException: No matching method sleep found taking 1 args
        at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:154)
        at clojure.lang.Reflector.invokeStaticMethod(Reflector.java:332)
        at com.walmartlabs.lacinia.tracing_test$resolve_slow$f__22220.invoke(tracing_test.clj:44)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

Since Java 20 introcuded overloaded Thread/sleep with 1 arg, you need to add a type hint in your clojure code.
