### PR TITLE
Support leading Pipes in Union Synatx

### DIFF
--- a/resources/com/walmartlabs/lacinia/schema.g4
+++ b/resources/com/walmartlabs/lacinia/schema.g4
@@ -118,7 +118,7 @@ unionExtDef
   ;
 
 unionTypes
-  : (anyName '|')* anyName
+  : '|'? ( anyName '|')* anyName
   ;
 
 enumDef

--- a/test/com/walmartlabs/lacinia/parser/schema_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/schema_test.clj
@@ -181,17 +181,25 @@
          (parse-string "interface Flow { ebb : String }"))))
 
 (deftest schema-union
-  (is (= {:unions
-          {:Matter
-           {:members [:Solid :Liquid :Gas :Plasma :INPUT_OBJECT]}}}
-         (parse-string "union Matter = Solid | Liquid | Gas | Plasma | INPUT_OBJECT")))
+
+  (testing "basic union type"
+    (is (= {:unions
+            {:Matter
+             {:members [:Solid :Liquid :Gas :Plasma :INPUT_OBJECT]}}}
+           (parse-string "union Matter = Solid | Liquid | Gas | Plasma | INPUT_OBJECT"))))
+
+  (testing "leading pipe chars in union"
+    (is (= {:unions
+            {:Matter
+             {:members [:Solid :Liquid :Gas :Plasma :INPUT_OBJECT]}}}
+           (parse-string "union Matter = | Solid | Liquid | Gas | Plasma | INPUT_OBJECT"))))
 
   (testing "extensions"
-   (is (= {:unions
-           {:Matter
-            {:members [:Solid :Liquid :Gas :Plasma :INPUT_OBJECT]}}}
-          (parse-string (str "union Matter = Solid\n"
-                             "extend union Matter = Liquid | Gas | Plasma | INPUT_OBJECT"))))))
+    (is (= {:unions
+            {:Matter
+             {:members [:Solid :Liquid :Gas :Plasma :INPUT_OBJECT]}}}
+           (parse-string (str "union Matter = Solid\n"
+                              "extend union Matter = Liquid | Gas | Plasma | INPUT_OBJECT"))))))
 
 (deftest schema-field-args
   (is (= {:objects


### PR DESCRIPTION
This change adds support for leading pipe values in union definitions. This was added to GraphQL in 2017.

This should address issue #465.