### PR TITLE
fix: tracing validation fields always null (#448)

### DIFF
--- a/src/com/walmartlabs/lacinia.clj
+++ b/src/com/walmartlabs/lacinia.clj
@@ -57,9 +57,9 @@
     (resolve/resolve-as {:errors validation-errors})
 
     :else
-    (executor/execute-query (assoc context constants/parsed-query-key prepared
-                                           ::tracing/validation {:start-offset start-offset
-                                                                 :duration (tracing/duration start-nanos)}))))
+    (executor/execute-query (assoc context constants/parsed-query-key (assoc prepared
+                                                                             ::tracing/validation {:start-offset start-offset
+                                                                                                   :duration (tracing/duration start-nanos)})))))
 
 (defn execute-parsed-query
   "Prepares a query, by applying query variables to it, resulting in a prepared

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -417,7 +417,7 @@
                                                                  *resolver-tracing
                                                                  (tracing/inject-tracing timing-start
                                                                                          (::tracing/parsing parsed-query)
-                                                                                         (::tracing/validation context)
+                                                                                         (::tracing/validation parsed-query)
                                                                                          @*resolver-tracing)
                                                                  errors (assoc :errors (distinct errors))
                                                                  warnings (assoc-in [:extensions :warnings] (distinct warnings))))))))

--- a/test/com/walmartlabs/lacinia/tracing_test.clj
+++ b/test/com/walmartlabs/lacinia/tracing_test.clj
@@ -100,3 +100,13 @@
                (let [durations (->> (get-in result [:extensions :tracing :execution :resolvers])
                                     (mapv :duration))]
                  (is (= 6 (count durations)))))))
+
+(deftest parsing-and-validation-timings-are-non-nil
+  ;; Regression test for https://github.com/walmartlabs/lacinia/issues/448
+  (let [result (q "{ root(delay: 5) { simple }}" enable-timing)
+        {:keys [parsing validation]} (get-in result [:extensions :tracing])]
+    (reporting result
+               (is (some? (:startOffset parsing)) "parsing startOffset should not be nil")
+               (is (pos? (:duration parsing)) "parsing duration should be positive")
+               (is (some? (:startOffset validation)) "validation startOffset should not be nil")
+               (is (pos? (:duration validation)) "validation duration should be positive"))))


### PR DESCRIPTION
## Summary

- `::tracing/validation` was stored on the `context` map but `execute-query` reads it alongside `::tracing/parsing` (which lives on the `parsed-query` map), causing validation `startOffset` and `duration` to always be `nil` in tracing output
- Fix stores `::tracing/validation` on the prepared query map, consistent with `::tracing/parsing`, and reads it from `parsed-query` in `execute-query`
- Adds regression test verifying both `parsing` and `validation` tracing phases have non-nil `startOffset` and positive `duration`

Fixes #448

🤖 Generated with [eca](https://eca.dev)