### PR TITLE
Fixes a runtime error that occurs when deep-merging fragments

### DIFF
--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -182,7 +182,7 @@
   [left-value right-value]
   (if (su/is-result-tuple? right-value)
     (let [{:keys [alias value]} right-value
-      left-alias-value (alias left-value)]
+          left-alias-value (alias left-value)]
       (cond
         (= left-alias-value :com.walmartlabs.lacinia.schema/null)
         left-value

--- a/src/com/walmartlabs/lacinia/internal_utils.clj
+++ b/src/com/walmartlabs/lacinia/internal_utils.clj
@@ -420,9 +420,6 @@
     (null? left)
     left
 
-    (null? right)
-    right
-
     (and (map? left) (map? right))
     (merge-with deep-merge left right)
 

--- a/src/com/walmartlabs/lacinia/internal_utils.clj
+++ b/src/com/walmartlabs/lacinia/internal_utils.clj
@@ -407,11 +407,22 @@
            nil
           coll))
 
+(defn- null?
+  [v]
+  (or (nil? v)
+      (= v :com.walmartlabs.lacinia.schema/null)))
+
 (defn deep-merge
   "Merges two maps together.  Later map override earlier.
   If a key is sequential, then each element in the list is merged."
   [left right]
   (cond
+    (null? left)
+    left
+
+    (null? right)
+    right
+
     (and (map? left) (map? right))
     (merge-with deep-merge left right)
 

--- a/test/com/walmartlabs/lacinia/internal_utils_tests.clj
+++ b/test/com/walmartlabs/lacinia/internal_utils_tests.clj
@@ -16,7 +16,8 @@
   (:require
     [clojure.test :refer [deftest testing is]]
     [com.walmartlabs.lacinia.internal-utils :refer [assoc-in! update-in! deep-merge]]
-    [clojure.string :as str])
+    [clojure.string :as str]
+    [flatland.ordered.map :refer [ordered-map]])
   (:import
     (clojure.lang ExceptionInfo)))
 
@@ -65,54 +66,18 @@
            (ex-data e)))))
 
 (deftest test-deep-merge
-  (testing "Basic map merge"
-    (is (= (deep-merge {:a 1} {:b 2})
-           {:a 1, :b 2}))
-    (is (= (deep-merge {:a 1} {:a 2})
-           {:a 2})))
+  (= (ordered-map [[:author :com.walmartlabs.lacinia.schema/null]])
+     (deep-merge
+       (ordered-map [[:author (ordered-map [[:name "John Doe"]])]])
+       (ordered-map [[:author :com.walmartlabs.lacinia.schema/null]]))
+     (deep-merge
+       (ordered-map [[:author :com.walmartlabs.lacinia.schema/null]])
+       (ordered-map [[:author (ordered-map [[:name "John Doe"]])]])))
 
-  (testing "Nested map merge"
-    (is (= (deep-merge {:a {:b 1}} {:a {:c 2}})
-           {:a {:b 1, :c 2}}))
-    (is (= (deep-merge {:a {:b 1}} {:a {:b 2}})
-           {:a {:b 2}})))
-
-  (testing "Mixed map and sequential"
-    (is (thrown-with-msg? ExceptionInfo #"unable to deep merge"
-                          (deep-merge {:a 1} [1 2 3])))
-    (is (thrown-with-msg? ExceptionInfo #"unable to deep merge"
-                          (deep-merge [1 2 3] {:a 1}))))
-
-  #_(testing "Merge with nil values"
-    (is (thrown-with-msg? ExceptionInfo #"unable to deep merge" (deep-merge {:a 1} nil)
-           {:a 1}))
-    (is (thrown-with-msg? ExceptionInfo #"unable to deep merge" (deep-merge nil {:a 1})
-           {:a 1})))
-
-  (testing "Merging with :com.walmartlabs.lacinia.schema/null values"
-    (is (= (deep-merge {:a 1} :com.walmartlabs.lacinia.schema/null)
-           :com.walmartlabs.lacinia.schema/null))
-    (is (= (deep-merge :com.walmartlabs.lacinia.schema/null {:a 1})
-           :com.walmartlabs.lacinia.schema/null))
-    (is (= (deep-merge :com.walmartlabs.lacinia.schema/null :com.walmartlabs.lacinia.schema/null)
-           :com.walmartlabs.lacinia.schema/null)))
-
-  (testing "Merging with empty maps"
-    (is (= (deep-merge {} {:a 1})
-           {:a 1}))
-    (is (= (deep-merge {:a 1} {})
-           {:a 1})))
-
-  (testing "Complex nested structures"
-    (is (= (deep-merge {:a {:b [1 2]}} {:a {:b [3 4]}})
-           {:a {:b [3 4]}}))
-    (is (= (deep-merge {:a [{:b 1} {:c 2}]} {:a [{:d 3} {:e 4}]})
-           {:a [{:b 1, :d 3} {:c 2, :e 4}]})))
-
-  (testing "Nested :com.walmartlabs.lacinia.schema/null values"
-    (is (= (deep-merge {:a {:b :com.walmartlabs.lacinia.schema/null}} {:a {:b 1}})
-           {:a {:b :com.walmartlabs.lacinia.schema/null}}))
-    (is (= (deep-merge {:a {:b 1}} {:a {:b :com.walmartlabs.lacinia.schema/null}})
-           {:a {:b :com.walmartlabs.lacinia.schema/null}}))
-    (is (= (deep-merge {:a {:b :com.walmartlabs.lacinia.schema/null, :c 2}} {:a {:b 1, :c :com.walmartlabs.lacinia.schema/null}})
-           {:a {:b :com.walmartlabs.lacinia.schema/null, :c :com.walmartlabs.lacinia.schema/null}}))))
+  (= (ordered-map [[:author nil]])
+     (deep-merge
+       (ordered-map [[:author (ordered-map [[:name "John Doe"]])]])
+       (ordered-map [[:author nil]]))
+     (deep-merge
+       (ordered-map [[:author nil]])
+       (ordered-map [[:author (ordered-map [[:name "John Doe"]])]]))))


### PR DESCRIPTION
Depending on the position of the fragment, you'll get inconsistent values.

I fixed a similar issue in #453, but in that case the fragment was nested, whereas this case is not.

This fails:
```graphql
query MyQuery {
  node(id: "1000") {
    ... on Post {
      id
      ...PostFragment
    }
  }
}

fragment PostFragment on Post {
  author {
    alwaysFail
  }
  ...PostFragment2   # <--
}

fragment PostFragment2 on Post {
  author {
    name
  }
}
```

While this is not:
```graphql
query MyQuery {
  node(id: "1000") {
    ... on Post {
      id
      ...PostFragment
    }
  }
}

fragment PostFragment on Post {
  ...PostFragment2   # <--
  author {
    alwaysFail
  }
}

fragment PostFragment2 on Post {
  author {
    name
  }
}
```

The reason seems to be that deep-merge is not commutative.
Given one of arguments is`nil` or `::null`, exception is thrown.
