### PR TITLE
Fix unicode unescape behavior affected by sequential replace

### DIFF
--- a/src/com/walmartlabs/lacinia/parser/common.clj
+++ b/src/com/walmartlabs/lacinia/parser/common.clj
@@ -54,8 +54,12 @@
   (-> v
       ;; Because of how parsing works, the string literal includes the enclosing quotes
       (subs 1 (dec (.length v)))
-      (str/replace #"\\([\\\"\/bfnrt])" #(unescape-ascii (second %)))
-      (str/replace #"\\u([A-Fa-f0-9]{4})" #(unescape-unicode (second %)))))
+      (str/replace #"\\(\\|u[A-Fa-f0-9]{4}|[\"\/bfnrt])"
+                   #(let [s (second %)]
+                      (cond
+                        (= s "\\") "\\"
+                        (= (first s) \u) (unescape-unicode (subs s 1))
+                        :else (unescape-ascii s))))))
 
 (defn ^:private indent-of
   [s]

--- a/test/com/walmartlabs/lacinia/parser/query_test.clj
+++ b/test/com/walmartlabs/lacinia/parser/query_test.clj
@@ -73,7 +73,12 @@
   (testing "unicode"
     (is (= {:id "1138"
             :newHomePlanet "❄ＨＯＴＨ❄"}
-           (args "mutation { changeHeroHomePlanet(id: \"1138\", newHomePlanet: \"\\u2744\\uff28\\uff2f\\uff34\\uff28\\u2744\") {name}}")))))
+           (args "mutation { changeHeroHomePlanet(id: \"1138\", newHomePlanet: \"\\u2744\\uff28\\uff2f\\uff34\\uff28\\u2744\") {name}}"))))
+
+  (testing "not unicode"
+    (is (= {:id "1139"
+            :newHomePlanet "\\u2744\\uff28\\uff2f\\uff34\\uff28\\u2744"}
+           (args "mutation { changeHeroHomePlanet(id: \"1139\", newHomePlanet: \"\\\\u2744\\\\uff28\\\\uff2f\\\\uff34\\\\uff28\\\\u2744\") {name}}")))))
 
 (deftest query-reserved-word
   ;; Use 'query', 'mutation', and 'subscription' in various unusual places.


### PR DESCRIPTION
I believe there is an issue in the unicode unescape logic.

The current implementation performs two replace operations sequentially, where the second replacement may be affected by the result of the first one. This can lead to incorrect behavior in certain cases.

I'm not sure whether this behavior was intentional. Looking through the commit history, it appears the implementation has been this way since it was introduced, and I couldn't find additional context explaining the design choice.

To clarify the problem, I added a test case that demonstrates the issue.

Please see the new test for a concrete example of the behavior.